### PR TITLE
Implement Raichu Gigashock attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -137,6 +137,15 @@ fn forecast_effect_attack(
         AttackId::A1203KangaskhanDizzyPunch => {
             probabilistic_damage_attack(vec![0.25, 0.5, 0.25], vec![0, 30, 60])
         }
+        AttackId::A1a026RaichuGigashock => {
+            let opponent = (state.current_player + 1) % 2;
+            let targets: Vec<(u32, usize)> = state
+                .enumerate_bench_pokemon(opponent)
+                .map(|(idx, _)| (20, idx))
+                .chain(std::iter::once((60, 0)))
+                .collect();
+            damage_effect_doutcome(targets, |_, _, _| {})
+        }
         AttackId::A1a030DedenneThunderShock => {
             damage_chance_status_attack(10, 0.5, StatusCondition::Paralyzed)
         }

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -50,6 +50,7 @@ pub enum AttackId {
     A1195WigglytuffSleepySong,
     A1196MeowthPayDay,
     A1203KangaskhanDizzyPunch,
+    A1a026RaichuGigashock,
     A1a030DedenneThunderShock,
     A2049PalkiaDimensionalStorm,
     A2119DialgaExMetallicTurbo,
@@ -135,6 +136,7 @@ lazy_static::lazy_static! {
         m.insert(("A1 285", 0), AttackId::A1096PikachuExCircleCircuit);
         m.insert(("A1 286", 1), AttackId::A1129MewtwoExPsydrive);
         // A1a
+        m.insert(("A1a 026", 0), AttackId::A1a026RaichuGigashock);
         m.insert(("A1a 030", 0), AttackId::A1a030DedenneThunderShock);
         // Full Arts A1a
         m.insert(("A1a 073", 0), AttackId::A1a030DedenneThunderShock);


### PR DESCRIPTION
This was created with OpenAI's codex (https://github.com/openai/codex) using the o4-mini model and the prompt: "read the README.md file to learn how to implement attacks. Then implement the Raichu Gigashock attack. It should be similar to Palkia's attack.". I had to correct mid-way with "You are enumerating all in_play_pokemon when doing the 20 damage. That only applies to bench pokemon. Please use enumerate_bench_pokemon instead".

Here some screenshots of the session:

<img width="1398" alt="Screenshot 2025-05-04 at 1 49 17 AM" src="https://github.com/user-attachments/assets/9b1c62cf-fffd-41e2-a374-7b021784f76a" />
<img width="1336" alt="Screenshot 2025-05-04 at 1 49 54 AM" src="https://github.com/user-attachments/assets/c0bee499-7591-4fa7-986a-a3bace5aa88b" />
<img width="1425" alt="Screenshot 2025-05-04 at 1 50 07 AM" src="https://github.com/user-attachments/assets/3a1f081b-5436-4778-a63b-a0d2434bf77a" />
<img width="1435" alt="Screenshot 2025-05-04 at 1 48 37 AM" src="https://github.com/user-attachments/assets/026a39b0-3a3c-4b53-8dc8-c29411033e6d" />
<img width="1450" alt="Screenshot 2025-05-04 at 1 48 23 AM" src="https://github.com/user-attachments/assets/b67933ed-407a-41ef-b185-23b00f7b7e2e" />

