### PR TITLE
Add Raichu Thunderbolt attack implementation

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -110,6 +110,7 @@ fn forecast_effect_attack(
             damage_chance_status_attack(60, 0.5, StatusCondition::Paralyzed)
         }
         AttackId::A1093FrosmothPowderSnow => damage_status_attack(40, StatusCondition::Asleep),
+        AttackId::A1095RaichuThunderbolt => thunderbolt_attack(),
         AttackId::A1096PikachuExCircleCircuit => {
             bench_count_attack(acting_player, state, 0, 30, Some(EnergyType::Lightning))
         }
@@ -466,6 +467,14 @@ fn damage_and_turn_effect_attack(index: usize, effect_duration: u8) -> (Probabil
         let active = state.get_active(action.actor);
         // TODO: Maybe create an EffectId enum and have a mapping between card,attack_idx to effect?
         state.add_turn_effect(active.card.clone(), effect_duration);
+    })
+}
+
+/// For Raichu's Thunderbolt attack that deals 140 damage and discards all energy
+fn thunderbolt_attack() -> (Probabilities, Mutations) {
+    active_damage_effect_doutcome(140, move |_, state, action| {
+        let active = state.get_active_mut(action.actor);
+        active.attached_energy.clear(); // Discard all energy
     })
 }
 

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -36,6 +36,7 @@ pub enum AttackId {
     A1080VaporeonBubbleDrain,
     A1083ArticunoIceBeam,
     A1093FrosmothPowderSnow,
+    A1095RaichuThunderbolt,
     A1096PikachuExCircleCircuit,
     A1101ElectabuzzThunderPunch,
     A1104ZapdosExThunderingHurricane,
@@ -95,6 +96,7 @@ lazy_static::lazy_static! {
         m.insert(("A1 080", 0), AttackId::A1080VaporeonBubbleDrain);
         m.insert(("A1 083", 0), AttackId::A1083ArticunoIceBeam);
         m.insert(("A1 093", 0), AttackId::A1093FrosmothPowderSnow);
+        m.insert(("A1 095", 0), AttackId::A1095RaichuThunderbolt);
         m.insert(("A1 096", 0), AttackId::A1096PikachuExCircleCircuit);
         m.insert(("A1 101", 0), AttackId::A1101ElectabuzzThunderPunch);
         m.insert(("A1 104", 1), AttackId::A1104ZapdosExThunderingHurricane);


### PR DESCRIPTION
This was generated with [Claude Code](https://claude.ai/code), by using the prompt: "Read the README.md to learn how to implement attacks. Then implement the Thunderbolt attack for the Raichu card.", and clicking "Yes" several times.

Here is a video of the session:

https://github.com/user-attachments/assets/5594254b-1f74-4572-8edc-fd908092dfbc




