### PR TITLE
feat(attacks): Implement Eelektross Thunder Fang attack

### DIFF
--- a/.github/prompts/implement-attack.prompt.md
+++ b/.github/prompts/implement-attack.prompt.md
@@ -9,3 +9,4 @@ mode: agent
 - Review similar attacks in `apply_attack_action.rs` to ensure consistency in implementation.
 - Implement the attack logic in `forecast_effect_attack` in `apply_attack_action.rs`.
   - Keep the code as a one-liner in the match statement, and implement the logic using a helper function.
+- Make sure to run `cargo clippy --fix` and `cargo fmt` to format the code.

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -168,6 +168,7 @@ fn forecast_effect_attack(
             vec![0, 50, 100, 150, 200],
         ),
         AttackId::A1106ZebstrikaThunderSpear => direct_damage(30, false),
+        AttackId::A1109EelektrossThunderFang => damage_chance_status_attack(80, 0.5, StatusCondition::Paralyzed),
         AttackId::A1128MewtwoPowerBlast => {
             self_energy_discard_attack(index, vec![EnergyType::Psychic])
         }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -168,7 +168,9 @@ fn forecast_effect_attack(
             vec![0, 50, 100, 150, 200],
         ),
         AttackId::A1106ZebstrikaThunderSpear => direct_damage(30, false),
-        AttackId::A1109EelektrossThunderFang => damage_chance_status_attack(80, 0.5, StatusCondition::Paralyzed),
+        AttackId::A1109EelektrossThunderFang => {
+            damage_chance_status_attack(80, 0.5, StatusCondition::Paralyzed)
+        }
         AttackId::A1128MewtwoPowerBlast => {
             self_energy_discard_attack(index, vec![EnergyType::Psychic])
         }

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -45,6 +45,7 @@ pub enum AttackId {
     A1103ZapdosRagingThunder,
     A1104ZapdosExThunderingHurricane,
     A1106ZebstrikaThunderSpear,
+    A1109EelektrossThunderFang,
     A1128MewtwoPowerBlast,
     A1129MewtwoExPsydrive,
     A1136GolurkDoubleLariat,
@@ -120,6 +121,7 @@ lazy_static::lazy_static! {
         m.insert(("A1 103", 0), AttackId::A1103ZapdosRagingThunder);
         m.insert(("A1 104", 1), AttackId::A1104ZapdosExThunderingHurricane);
         m.insert(("A1 106", 0), AttackId::A1106ZebstrikaThunderSpear);
+        m.insert(("A1 109", 0), AttackId::A1109EelektrossThunderFang);
         m.insert(("A1 128", 0), AttackId::A1128MewtwoPowerBlast);
         m.insert(("A1 129", 1), AttackId::A1129MewtwoExPsydrive);
         m.insert(("A1 136", 0), AttackId::A1136GolurkDoubleLariat);


### PR DESCRIPTION
This commit implements the Thunder Fang attack for the Eelektross card.

The attack deals 80 damage and, if a coin flip is heads, paralyzes the opponent's active Pokémon.