### PR TITLE
Implement Simulation Event Handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -185,7 +191,7 @@ version = "3.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_lex 0.2.4",
  "indexmap 1.9.3",
  "textwrap",
@@ -329,6 +335,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "csv"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
+dependencies = [
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "deckgym"
 version = "0.1.0"
 dependencies = [
@@ -336,6 +363,7 @@ dependencies = [
  "clap 4.5.40",
  "colored",
  "criterion",
+ "csv",
  "env_logger",
  "humantime",
  "indexmap 2.10.0",
@@ -348,6 +376,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
+ "uuid",
 ]
 
 [[package]]
@@ -393,7 +422,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -754,6 +795,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -780,7 +827,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -968,6 +1015,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
+dependencies = [
+ "getrandom 0.3.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "walkdir"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -982,6 +1040,15 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1213,6 +1280,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,11 +248,10 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
-version = "2.2.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "lazy_static",
  "windows-sys",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 log = "0.4.22"
 env_logger = "0.11.6"
-colored = "2.2.0"
+colored = "3"
 chrono = "0.4.39"
 indexmap = "2.7.0"
 num-format = "0.4.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,8 @@ chrono = "0.4.39"
 indexmap = "2.7.0"
 num-format = "0.4.4"
 humantime = "2.1.0"
+uuid = { version = "1.17.0", features = ["v4"] }
+csv = "1.3.1"
 pyo3 = { version = "0.22", features = ["extension-module"], optional = true }
 strum = "0.27"
 strum_macros = "0.27"

--- a/example_decks/mewtwoex.txt
+++ b/example_decks/mewtwoex.txt
@@ -1,4 +1,4 @@
-Energy: Grass
+Energy: Psychic
 1 A1 128
 2 A1 129
 2 A1 130

--- a/example_decks/solgaleo_shiinotic.txt
+++ b/example_decks/solgaleo_shiinotic.txt
@@ -1,0 +1,12 @@
+Energy: Metal
+2 Cosmog A3 85
+1 Cosmoem A3 86
+2 Morelull A3 157
+2 Solgaleo ex A3 239
+2 Shiinotic A3a 27
+2 Giant Cape A2 147
+1 Rocky Helmet A2 148
+2 Rare Candy A3 144
+2 Potion P-A 1
+2 Poké Ball P-A 5
+2 Professor's Research P-A 7

--- a/example_decks/solgaleo_sylveon.txt
+++ b/example_decks/solgaleo_sylveon.txt
@@ -1,0 +1,12 @@
+Energy: Metal
+2 Cosmog A3 85
+1 Cosmoem A3 86
+2 Solgaleo ex A3 239
+2 Eevee A3b 78
+2 Sylveon ex A3b 89
+2 Giant Cape A2 147
+1 Rocky Helmet A2 148
+2 Rare Candy A3 144
+2 Potion P-A 1
+2 Poké Ball P-A 5
+2 Professor's Research P-A 7

--- a/examples/SylveonExvsShiinotic.ipynb
+++ b/examples/SylveonExvsShiinotic.ipynb
@@ -1,0 +1,154 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "86ccf180-3964-4d66-b865-372283d2eb25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fc30626b-d15c-4ec3-8dab-e1d84a7fcea0",
+   "metadata": {},
+   "source": [
+    "# First Seen In Play\n",
+    "We will look at the min_turn (fastest turn) where Solgelo Ex is in play (with rare candy). \n",
+    "Then we will make a Histogram of these fastest turns."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9aef7f7b-b32c-4270-8a65-b1a344bff268",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs_df = pd.read_csv('first_turn_seen.csv')\n",
+    "fs_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2a5932b6-45f5-4c42-a970-64d3c6722641",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# https://www.deckgym.com/builder?name=Solgaleo%20Sylveon&energy=Grass&cards=A3086_A3171_A3171_A3239_A3239_A3b034_A3b034_A3b055_A3b055_A2147_A2147_A2148_A2b111_A2b111_A3144_A3144_P-A001_P-A001_P-A007_P-A007\n",
+    "solgaleo_sylveon_df = fs_df[(fs_df['actor'] == 1) & (fs_df['card_name'] == 'Solgaleo ex')]\n",
+    "# https://www.deckgym.com/builder?name=Solgaleo%20Shiinotic&energy=Grass&cards=A3086_A3157_A3157_A3171_A3171_A3239_A3239_A3a027_A3a027_A2147_A2147_A2148_A2b111_A2b111_A3144_A3144_P-A001_P-A001_P-A007_P-A007\n",
+    "solgaleo_shiinotic_df = fs_df[(fs_df['actor'] == 0) & (fs_df['card_name'] == 'Solgaleo ex')]\n",
+    "assert len(solgaleo_sylveon_df['game_id'].unique()) == solgaleo_sylveon_df.shape[0]\n",
+    "assert len(solgaleo_shiinotic_df['game_id'].unique()) == solgaleo_shiinotic_df.shape[0]\n",
+    "solgaleo_sylveon_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b49cb8f7-6681-4c26-8798-e843b2964c35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solgaleo_sylveon_distribution_df = solgaleo_sylveon_df['min_turn'].value_counts().sort_index()\n",
+    "solgaleo_sylveon_distribution_df = (solgaleo_sylveon_distribution_df.cumsum() * 100 / solgaleo_sylveon_distribution_df.sum()).round(2)\n",
+    "solgaleo_sylveon_distribution_df.to_csv('solgaleo_sylveon_distribution.csv')\n",
+    "solgaleo_sylveon_distribution_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "128fc7d3-a388-42fd-86e9-99f9ad3c41b2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solgaleo_shiinotic_distribution_df = solgaleo_shiinotic_df['min_turn'].value_counts().sort_index()\n",
+    "solgaleo_shiinotic_distribution_df = (solgaleo_shiinotic_distribution_df.cumsum() * 100 / solgaleo_shiinotic_distribution_df.sum()).round(2)\n",
+    "solgaleo_shiinotic_distribution_df.to_csv('solgaleo_shiinotic_distribution.csv')\n",
+    "solgaleo_shiinotic_distribution_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e363323c-a0bc-4597-aa62-bcf180d70885",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "solgaleo_sylveon_df['min_turn'].mean(), solgaleo_shiinotic_df['min_turn'].mean()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "176659a0-66bb-4fda-be15-f32b73c6dbf9",
+   "metadata": {},
+   "source": [
+    "# DeckOut Speed\n",
+    "We will see whats the distribution of the turn the user decks out. Then we'll get the first time we see 0."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6078661b-5668-4365-ac0b-82ca6ff8a1dc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_df = pd.read_csv('deck_sizes.csv')\n",
+    "ds_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79ad2d19-0c14-43cb-86ba-10623dfffba8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sylveon_ds_df = ds_df[ds_df['actor'] == 0]\n",
+    "sylveon_avg_decksize_per_turn = sylveon_ds_df.groupby(['turn'])['deck_size'].mean().round(2)\n",
+    "sylveon_avg_decksize_per_turn.to_csv('sylveon_avg_decksize_per_turn.csv')\n",
+    "sylveon_avg_decksize_per_turn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3bf0616b-cd94-4032-a383-86fb2d73fbb9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "shiinotic_ds_df = ds_df[ds_df['actor'] == 1]\n",
+    "shiinotic_avg_decksize_per_turn = shiinotic_ds_df.groupby(['turn'])['deck_size'].mean().round(2)\n",
+    "shiinotic_avg_decksize_per_turn.to_csv('shiinotic_avg_decksize_per_turn.csv')\n",
+    "shiinotic_avg_decksize_per_turn"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/sylveon_deck_draw_speed.rs
+++ b/examples/sylveon_deck_draw_speed.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use deckgym::{
+    actions::Action,
+    players::PlayerCode,
+    simulation_event_handler::{CompositeSimulationEventHandler, SimulationEventHandler},
+    Simulation, State,
+};
+
+/// Run with `cargo run --example sylveon_deck_draw_speed`
+fn main() {
+    let num_simulations = 1000;
+    let deck_a_path = "example_decks/solgaleo_sylveon.txt";
+    let deck_b_path = "example_decks/mewtwoex.txt";
+    let player_codes = vec![PlayerCode::E, PlayerCode::E];
+    println!("This will count how fast the user cant draw cards from the deck.");
+
+    let deckout_collector = Box::new(DeckOutCollector::new());
+    let mut composite_handler = CompositeSimulationEventHandler::new();
+    composite_handler.add_handler(deckout_collector);
+    let mut simulation = Simulation::new(
+        deck_a_path,
+        deck_b_path,
+        player_codes,
+        num_simulations,
+        None,
+        composite_handler,
+    )
+    .expect("Failed to create simulation");
+    simulation.run();
+}
+
+/// Simulation event handler that counts how fast players run out of cards in their decks.
+pub struct DeckOutCollector {
+    deck_sizes: HashMap<(Uuid, u8, usize), usize>, // (game_id, turn, actor) -> deck_size
+}
+
+impl DeckOutCollector {
+    pub fn new() -> Self {
+        Self {
+            deck_sizes: HashMap::new(),
+        }
+    }
+}
+
+/// It'd be nice to have the state passed in on_action, so that we can access the current player and their deck.
+/// we probably have to keep track of (turn, actor, deck_size) tuples to know when a player runs out of cards.
+/// Then with that, we can get a turn-where-player-ran-out-of-cards per game.
+/// This will generate a CSV file with (game_id, turn, actor, deck_size) tuples for each game.
+impl SimulationEventHandler for DeckOutCollector {
+    fn on_action(
+        &mut self,
+        game_id: Uuid,
+        _state_before_action: &State,
+        actor: usize,
+        _playable_actions: &Vec<Action>,
+        _action: &Action,
+        state_after_action: &State,
+    ) {
+        let turn = state_after_action.turn_count;
+        let deck_size = state_after_action.decks[actor].cards.len();
+
+        // Since this is called multiple times per turn, writing idempotently
+        // we'll store the last known deck size for each actor and turn.
+        self.deck_sizes.insert((game_id, turn, actor), deck_size);
+    }
+
+    fn on_game_end(
+        &mut self,
+        _game_id: Uuid,
+        _state: State,
+        _result: Option<deckgym::state::GameOutcome>,
+    ) {
+        println!("Game ended");
+    }
+
+    fn on_simulation_end(&mut self) {
+        println!("Deck sizes collected for all games. Writing to CSV...");
+
+        // Write the deck sizes to a CSV file
+        let absolute_path = std::env::current_dir()
+            .expect("Failed to get current directory")
+            .join("deck_sizes.csv");
+        let mut wtr = csv::Writer::from_path(&absolute_path).expect("Failed to create CSV writer");
+
+        // Convert to Vec and sort by (game_id, turn, actor)
+        let mut sorted_data: Vec<_> = self.deck_sizes.iter().collect();
+        sorted_data.sort_by_key(|((game_id, turn, actor), _)| (*game_id, *turn, *actor));
+
+        for ((game_id, turn, actor), deck_size) in sorted_data {
+            wtr.write_record(&[
+                game_id.to_string(),
+                turn.to_string(),
+                actor.to_string(),
+                deck_size.to_string(),
+            ])
+            .expect("Failed to write record to CSV");
+        }
+        wtr.flush().expect("Failed to flush CSV writer");
+        println!("Deck sizes written to {}", absolute_path.display());
+    }
+}

--- a/examples/sylveon_deck_draw_speed.rs
+++ b/examples/sylveon_deck_draw_speed.rs
@@ -4,6 +4,7 @@ use uuid::Uuid;
 use deckgym::{
     actions::Action,
     players::PlayerCode,
+    simulate::initialize_logger,
     simulation_event_handler::{
         CompositeSimulationEventHandler, SimulationEventHandler, StatsCollector,
     },
@@ -15,14 +16,17 @@ fn main() {
     let num_simulations = 1000;
     let deck_a_path = "example_decks/solgaleo_sylveon.txt";
     let deck_b_path = "example_decks/mewtwoex.txt";
-    let player_codes = vec![PlayerCode::ER, PlayerCode::ER];
+    let player_codes = vec![PlayerCode::R, PlayerCode::R];
+    initialize_logger(1);
     println!("This will count how fast the user cant draw cards from the deck.");
 
     let stats_collector = Box::new(StatsCollector::new());
     let deckout_collector = Box::new(DeckOutCollector::new());
+    let first_turn_seen_collector = Box::new(FirstTurnSeenCollector::new());
     let mut composite_handler = CompositeSimulationEventHandler::new();
     composite_handler.add_handler(stats_collector);
     composite_handler.add_handler(deckout_collector);
+    composite_handler.add_handler(first_turn_seen_collector);
     let mut simulation = Simulation::new(
         deck_a_path,
         deck_b_path,
@@ -67,15 +71,6 @@ impl SimulationEventHandler for DeckOutCollector {
         self.deck_sizes.insert((game_id, turn, actor), deck_size);
     }
 
-    fn on_game_end(
-        &mut self,
-        _game_id: Uuid,
-        _state: State,
-        _result: Option<deckgym::state::GameOutcome>,
-    ) {
-        println!("Game ended");
-    }
-
     fn on_simulation_end(&mut self) {
         println!("Deck sizes collected for all games. Writing to CSV...");
 
@@ -89,6 +84,9 @@ impl SimulationEventHandler for DeckOutCollector {
         let mut sorted_data: Vec<_> = self.deck_sizes.iter().collect();
         sorted_data.sort_by_key(|((game_id, turn, actor), _)| (*game_id, *turn, *actor));
 
+        // Write header
+        wtr.write_record(&["game_id", "turn", "actor", "deck_size"])
+            .expect("Failed to write header to CSV");
         for ((game_id, turn, actor), deck_size) in sorted_data {
             wtr.write_record(&[
                 game_id.to_string(),
@@ -100,5 +98,78 @@ impl SimulationEventHandler for DeckOutCollector {
         }
         wtr.flush().expect("Failed to flush CSV writer");
         println!("Deck sizes written to {}", absolute_path.display());
+    }
+}
+
+/// Simulation event handler that tracks the first turn a card is in play.
+pub struct FirstTurnSeenCollector {
+    /// (game_id, actor, card_name) -> min_turn
+    first_turn_seen: HashMap<(Uuid, usize, String), u8>,
+}
+
+impl FirstTurnSeenCollector {
+    pub fn new() -> Self {
+        Self {
+            first_turn_seen: HashMap::new(),
+        }
+    }
+}
+
+impl SimulationEventHandler for FirstTurnSeenCollector {
+    fn on_action(
+        &mut self,
+        game_id: Uuid,
+        _state_before_action: &State,
+        actor: usize,
+        _playable_actions: &[Action],
+        _action: &Action,
+        state_after_action: &State,
+    ) {
+        let turn = state_after_action.turn_count;
+        for card in state_after_action.in_play_pokemon[actor].iter() {
+            if let Some(card) = card {
+                let card_name = card.get_name();
+                let key = (game_id, actor, card_name.clone());
+                if !self.first_turn_seen.contains_key(&key) {
+                    println!(
+                        "Setting first turn seen for {:?} in game {}: turn {}",
+                        card_name.clone(),
+                        game_id,
+                        turn
+                    );
+                    self.first_turn_seen.insert(key, turn);
+                }
+            }
+        }
+    }
+
+    fn on_simulation_end(&mut self) {
+        println!("First turn seen collected for all games. Writing to CSV...");
+
+        // Write the first turn seen to a CSV file
+        let absolute_path = std::env::current_dir()
+            .expect("Failed to get current directory")
+            .join("first_turn_seen.csv");
+        let mut wtr = csv::Writer::from_path(&absolute_path).expect("Failed to create CSV writer");
+
+        // Convert to Vec and sort by (game_id, actor, card_name)
+        let mut sorted_data: Vec<_> = self.first_turn_seen.iter().collect();
+        sorted_data
+            .sort_by_key(|((game_id, actor, card_name), _)| (*game_id, *actor, card_name.clone()));
+
+        // Write header
+        wtr.write_record(&["game_id", "actor", "card_name", "min_turn"])
+            .expect("Failed to write header to CSV");
+        for ((game_id, actor, card_name), min_turn) in &sorted_data {
+            wtr.write_record(&[
+                game_id.to_string(),
+                actor.to_string(),
+                card_name.clone(),
+                min_turn.to_string(),
+            ])
+            .expect("Failed to write record to CSV");
+        }
+        wtr.flush().expect("Failed to flush CSV writer");
+        println!("First turn seen written to {}", absolute_path.display());
     }
 }

--- a/examples/sylveon_deck_draw_speed.rs
+++ b/examples/sylveon_deck_draw_speed.rs
@@ -16,7 +16,7 @@ fn main() {
     let num_simulations = 1000;
     let deck_a_path = "example_decks/solgaleo_sylveon.txt";
     let deck_b_path = "example_decks/mewtwoex.txt";
-    let player_codes = vec![PlayerCode::R, PlayerCode::R];
+    let player_codes = vec![PlayerCode::ER, PlayerCode::ER];
     initialize_logger(1);
     println!("This will count how fast the user cant draw cards from the deck.");
 

--- a/examples/sylveon_deck_draw_speed.rs
+++ b/examples/sylveon_deck_draw_speed.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use uuid::Uuid;
 
 use deckgym::{
@@ -13,19 +13,17 @@ use deckgym::{
 
 /// Run with `cargo run --example sylveon_deck_draw_speed`
 fn main() {
-    let num_simulations = 1000;
-    let deck_a_path = "example_decks/solgaleo_sylveon.txt";
-    let deck_b_path = "example_decks/mewtwoex.txt";
+    let num_simulations = 1_000_000;
+    let deck_a_path = "example_decks/solgaleo_shiinotic.txt";
+    let deck_b_path = "example_decks/solgaleo_sylveon.txt";
     let player_codes = vec![PlayerCode::ER, PlayerCode::ER];
     initialize_logger(1);
     println!("This will count how fast the user cant draw cards from the deck.");
 
     let stats_collector = Box::new(StatsCollector::new());
-    let deckout_collector = Box::new(DeckOutCollector::new());
     let first_turn_seen_collector = Box::new(FirstTurnSeenCollector::new());
     let mut composite_handler = CompositeSimulationEventHandler::new();
     composite_handler.add_handler(stats_collector);
-    composite_handler.add_handler(deckout_collector);
     composite_handler.add_handler(first_turn_seen_collector);
     let mut simulation = Simulation::new(
         deck_a_path,
@@ -39,78 +37,18 @@ fn main() {
     simulation.run();
 }
 
-/// Simulation event handler that counts how fast players run out of cards in their decks.
-/// It generates a CSV file with (game_id, turn, actor, last_known_deck_size) tuples for each game.
-pub struct DeckOutCollector {
-    deck_sizes: HashMap<(Uuid, u8, usize), usize>, // (game_id, turn, actor) -> deck_size
-}
-
-impl DeckOutCollector {
-    pub fn new() -> Self {
-        Self {
-            deck_sizes: HashMap::new(),
-        }
-    }
-}
-
-impl SimulationEventHandler for DeckOutCollector {
-    fn on_action(
-        &mut self,
-        game_id: Uuid,
-        _state_before_action: &State,
-        actor: usize,
-        _playable_actions: &[Action],
-        _action: &Action,
-        state_after_action: &State,
-    ) {
-        let turn = state_after_action.turn_count;
-        let deck_size = state_after_action.decks[actor].cards.len();
-
-        // Since this is called multiple times per turn, writing idempotently
-        // we'll store the last known deck size for each game-turn-actor combination.
-        self.deck_sizes.insert((game_id, turn, actor), deck_size);
-    }
-
-    fn on_simulation_end(&mut self) {
-        println!("Deck sizes collected for all games. Writing to CSV...");
-
-        // Write the deck sizes to a CSV file
-        let absolute_path = std::env::current_dir()
-            .expect("Failed to get current directory")
-            .join("deck_sizes.csv");
-        let mut wtr = csv::Writer::from_path(&absolute_path).expect("Failed to create CSV writer");
-
-        // Convert to Vec and sort by (game_id, turn, actor)
-        let mut sorted_data: Vec<_> = self.deck_sizes.iter().collect();
-        sorted_data.sort_by_key(|((game_id, turn, actor), _)| (*game_id, *turn, *actor));
-
-        // Write header
-        wtr.write_record(&["game_id", "turn", "actor", "deck_size"])
-            .expect("Failed to write header to CSV");
-        for ((game_id, turn, actor), deck_size) in sorted_data {
-            wtr.write_record(&[
-                game_id.to_string(),
-                turn.to_string(),
-                actor.to_string(),
-                deck_size.to_string(),
-            ])
-            .expect("Failed to write record to CSV");
-        }
-        wtr.flush().expect("Failed to flush CSV writer");
-        println!("Deck sizes written to {}", absolute_path.display());
-    }
-}
-
 /// Simulation event handler that tracks the first turn a card is in play.
 pub struct FirstTurnSeenCollector {
     /// (game_id, actor, card_name) -> min_turn
     first_turn_seen: HashMap<(Uuid, usize, String), u8>,
+    game_ids: HashSet<Uuid>,
 }
 
 impl FirstTurnSeenCollector {
     pub fn new() -> Self {
         Self {
             first_turn_seen: HashMap::new(),
+            game_ids: HashSet::new(),
         }
     }
 }
@@ -131,16 +69,28 @@ impl SimulationEventHandler for FirstTurnSeenCollector {
                 let card_name = card.get_name();
                 let key = (game_id, actor, card_name.clone());
                 if !self.first_turn_seen.contains_key(&key) {
-                    println!(
-                        "Setting first turn seen for {:?} in game {}: turn {}",
-                        card_name.clone(),
-                        game_id,
-                        turn
-                    );
                     self.first_turn_seen.insert(key, turn);
                 }
             }
         }
+    }
+
+    // Every 100 games, give a progress update
+    fn on_game_end(
+        &mut self,
+        _game_id: Uuid,
+        _state: State,
+        _result: Option<deckgym::state::GameOutcome>,
+    ) {
+        if self.game_ids.len() % 1000 == 0 {
+            println!(
+                "Processed {} games so far. First turn seen: {}",
+                self.game_ids.len(),
+                self.first_turn_seen.len()
+            );
+        }
+        // Store the game ID to track progress
+        self.game_ids.insert(_game_id);
     }
 
     fn on_simulation_end(&mut self) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,10 +7,8 @@ name = "deckgym"
 description = "Python bindings for the deckgym-core Pokémon TCG Pocket simulator"
 readme = "README.md"
 requires-python = ">=3.8"
-license = {file = "LICENSE.txt"}
-authors = [
-    {name = "DeckGym Team"},
-]
+license = { file = "LICENSE.txt" }
+authors = [{ name = "DeckGym Team" }]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",
@@ -36,6 +34,4 @@ python-source = "python"
 module-name = "deckgym"
 
 [dependency-groups]
-dev = [
-    "pytest>=8.3.5",
-]
+dev = ["pytest>=8.3.5"]

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -5,7 +5,7 @@ use crate::{
     actions::{
         apply_action_helpers::{Mutations, Probabilities},
         mutations::{ability_doutcome, ability_mutation},
-        shared_mutations::pokeball_outcomes,
+        shared_mutations::pokemon_search_outcomes,
         Action, SimpleAction,
     },
     types::EnergyType,
@@ -29,7 +29,7 @@ pub(crate) fn forecast_ability(
         AbilityId::A1132Gardevoir => charge_active(EnergyType::Psychic),
         AbilityId::A2a071Arceus => panic!("Arceus's ability cant be used on demand"),
         AbilityId::A3122SolgaleoExRisingRoad => rising_road(index),
-        AbilityId::A3a027ShiinoticIlluminate => pokeball_outcomes(action.actor, state),
+        AbilityId::A3a027ShiinoticIlluminate => pokemon_search_outcomes(action.actor, state, false),
         AbilityId::A3b034SylveonExHappyRibbon => panic!("Happy Ribbon cant be used on demand"),
     }
 }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -201,9 +201,12 @@ fn forecast_effect_attack(
         }
         AttackId::A1154HitmonleeStretchKick => direct_damage(30, true),
         AttackId::A1163GrapploctKnockBack => knock_back_attack(60),
-        AttackId::A1165ArbokCorner => {
-            damage_and_card_effect_attack(index, 1, CardEffect::NoRetreat)
-        }
+        AttackId::A1165ArbokCorner => damage_and_card_effect_attack(
+            index,
+            (state.current_player + 1) % 2,
+            1,
+            CardEffect::NoRetreat,
+        ),
         AttackId::A1171NidokingPoisonHorn => damage_status_attack(90, StatusCondition::Poisoned),
         AttackId::A1174GrimerPoisonGas => damage_status_attack(10, StatusCondition::Poisoned),
         AttackId::A1178MawileCrunch => mawile_crunch(),
@@ -240,6 +243,12 @@ fn forecast_effect_attack(
         }
         AttackId::A2035PiplupHeal | AttackId::PA034PiplupHeal => self_heal_attack(20, index),
         AttackId::A3085CosmogTeleport => teleport_attack(),
+        AttackId::A3086CosmoemStiffen => damage_and_card_effect_attack(
+            0,
+            state.current_player,
+            1,
+            CardEffect::ReducedDamage { amount: 50 },
+        ),
         AttackId::A3122SolgaleoExSolBreaker => self_damage_attack(120, 10),
         AttackId::A3a094JynxPsychic => {
             damage_based_on_opponent_energy(acting_player, state, 30, 20)
@@ -617,13 +626,13 @@ fn damage_and_turn_effect_attack(
 
 fn damage_and_card_effect_attack(
     index: usize,
+    player: usize,
     effect_duration: u8,
     effect: CardEffect,
 ) -> (Probabilities, Mutations) {
     index_active_damage_doutcome(index, move |_, state, _| {
-        let opponent = (state.current_player + 1) % 2;
         state
-            .get_active_mut(opponent)
+            .get_active_mut(player)
             .add_effect(effect, effect_duration);
     })
 }

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -2,7 +2,7 @@ use log::debug;
 use rand::rngs::StdRng;
 
 use crate::{
-    actions::{mutations::doutcome, shared_mutations::pokeball_outcomes},
+    actions::{mutations::doutcome, shared_mutations::pokemon_search_outcomes},
     card_ids::CardId,
     card_logic::can_rare_candy_evolve,
     effects::TurnEffect,
@@ -28,7 +28,7 @@ pub fn forecast_trainer_action(
     match trainer_id {
         CardId::PA001Potion => doutcome(potion_effect),
         CardId::PA002XSpeed => doutcome(x_speed_effect),
-        CardId::PA005PokeBall => pokeball_outcomes(acting_player, state),
+        CardId::PA005PokeBall => pokemon_search_outcomes(acting_player, state, true),
         CardId::PA006RedCard => doutcome(red_card_effect),
         CardId::PA007ProfessorsResearch => doutcome(professor_oak_effect),
         CardId::A1219Erika | CardId::A1266Erika => doutcome(erika_effect),

--- a/src/actions/shared_mutations.rs
+++ b/src/actions/shared_mutations.rs
@@ -5,28 +5,36 @@ use crate::{
         apply_action_helpers::{apply_common_mutation, Mutations, Probabilities},
         mutations::doutcome,
     },
+    types::Card,
     State,
 };
 
-pub(crate) fn pokeball_outcomes(acting_player: usize, state: &State) -> (Probabilities, Mutations) {
-    let num_basic_in_deck = state.decks[acting_player]
+pub(crate) fn pokemon_search_outcomes(
+    acting_player: usize,
+    state: &State,
+    basic_only: bool,
+) -> (Probabilities, Mutations) {
+    let card_filter = if basic_only {
+        |x: &&Card| x.is_basic()
+    } else {
+        |x: &&Card| matches!(x, Card::Pokemon(_))
+    };
+    let num_pokemon_in_deck = state.decks[acting_player]
         .cards
         .iter()
-        .filter(|x| x.is_basic())
+        .filter(card_filter)
         .count();
-    if num_basic_in_deck == 0 {
+    if num_pokemon_in_deck == 0 {
         doutcome({
             |rng, state, action| {
-                // IF FROM ABILITY, MARK IT DONE
-
-                // If there are no basic Pokemon in the deck, just shuffle it
+                // If there are no Pokemon in the deck, just shuffle it
                 state.decks[action.actor].shuffle(false, rng);
             }
         })
     } else {
-        let probabilities = vec![1.0 / (num_basic_in_deck as f64); num_basic_in_deck];
+        let probabilities = vec![1.0 / (num_pokemon_in_deck as f64); num_pokemon_in_deck];
         let mut outcomes: Mutations = vec![];
-        for i in 0..num_basic_in_deck {
+        for i in 0..num_pokemon_in_deck {
             outcomes.push(Box::new({
                 move |rng, state, action| {
                     apply_common_mutation(state, action);
@@ -34,14 +42,14 @@ pub(crate) fn pokeball_outcomes(acting_player: usize, state: &State) -> (Probabi
                     let card = state.decks[action.actor]
                         .cards
                         .iter()
-                        .filter(|x| x.is_basic())
+                        .filter(card_filter)
                         .nth(i)
                         .cloned()
-                        .expect("Should be a basic card");
+                        .expect("Card should be in deck");
 
-                    // Put 1 random Basic Pokemon from your deck into your hand.
+                    // Put 1 random Pokemon from your deck into your hand.
                     let deck = &mut state.decks[action.actor];
-                    debug!("Pokeball selected card: {card:?}");
+                    debug!("Fetched {card:?} from deck for player {}", action.actor);
                     // Add it to hand and remove one of it from deck
                     state.hands[action.actor].push(card.clone());
                     if let Some(pos) = deck.cards.iter().position(|x| x == &card) {

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -82,6 +82,7 @@ pub enum AttackId {
     A2119DialgaExMetallicTurbo,
     A2a071ArceusExUltimateForce,
     A3085CosmogTeleport,
+    A3086CosmoemStiffen,
     A3122SolgaleoExSolBreaker,
     A3a094JynxPsychic,
     PA031CinccinoDoTheWave,
@@ -218,6 +219,7 @@ lazy_static::lazy_static! {
 
         // A3
         m.insert(("A3 085", 0), AttackId::A3085CosmogTeleport);
+        m.insert(("A3 086", 0), AttackId::A3086CosmoemStiffen);
         m.insert(("A3 122", 0), AttackId::A3122SolgaleoExSolBreaker);
         m.insert(("A3 171", 0), AttackId::A3085CosmogTeleport);
         m.insert(("A3 189", 0), AttackId::A3122SolgaleoExSolBreaker);

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -2,6 +2,7 @@
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub enum CardEffect {
     NoRetreat,
+    ReducedDamage { amount: u32 },
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]

--- a/src/game.rs
+++ b/src/game.rs
@@ -151,7 +151,7 @@ impl<'a> Game<'a> {
             EnergyType::Lightning => "yellow",
             EnergyType::Psychic => "magenta",
             EnergyType::Water => "blue",
-            EnergyType::Darkness => "black",
+            EnergyType::Darkness => "bright_black",
             EnergyType::Metal => "bright_black",
             EnergyType::Dragon => todo!(),
         };

--- a/src/game.rs
+++ b/src/game.rs
@@ -79,7 +79,7 @@ impl Game {
                 "Possible Actions: {:?}",
                 actions.iter().map(|x| x.action.clone()).collect::<Vec<_>>()
             );
-            player.decision_fn(&mut self.rng, &self.state, actions)
+            player.decision_fn(&mut self.rng, &self.state, &actions)
         };
         let player = &self.players[actor];
         self.print_action(&action, actor, player.as_ref(), &color);

--- a/src/game.rs
+++ b/src/game.rs
@@ -135,6 +135,7 @@ impl Game {
         self.degrees_per_ply.clone()
     }
 
+    /// see https://github.com/colored-rs/colored?tab=readme-ov-file#colors
     fn get_color(&self, actor: usize) -> String {
         let energy = self.state.decks[actor].energy_types[0];
         let color = match energy {
@@ -146,7 +147,7 @@ impl Game {
             EnergyType::Psychic => "magenta",
             EnergyType::Water => "blue",
             EnergyType::Darkness => "black",
-            EnergyType::Metal => "black",
+            EnergyType::Metal => "bright_black",
             EnergyType::Dragon => todo!(),
         };
         color.to_string()

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -5,7 +5,7 @@ use log::debug;
 
 use crate::{
     actions::SimpleAction,
-    effects::TurnEffect,
+    effects::{CardEffect, TurnEffect},
     tool_ids::ToolId,
     types::{Card, EnergyType, PlayedCard, TrainerCard, BASIC_STAGE},
     AbilityId, State,
@@ -117,13 +117,25 @@ pub(crate) fn get_damage_from_attack(
         return attack.fixed_damage;
     }
 
-    // Modifiers by effect
-    let effect_modifiers = state
+    // Modifiers by effect (like Giovanni)
+    let increased_turn_effect_modifiers = state
         .get_current_turn_effects()
         .iter()
         .filter(|x| matches!(x, TurnEffect::IncreasedDamage { .. }))
         .map(|x| match x {
             TurnEffect::IncreasedDamage { amount } => *amount,
+            _ => 0,
+        })
+        .sum::<u32>();
+
+    // Modifiers by receiving card effects
+    let reduced_card_effect_modifiers = state
+        .get_active((player + 1) % 2)
+        .get_active_effects()
+        .iter()
+        .filter(|effect| matches!(effect, CardEffect::ReducedDamage { .. }))
+        .map(|effect| match effect {
+            CardEffect::ReducedDamage { amount } => *amount,
             _ => 0,
         })
         .sum::<u32>();
@@ -144,10 +156,14 @@ pub(crate) fn get_damage_from_attack(
     }
 
     debug!(
-        "Attack: {:?}, Weakness: {}, Effects: {}",
-        attack.fixed_damage, weakness_modifier, effect_modifiers
+        "Attack: {:?}, Weakness: {}, IncreasedDamage: {}, ReducedDamage: {}",
+        attack.fixed_damage,
+        weakness_modifier,
+        increased_turn_effect_modifiers,
+        reduced_card_effect_modifiers
     );
-    attack.fixed_damage + weakness_modifier + effect_modifiers
+    attack.fixed_damage + weakness_modifier + increased_turn_effect_modifiers
+        - reduced_card_effect_modifiers
 }
 
 // Check if attached satisfies cost (considering Colorless)
@@ -253,6 +269,31 @@ mod tests {
             damage_with_giovanni,
             base_damage + 10,
             "Giovanni should add exactly 10 damage to attacks"
+        );
+    }
+
+    #[test]
+    fn test_cosmoem_reduced_damage() {
+        // Arrange
+        let mut state = State::default();
+        let attacker = get_card_by_enum(CardId::A3122SolgaleoEx);
+        let played_attacker = to_playable_card(&attacker, false);
+        state.in_play_pokemon[0][0] = Some(played_attacker);
+        let defender = get_card_by_enum(CardId::A3086Cosmoem);
+        let played_defender = to_playable_card(&defender, false);
+        state.in_play_pokemon[1][0] = Some(played_defender);
+        state.in_play_pokemon[1][0]
+            .as_mut()
+            .unwrap()
+            .add_effect(crate::effects::CardEffect::ReducedDamage { amount: 50 }, 1);
+
+        // Act
+        let damage_with_stiffen = get_damage_from_attack(&state, 0, 0, 0);
+
+        // Assert
+        assert_eq!(
+            damage_with_stiffen, 70,
+            "Cosmoem's Stiffen should reduce damage by exactly 50"
         );
     }
 }

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -162,8 +162,8 @@ pub(crate) fn get_damage_from_attack(
         increased_turn_effect_modifiers,
         reduced_card_effect_modifiers
     );
-    attack.fixed_damage + weakness_modifier + increased_turn_effect_modifiers
-        - reduced_card_effect_modifiers
+    (attack.fixed_damage + weakness_modifier + increased_turn_effect_modifiers)
+        .saturating_sub(reduced_card_effect_modifiers)
 }
 
 // Check if attached satisfies cost (considering Colorless)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ pub mod move_generation;
 mod optimize;
 pub mod players;
 pub mod simulate;
+pub mod simulation_event_handler;
 pub mod state;
 pub mod test_helpers; // TODO: Compile/Expose only in test mode?
 pub mod tool_ids;
@@ -24,7 +25,7 @@ pub use game::Game;
 pub use move_generation::generate_possible_actions;
 pub use move_generation::generate_possible_trainer_actions;
 pub use optimize::optimize;
-pub use simulate::{simulate, Simulation, SimulationResults};
+pub use simulate::{simulate, Simulation};
 pub use state::State;
 
 #[cfg(feature = "python")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub use game::Game;
 pub use move_generation::generate_possible_actions;
 pub use move_generation::generate_possible_trainer_actions;
 pub use optimize::optimize;
-pub use simulate::simulate;
+pub use simulate::{simulate, Simulation, SimulationResults};
 pub use state::State;
 
 #[cfg(feature = "python")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,9 @@
 use clap::{ArgAction, Parser, Subcommand};
 use colored::Colorize;
 use deckgym::players::{parse_player_code, PlayerCode};
+use deckgym::simulate::initialize_logger;
 use deckgym::{optimize, simulate};
-use env_logger::{Builder, Env};
 use log::warn;
-use std::io::Write;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -110,17 +109,4 @@ fn main() {
             );
         }
     }
-}
-
-// Set up the logger according to the given verbosity.
-fn initialize_logger(verbose: u8) {
-    let level = match verbose {
-        1 => "warn",
-        2 => "info",
-        3 => "debug",
-        _ => "trace",
-    };
-    Builder::from_env(Env::default().default_filter_or(level))
-        .format(|buf, record| writeln!(buf, "{}", record.args()))
-        .init();
 }

--- a/src/players/attach_attack_player.rs
+++ b/src/players/attach_attack_player.rs
@@ -16,7 +16,7 @@ pub struct AttachAttackPlayer {
 }
 
 impl Player for AttachAttackPlayer {
-    fn decision_fn(&mut self, _: &mut StdRng, _: &State, possible_actions: Vec<Action>) -> Action {
+    fn decision_fn(&mut self, _: &mut StdRng, _: &State, possible_actions: &Vec<Action>) -> Action {
         let maybe_attach = possible_actions
             .iter()
             .find(|action| matches!(action.action, SimpleAction::Attach { .. }));

--- a/src/players/attach_attack_player.rs
+++ b/src/players/attach_attack_player.rs
@@ -16,7 +16,7 @@ pub struct AttachAttackPlayer {
 }
 
 impl Player for AttachAttackPlayer {
-    fn decision_fn(&mut self, _: &mut StdRng, _: &State, possible_actions: &Vec<Action>) -> Action {
+    fn decision_fn(&mut self, _: &mut StdRng, _: &State, possible_actions: &[Action]) -> Action {
         let maybe_attach = possible_actions
             .iter()
             .find(|action| matches!(action.action, SimpleAction::Attach { .. }));

--- a/src/players/end_turn_player.rs
+++ b/src/players/end_turn_player.rs
@@ -14,7 +14,7 @@ pub struct EndTurnPlayer {
 }
 
 impl Player for EndTurnPlayer {
-    fn decision_fn(&mut self, _: &mut StdRng, _: &State, possible_actions: Vec<Action>) -> Action {
+    fn decision_fn(&mut self, _: &mut StdRng, _: &State, possible_actions: &Vec<Action>) -> Action {
         let maybe_end_turn = possible_actions
             .iter()
             .find(|action| matches!(action.action, SimpleAction::EndTurn));

--- a/src/players/end_turn_player.rs
+++ b/src/players/end_turn_player.rs
@@ -14,7 +14,7 @@ pub struct EndTurnPlayer {
 }
 
 impl Player for EndTurnPlayer {
-    fn decision_fn(&mut self, _: &mut StdRng, _: &State, possible_actions: &Vec<Action>) -> Action {
+    fn decision_fn(&mut self, _: &mut StdRng, _: &State, possible_actions: &[Action]) -> Action {
         let maybe_end_turn = possible_actions
             .iter()
             .find(|action| matches!(action.action, SimpleAction::EndTurn));

--- a/src/players/evolution_rusher_player.rs
+++ b/src/players/evolution_rusher_player.rs
@@ -14,9 +14,11 @@ use super::Player;
 ///   1. Using Poke Ball if possible
 ///   2. Using Shiinotic Ability if possible
 ///   3. Using Prof Research if possible
+///
 /// Then it will try to Rush Evolution by:
 ///   1. Using Rare Candy if available
 ///   2. Evolve Pokemon if possible
+///
 /// After those priorities, it will try to attach energy and attack if possible.
 pub struct EvolutionRusherPlayer {
     pub deck: Deck,

--- a/src/players/evolution_rusher_player.rs
+++ b/src/players/evolution_rusher_player.rs
@@ -19,7 +19,10 @@ use super::Player;
 ///   1. Using Rare Candy if available
 ///   2. Evolve Pokemon if possible
 ///
-/// After those priorities, it will try to attach energy and attack if possible.
+/// Lastly, it will try to draw cards if possible (saying "yes" to Sylveon's ability).
+///
+/// After those priorities, it will try to attach energy and attack if possible, or choose
+/// the first available action.
 pub struct EvolutionRusherPlayer {
     pub deck: Deck,
 }
@@ -75,6 +78,14 @@ impl Player for EvolutionRusherPlayer {
             .find(|action| matches!(action.action, SimpleAction::Evolve(_, _)));
         if let Some(evolve) = maybe_evolve {
             return evolve.clone();
+        }
+
+        // Draw cards if possible (Sylveon's ability)
+        let maybe_draw = possible_actions
+            .iter()
+            .find(|action| matches!(action.action, SimpleAction::DrawCard { .. }));
+        if let Some(draw) = maybe_draw {
+            return draw.clone();
         }
 
         // Attach randomly and attack if possible

--- a/src/players/evolution_rusher_player.rs
+++ b/src/players/evolution_rusher_player.rs
@@ -29,7 +29,7 @@ impl Player for EvolutionRusherPlayer {
         &mut self,
         _: &mut StdRng,
         state: &State,
-        possible_actions: &Vec<Action>,
+        possible_actions: &[Action],
     ) -> Action {
         // Draw priorities
         let pokeball_trainer = get_card_by_enum(CardId::PA005PokeBall).as_trainer();

--- a/src/players/evolution_rusher_player.rs
+++ b/src/players/evolution_rusher_player.rs
@@ -1,0 +1,106 @@
+use rand::rngs::StdRng;
+use std::fmt::Debug;
+
+use crate::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    Deck, State,
+};
+
+use super::Player;
+
+/// A player that first tries to accelerate deck as much as possible by:
+///   1. Using Poke Ball if possible
+///   2. Using Shiinotic Ability if possible
+///   3. Using Prof Research if possible
+/// Then it will try to Rush Evolution by:
+///   1. Using Rare Candy if available
+///   2. Evolve Pokemon if possible
+/// After those priorities, it will try to attach energy and attack if possible.
+pub struct EvolutionRusherPlayer {
+    pub deck: Deck,
+}
+
+impl Player for EvolutionRusherPlayer {
+    fn decision_fn(
+        &mut self,
+        _: &mut StdRng,
+        state: &State,
+        possible_actions: &Vec<Action>,
+    ) -> Action {
+        // Draw priorities
+        let pokeball_trainer = get_card_by_enum(CardId::PA005PokeBall).as_trainer();
+        let maybe_poke_ball = possible_actions
+            .iter()
+            .find(|action| matches!(&action.action, SimpleAction::Play { trainer_card } if trainer_card == &pokeball_trainer));
+        if let Some(poke_ball) = maybe_poke_ball {
+            return poke_ball.clone();
+        }
+        let shiinotic = get_card_by_enum(CardId::A3a027Shiinotic);
+        let maybe_shiinotic = possible_actions.iter().find(|action| {
+            matches!(action.action, SimpleAction::UseAbility(idx) if {
+                let in_play_idx = action.actor;
+                let pokemon = &state.in_play_pokemon[in_play_idx][idx];
+                if let Some(pokemon) = pokemon {
+                    pokemon.card == shiinotic
+                } else {
+                    false
+                }
+            })
+        });
+        if let Some(shiinotic) = maybe_shiinotic {
+            return shiinotic.clone();
+        }
+        let profoak = get_card_by_enum(CardId::PA007ProfessorsResearch).as_trainer();
+        let maybe_profoak = possible_actions.iter().find(|action| {
+            matches!(&action.action, SimpleAction::Play { trainer_card } if trainer_card == &profoak)
+        });
+        if let Some(profoak) = maybe_profoak {
+            return profoak.clone();
+        }
+
+        // Evolution priorities
+        let rare_candy = get_card_by_enum(CardId::A3144RareCandy).as_trainer();
+        let maybe_rare_candy = possible_actions.iter().find(|action| {
+            matches!(&action.action, SimpleAction::Play { trainer_card } if trainer_card == &rare_candy)
+        });
+        if let Some(rare_candy) = maybe_rare_candy {
+            return rare_candy.clone();
+        }
+        let maybe_evolve = possible_actions
+            .iter()
+            .find(|action| matches!(action.action, SimpleAction::Evolve(_, _)));
+        if let Some(evolve) = maybe_evolve {
+            return evolve.clone();
+        }
+
+        // Attach randomly and attack if possible
+        let maybe_attach = possible_actions
+            .iter()
+            .find(|action| matches!(action.action, SimpleAction::Attach { .. }));
+        if let Some(attach) = maybe_attach {
+            return attach.clone();
+        }
+        let maybe_attack = possible_actions
+            .iter()
+            .find(|action| matches!(action.action, SimpleAction::Attack(_)));
+        if let Some(attack) = maybe_attack {
+            return attack.clone();
+        }
+        possible_actions
+            .first()
+            .expect("There should always be at least one playable action")
+            .clone()
+    }
+
+    fn get_deck(&self) -> Deck {
+        self.deck.clone()
+    }
+}
+
+impl Debug for EvolutionRusherPlayer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "EvolutionRusherPlayer")
+    }
+}

--- a/src/players/expectiminimax_player.rs
+++ b/src/players/expectiminimax_player.rs
@@ -17,7 +17,7 @@ impl Player for ExpectiMiniMaxPlayer {
         &mut self,
         rng: &mut StdRng,
         state: &State,
-        possible_actions: Vec<Action>,
+        possible_actions: &Vec<Action>,
     ) -> Action {
         let myself = possible_actions[0].actor;
 

--- a/src/players/expectiminimax_player.rs
+++ b/src/players/expectiminimax_player.rs
@@ -17,7 +17,7 @@ impl Player for ExpectiMiniMaxPlayer {
         &mut self,
         rng: &mut StdRng,
         state: &State,
-        possible_actions: &Vec<Action>,
+        possible_actions: &[Action],
     ) -> Action {
         let myself = possible_actions[0].actor;
 

--- a/src/players/human_player.rs
+++ b/src/players/human_player.rs
@@ -16,7 +16,7 @@ impl Player for HumanPlayer {
         &mut self,
         _: &mut StdRng,
         state: &State,
-        possible_actions: Vec<Action>,
+        possible_actions: &Vec<Action>,
     ) -> Action {
         if possible_actions.len() == 1 {
             println!("Only one possible action, selecting it.");

--- a/src/players/human_player.rs
+++ b/src/players/human_player.rs
@@ -16,7 +16,7 @@ impl Player for HumanPlayer {
         &mut self,
         _: &mut StdRng,
         state: &State,
-        possible_actions: &Vec<Action>,
+        possible_actions: &[Action],
     ) -> Action {
         if possible_actions.len() == 1 {
             println!("Only one possible action, selecting it.");

--- a/src/players/mcts_player.rs
+++ b/src/players/mcts_player.rs
@@ -31,7 +31,7 @@ impl Player for MctsPlayer {
         &mut self,
         rng: &mut StdRng,
         state: &State,
-        possible_actions: Vec<Action>,
+        possible_actions: &Vec<Action>,
     ) -> Action {
         // Step 1: Initialize the root node of the search tree
         let investigator = possible_actions[0].actor; // myself

--- a/src/players/mcts_player.rs
+++ b/src/players/mcts_player.rs
@@ -31,14 +31,14 @@ impl Player for MctsPlayer {
         &mut self,
         rng: &mut StdRng,
         state: &State,
-        possible_actions: &Vec<Action>,
+        possible_actions: &[Action],
     ) -> Action {
         // Step 1: Initialize the root node of the search tree
         let investigator = possible_actions[0].actor; // myself
         let mut root = self
             .node_lookup
             .entry(state.clone())
-            .or_insert_with(|| MctsNode::new(state.clone(), possible_actions.clone()))
+            .or_insert_with(|| MctsNode::new(state.clone(), possible_actions.to_vec()))
             .clone();
 
         // Step 2: Perform iterations of MCTS

--- a/src/players/mod.rs
+++ b/src/players/mod.rs
@@ -1,5 +1,6 @@
 mod attach_attack_player;
 mod end_turn_player;
+mod evolution_rusher_player;
 mod expectiminimax_player;
 mod human_player;
 mod mcts_player;
@@ -10,6 +11,7 @@ mod weighted_random_player;
 pub use attach_attack_player::AttachAttackPlayer;
 use clap::ValueEnum;
 pub use end_turn_player::EndTurnPlayer;
+pub use evolution_rusher_player::EvolutionRusherPlayer;
 pub use expectiminimax_player::ExpectiMiniMaxPlayer;
 pub use human_player::HumanPlayer;
 pub use mcts_player::MctsPlayer;
@@ -42,6 +44,7 @@ pub enum PlayerCode {
     M,
     V,
     E,
+    ER, // Evolution Rusher
 }
 /// Custom parser function enforcing case-insensitivity
 pub fn parse_player_code(s: &str) -> Result<PlayerCode, String> {
@@ -54,6 +57,7 @@ pub fn parse_player_code(s: &str) -> Result<PlayerCode, String> {
         "m" => Ok(PlayerCode::M),
         "v" => Ok(PlayerCode::V),
         "e" => Ok(PlayerCode::E),
+        "er" => Ok(PlayerCode::ER),
         _ => Err(format!("Invalid player code: {s}")),
     }
 }
@@ -96,5 +100,6 @@ fn get_player(deck: Deck, player: &PlayerCode) -> Box<dyn Player> {
         PlayerCode::M => Box::new(MctsPlayer::new(deck, 100)),
         PlayerCode::V => Box::new(ValueFunctionPlayer { deck }),
         PlayerCode::E => Box::new(ExpectiMiniMaxPlayer { deck, max_depth: 3 }),
+        PlayerCode::ER => Box::new(EvolutionRusherPlayer { deck }),
     }
 }

--- a/src/players/mod.rs
+++ b/src/players/mod.rs
@@ -29,7 +29,7 @@ pub trait Player: Debug {
         &mut self,
         rng: &mut StdRng,
         state: &State,
-        possible_actions: &Vec<Action>,
+        possible_actions: &[Action],
     ) -> Action;
 }
 

--- a/src/players/mod.rs
+++ b/src/players/mod.rs
@@ -64,13 +64,13 @@ pub fn parse_player_code_generic(s: String) -> Result<PlayerCode, String> {
 
 pub fn fill_code_array(maybe_players: Option<Vec<PlayerCode>>) -> Vec<PlayerCode> {
     match maybe_players {
-        Some(mut cli_players) => {
-            if cli_players.is_empty() || cli_players.len() > 2 {
+        Some(mut player_codes) => {
+            if player_codes.is_empty() || player_codes.len() > 2 {
                 panic!("Invalid number of players");
-            } else if cli_players.len() == 1 {
-                cli_players.push(PlayerCode::R);
+            } else if player_codes.len() == 1 {
+                player_codes.push(PlayerCode::R);
             }
-            cli_players
+            player_codes
         }
         None => vec![PlayerCode::R, PlayerCode::R],
     }

--- a/src/players/mod.rs
+++ b/src/players/mod.rs
@@ -27,7 +27,7 @@ pub trait Player: Debug {
         &mut self,
         rng: &mut StdRng,
         state: &State,
-        possible_actions: Vec<Action>,
+        possible_actions: &Vec<Action>,
     ) -> Action;
 }
 

--- a/src/players/random_player.rs
+++ b/src/players/random_player.rs
@@ -10,12 +10,7 @@ pub struct RandomPlayer {
 }
 
 impl Player for RandomPlayer {
-    fn decision_fn(
-        &mut self,
-        rng: &mut StdRng,
-        _: &State,
-        possible_actions: &Vec<Action>,
-    ) -> Action {
+    fn decision_fn(&mut self, rng: &mut StdRng, _: &State, possible_actions: &[Action]) -> Action {
         possible_actions
             .choose(rng)
             .expect("There should always be at least one playable action")

--- a/src/players/random_player.rs
+++ b/src/players/random_player.rs
@@ -14,7 +14,7 @@ impl Player for RandomPlayer {
         &mut self,
         rng: &mut StdRng,
         _: &State,
-        possible_actions: Vec<Action>,
+        possible_actions: &Vec<Action>,
     ) -> Action {
         possible_actions
             .choose(rng)

--- a/src/players/value_function_player.rs
+++ b/src/players/value_function_player.rs
@@ -15,7 +15,7 @@ impl Player for ValueFunctionPlayer {
         &mut self,
         rng: &mut StdRng,
         state: &State,
-        possible_actions: Vec<Action>,
+        possible_actions: &Vec<Action>,
     ) -> Action {
         // Get value for the possible actions
         let myself = possible_actions[0].actor;

--- a/src/players/value_function_player.rs
+++ b/src/players/value_function_player.rs
@@ -15,7 +15,7 @@ impl Player for ValueFunctionPlayer {
         &mut self,
         rng: &mut StdRng,
         state: &State,
-        possible_actions: &Vec<Action>,
+        possible_actions: &[Action],
     ) -> Action {
         // Get value for the possible actions
         let myself = possible_actions[0].actor;

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -16,7 +16,7 @@ impl Player for WeightedRandomPlayer {
         &mut self,
         rng: &mut StdRng,
         _: &State,
-        possible_actions: Vec<Action>,
+        possible_actions: &Vec<Action>,
     ) -> Action {
         // Get weights for the possible actions
         let weights: Vec<u32> = possible_actions

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -12,12 +12,7 @@ pub struct WeightedRandomPlayer {
 }
 
 impl Player for WeightedRandomPlayer {
-    fn decision_fn(
-        &mut self,
-        rng: &mut StdRng,
-        _: &State,
-        possible_actions: &Vec<Action>,
-    ) -> Action {
+    fn decision_fn(&mut self, rng: &mut StdRng, _: &State, possible_actions: &[Action]) -> Action {
         // Get weights for the possible actions
         let weights: Vec<u32> = possible_actions
             .iter()

--- a/src/simulate.rs
+++ b/src/simulate.rs
@@ -1,4 +1,4 @@
-use log::{info, warn};
+use log::warn;
 use num_format::{Locale, ToFormattedString};
 
 use crate::{
@@ -10,12 +10,9 @@ use crate::{
     Deck, Game,
 };
 
-/// Object-oriented simulation configuration and runner
 pub struct Simulation {
     deck_a: Deck,
     deck_b: Deck,
-    deck_a_path: String,
-    deck_b_path: String,
     player_codes: Vec<PlayerCode>,
     num_simulations: u32,
     seed: Option<u64>,
@@ -23,24 +20,20 @@ pub struct Simulation {
 }
 
 impl Simulation {
-    /// Create a new simulation from file paths
     pub fn new(
         deck_a_path: &str,
         deck_b_path: &str,
-        players: Option<Vec<PlayerCode>>,
+        player_codes: Vec<PlayerCode>,
         num_simulations: u32,
         seed: Option<u64>,
         event_handler: CompositeSimulationEventHandler,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let deck_a = Deck::from_file(deck_a_path)?;
         let deck_b = Deck::from_file(deck_b_path)?;
-        let player_codes = fill_code_array(players);
 
         Ok(Simulation {
             deck_a,
             deck_b,
-            deck_a_path: deck_a_path.to_string(),
-            deck_b_path: deck_b_path.to_string(),
             player_codes,
             num_simulations,
             seed,
@@ -48,24 +41,9 @@ impl Simulation {
         })
     }
 
-    /// Run the simulation and return results
     pub fn run(&mut self) -> Vec<Option<GameOutcome>> {
-        // Simulate Games and accumulate statistics
-        warn!(
-            "Running {} games with players:",
-            self.num_simulations.to_formatted_string(&Locale::en),
-        );
-        warn!(
-            "\tPlayer 0: {:?}({})",
-            self.player_codes[0], self.deck_a_path
-        );
-        warn!(
-            "\tPlayer 1: {:?}({})",
-            self.player_codes[1], self.deck_b_path
-        );
-
-        let mut outcomes = Vec::with_capacity(self.num_simulations as usize);
         self.event_handler.on_simulation_start();
+        let mut outcomes = vec![];
         for i in 1..=self.num_simulations {
             let players = create_players(
                 self.deck_a.clone(),
@@ -73,15 +51,16 @@ impl Simulation {
                 self.player_codes.clone(),
             );
             let seed = self.seed.unwrap_or(rand::random::<u64>());
-            self.event_handler.on_game_start();
+            self.event_handler.on_game_start(i);
+
             // Give the self.event_handler a mutable reference to the Game
             let mut game = Game::new_with_event_handlers(players, seed, &mut self.event_handler);
             let outcome = game.play();
             let clone = game.get_state_clone();
             // done with the game, should be dropped now
-            self.event_handler.on_game_end(clone, outcome);
 
-            info!("Simulation {i}: Winner is {outcome:?}");
+            self.event_handler.on_game_end(i, clone, outcome);
+
             outcomes.push(outcome);
         }
         self.event_handler.on_simulation_end();
@@ -98,13 +77,22 @@ pub fn simulate(
     num_simulations: u32,
     seed: Option<u64>,
 ) {
+    let player_codes = fill_code_array(players);
+
+    warn!(
+        "Running {} games with players:",
+        num_simulations.to_formatted_string(&Locale::en),
+    );
+    warn!("\tPlayer 0: {:?}({})", player_codes[0], deck_a_path);
+    warn!("\tPlayer 1: {:?}({})", player_codes[1], deck_b_path);
+
     let stats_collector = Box::new(StatsCollector::new());
     let mut composite_handler = CompositeSimulationEventHandler::new();
     composite_handler.add_handler(stats_collector);
     let mut simulation = Simulation::new(
         deck_a_path,
         deck_b_path,
-        players,
+        player_codes,
         num_simulations,
         seed,
         composite_handler,

--- a/src/simulate.rs
+++ b/src/simulate.rs
@@ -9,6 +9,145 @@ use crate::{
     Deck, Game,
 };
 
+/// Object-oriented simulation configuration and runner
+pub struct Simulation {
+    deck_a: Deck,
+    deck_b: Deck,
+    deck_a_path: String,
+    deck_b_path: String,
+    player_codes: Vec<PlayerCode>,
+    num_simulations: u32,
+    seed: Option<u64>,
+}
+
+impl Simulation {
+    /// Create a new simulation from file paths
+    pub fn new(
+        deck_a_path: &str,
+        deck_b_path: &str,
+        players: Option<Vec<PlayerCode>>,
+        num_simulations: u32,
+        seed: Option<u64>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let deck_a = Deck::from_file(deck_a_path)?;
+        let deck_b = Deck::from_file(deck_b_path)?;
+        let player_codes = fill_code_array(players);
+
+        Ok(Simulation {
+            deck_a,
+            deck_b,
+            deck_a_path: deck_a_path.to_string(),
+            deck_b_path: deck_b_path.to_string(),
+            player_codes,
+            num_simulations,
+            seed,
+        })
+    }
+
+    /// Create a new simulation from deck objects
+    pub fn from_decks(
+        deck_a: Deck,
+        deck_b: Deck,
+        players: Option<Vec<PlayerCode>>,
+        num_simulations: u32,
+        seed: Option<u64>,
+    ) -> Self {
+        let player_codes = fill_code_array(players);
+
+        Simulation {
+            deck_a,
+            deck_b,
+            deck_a_path: "deck_a".to_string(),
+            deck_b_path: "deck_b".to_string(),
+            player_codes,
+            num_simulations,
+            seed,
+        }
+    }
+
+    /// Run the simulation and return results
+    pub fn run(&self) -> SimulationResults {
+        // Simulate Games and accumulate statistics
+        warn!(
+            "Running {} games with players {:?}",
+            self.num_simulations.to_formatted_string(&Locale::en),
+            self.player_codes
+        );
+
+        let start = Instant::now(); // Start the timer
+        let mut wins_per_deck = [0, 0, 0];
+        let mut turns_per_game = Vec::new();
+        let mut plys_per_game = Vec::new();
+        let mut total_degrees = Vec::new();
+
+        for i in 1..=self.num_simulations {
+            let players = create_players(
+                self.deck_a.clone(),
+                self.deck_b.clone(),
+                self.player_codes.clone(),
+            );
+            let seed = self.seed.unwrap_or(rand::random::<u64>());
+            let mut game = Game::new(players, seed);
+            let outcome = game.play();
+            turns_per_game.push(game.get_state_clone().turn_count);
+            plys_per_game.push(game.get_num_plys());
+            total_degrees.extend(game.get_degrees_per_ply().iter());
+            info!("Simulation {i}: Winner is {outcome:?}");
+            match outcome {
+                Some(GameOutcome::Win(winner_name)) => {
+                    wins_per_deck[winner_name] += 1;
+                }
+                Some(GameOutcome::Tie) | None => {
+                    wins_per_deck[2] += 1;
+                }
+            }
+        }
+
+        let duration = start.elapsed(); // Measure elapsed time
+        let avg_time_per_game = duration.as_secs_f64() / self.num_simulations as f64;
+        let avg_duration = Duration::from_secs_f64(avg_time_per_game);
+
+        // Calculate averages
+        let avg_turns_per_game = turns_per_game
+            .iter()
+            .map(|&turns| turns as u32)
+            .sum::<u32>() as f32
+            / self.num_simulations as f32;
+
+        let avg_plys_per_game =
+            plys_per_game.iter().sum::<u32>() as f32 / self.num_simulations as f32;
+
+        let avg_degrees_per_ply = if total_degrees.is_empty() {
+            0.0
+        } else {
+            total_degrees.iter().sum::<u32>() as f32 / total_degrees.len() as f32
+        };
+
+        SimulationResults {
+            total_games: self.num_simulations,
+            player_a_wins: wins_per_deck[0],
+            player_b_wins: wins_per_deck[1],
+            ties: wins_per_deck[2],
+            player_a_win_rate: wins_per_deck[0] as f32 / self.num_simulations as f32,
+            player_b_win_rate: wins_per_deck[1] as f32 / self.num_simulations as f32,
+            tie_rate: wins_per_deck[2] as f32 / self.num_simulations as f32,
+            avg_turns_per_game,
+            avg_plys_per_game,
+            avg_degrees_per_ply,
+            duration,
+            avg_time_per_game: avg_duration,
+        }
+    }
+
+    /// Run the simulation and print the results
+    pub fn run_and_print(&self) -> SimulationResults {
+        let results = self.run();
+        results.print_stats(&self.deck_a_path, &self.deck_b_path, &self.player_codes);
+        results
+    }
+}
+
+/// Legacy functional API for backwards compatibility
 pub fn simulate(
     deck_a_path: &str,
     deck_b_path: &str,
@@ -16,84 +155,67 @@ pub fn simulate(
     num_simulations: u32,
     seed: Option<u64>,
 ) {
-    // Read the decks files and initialize Players
-    let deck_a = Deck::from_file(deck_a_path).expect("Failed to parse deck from file");
-    let deck_b = Deck::from_file(deck_b_path).expect("Failed to parse deck from file");
-    let cli_players = fill_code_array(players);
+    let simulation = Simulation::new(deck_a_path, deck_b_path, players, num_simulations, seed)
+        .expect("Failed to create simulation");
+    simulation.run_and_print();
+}
 
-    // Simulate Games and accumulate statistics
-    warn!(
-        "Running {} games with players {:?}",
-        num_simulations.to_formatted_string(&Locale::en),
-        cli_players
-    );
-    let start = Instant::now(); // Start the timer
-    let mut wins_per_deck = [0, 0, 0];
-    let mut turns_per_game = Vec::new();
-    let mut plys_per_game = Vec::new();
-    let mut total_degrees = Vec::new();
-    for i in 1..=num_simulations {
-        let players = create_players(deck_a.clone(), deck_b.clone(), cli_players.clone());
-        let seed = seed.unwrap_or(rand::random::<u64>());
-        let mut game = Game::new(players, seed);
-        let outcome = game.play();
-        turns_per_game.push(game.get_state_clone().turn_count);
-        plys_per_game.push(game.get_num_plys());
-        total_degrees.extend(game.get_degrees_per_ply().iter());
-        info!("Simulation {i}: Winner is {outcome:?}");
-        match outcome {
-            Some(GameOutcome::Win(winner_name)) => {
-                wins_per_deck[winner_name] += 1;
-            }
-            Some(GameOutcome::Tie) | None => {
-                wins_per_deck[2] += 1;
-            }
-        }
+/// Results from running a simulation
+#[derive(Debug, Clone)]
+pub struct SimulationResults {
+    pub total_games: u32,
+    pub player_a_wins: u32,
+    pub player_b_wins: u32,
+    pub ties: u32,
+    pub player_a_win_rate: f32,
+    pub player_b_win_rate: f32,
+    pub tie_rate: f32,
+    pub avg_turns_per_game: f32,
+    pub avg_plys_per_game: f32,
+    pub avg_degrees_per_ply: f32,
+    pub duration: Duration,
+    pub avg_time_per_game: Duration,
+}
+
+impl SimulationResults {
+    /// Print detailed statistics about the simulation results
+    pub fn print_stats(&self, deck_a_path: &str, deck_b_path: &str, player_codes: &[PlayerCode]) {
+        warn!(
+            "Ran {} simulations in {} ({} per game)!",
+            self.total_games.to_formatted_string(&Locale::en),
+            humantime::format_duration(self.duration),
+            humantime::format_duration(self.avg_time_per_game)
+        );
+        warn!(
+            "Average number of turns per game: {:.2}",
+            self.avg_turns_per_game
+        );
+        warn!(
+            "Average number of plys per game: {:.2}",
+            self.avg_plys_per_game
+        );
+        warn!(
+            "Average number of degrees per ply: {:.2}",
+            self.avg_degrees_per_ply
+        );
+        warn!(
+            "Player {:?} with Deck {} wins: {} ({:.2}%)",
+            player_codes[0],
+            deck_a_path,
+            self.player_a_wins.to_formatted_string(&Locale::en),
+            self.player_a_win_rate * 100.0
+        );
+        warn!(
+            "Player {:?} with Deck {} wins: {} ({:.2}%)",
+            player_codes[1],
+            deck_b_path,
+            self.player_b_wins.to_formatted_string(&Locale::en),
+            self.player_b_win_rate * 100.0
+        );
+        warn!(
+            "Draws: {} ({:.2}%)",
+            self.ties.to_formatted_string(&Locale::en),
+            self.tie_rate * 100.0
+        );
     }
-    let duration = start.elapsed(); // Measure elapsed time
-    let avg_time_per_game = duration.as_secs_f64() / num_simulations as f64;
-    let avg_duration = Duration::from_secs_f64(avg_time_per_game);
-
-    // Print statistics
-    warn!(
-        "Ran {} simulations in {} ({} per game)!",
-        num_simulations.to_formatted_string(&Locale::en),
-        humantime::format_duration(duration),
-        humantime::format_duration(avg_duration)
-    );
-    warn!(
-        "Average number of turns per game: {:.2}",
-        turns_per_game
-            .iter()
-            .map(|&turns| turns as u32)
-            .sum::<u32>() as f32
-            / num_simulations as f32
-    );
-    warn!(
-        "Average number of plys per game: {:.2}",
-        plys_per_game.iter().sum::<u32>() as f32 / num_simulations as f32
-    );
-    warn!(
-        "Average number of degrees per ply: {:.2}",
-        total_degrees.iter().sum::<u32>() as f32 / total_degrees.len() as f32
-    );
-    warn!(
-        "Player {:?} with Deck {} wins: {} ({:.2}%)",
-        cli_players[0],
-        deck_a_path,
-        wins_per_deck[0].to_formatted_string(&Locale::en),
-        wins_per_deck[0] as f32 / num_simulations as f32 * 100.0
-    );
-    warn!(
-        "Player {:?} with Deck {} wins: {} ({:.2}%)",
-        cli_players[1],
-        deck_b_path,
-        wins_per_deck[1].to_formatted_string(&Locale::en),
-        wins_per_deck[1] as f32 / num_simulations as f32 * 100.0
-    );
-    warn!(
-        "Draws: {} ({:.2}%)",
-        wins_per_deck[2].to_formatted_string(&Locale::en),
-        wins_per_deck[2] as f32 / num_simulations as f32 * 100.0
-    );
 }

--- a/src/simulate.rs
+++ b/src/simulate.rs
@@ -1,12 +1,13 @@
-use std::time::{Duration, Instant};
-
 use log::{info, warn};
 use num_format::{Locale, ToFormattedString};
 
 use crate::{
     players::{create_players, fill_code_array, PlayerCode},
+    simulation_event_handler::{
+        CompositeSimulationEventHandler, SimulationEventHandler, StatsCollector,
+    },
     state::GameOutcome,
-    Deck, Game, State,
+    Deck, Game,
 };
 
 /// Object-oriented simulation configuration and runner
@@ -18,7 +19,7 @@ pub struct Simulation {
     player_codes: Vec<PlayerCode>,
     num_simulations: u32,
     seed: Option<u64>,
-    event_handlers: Vec<Box<dyn SimulationEventHandler + Send + Sync>>,
+    event_handler: CompositeSimulationEventHandler,
 }
 
 impl Simulation {
@@ -29,7 +30,7 @@ impl Simulation {
         players: Option<Vec<PlayerCode>>,
         num_simulations: u32,
         seed: Option<u64>,
-        event_handlers: Vec<Box<dyn SimulationEventHandler + Send + Sync>>,
+        event_handler: CompositeSimulationEventHandler,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         let deck_a = Deck::from_file(deck_a_path)?;
         let deck_b = Deck::from_file(deck_b_path)?;
@@ -43,49 +44,28 @@ impl Simulation {
             player_codes,
             num_simulations,
             seed,
-            event_handlers,
+            event_handler,
         })
     }
 
-    /// Create a new simulation from deck objects
-    pub fn from_decks(
-        deck_a: Deck,
-        deck_b: Deck,
-        players: Option<Vec<PlayerCode>>,
-        num_simulations: u32,
-        seed: Option<u64>,
-        event_handlers: Vec<Box<dyn SimulationEventHandler + Send + Sync>>,
-    ) -> Self {
-        let player_codes = fill_code_array(players);
-
-        Simulation {
-            deck_a,
-            deck_b,
-            deck_a_path: "deck_a".to_string(),
-            deck_b_path: "deck_b".to_string(),
-            player_codes,
-            num_simulations,
-            seed,
-            event_handlers,
-        }
-    }
-
     /// Run the simulation and return results
-    pub fn run(&mut self) -> SimulationResults {
+    pub fn run(&mut self) -> Vec<Option<GameOutcome>> {
         // Simulate Games and accumulate statistics
         warn!(
-            "Running {} games with players {:?}",
+            "Running {} games with players:",
             self.num_simulations.to_formatted_string(&Locale::en),
-            self.player_codes
+        );
+        warn!(
+            "\tPlayer 0: {:?}({})",
+            self.player_codes[0], self.deck_a_path
+        );
+        warn!(
+            "\tPlayer 1: {:?}({})",
+            self.player_codes[1], self.deck_b_path
         );
 
-        let start = Instant::now(); // Start the timer
-        let mut wins_per_deck = [0, 0, 0];
-        let mut turns_per_game = Vec::new();
-        let mut plys_per_game = Vec::new();
-        let mut total_degrees = Vec::new();
-
-        self.broadcast(|h| h.on_simulation_start());
+        let mut outcomes = Vec::with_capacity(self.num_simulations as usize);
+        self.event_handler.on_simulation_start();
         for i in 1..=self.num_simulations {
             let players = create_players(
                 self.deck_a.clone(),
@@ -93,77 +73,20 @@ impl Simulation {
                 self.player_codes.clone(),
             );
             let seed = self.seed.unwrap_or(rand::random::<u64>());
-            let mut game = Game::new(players, seed);
-
-            self.broadcast(|h| h.on_game_start(game.get_state_clone()));
+            self.event_handler.on_game_start();
+            // Give the self.event_handler a mutable reference to the Game
+            let mut game = Game::new_with_event_handlers(players, seed, &mut self.event_handler);
             let outcome = game.play();
-            self.broadcast(|h| h.on_game_end(game.get_state_clone(), outcome));
+            let clone = game.get_state_clone();
+            // done with the game, should be dropped now
+            self.event_handler.on_game_end(clone, outcome);
 
-            turns_per_game.push(game.get_state_clone().turn_count);
-            plys_per_game.push(game.get_num_plys());
-            total_degrees.extend(game.get_degrees_per_ply().iter());
             info!("Simulation {i}: Winner is {outcome:?}");
-            match outcome {
-                Some(GameOutcome::Win(winner_name)) => {
-                    wins_per_deck[winner_name] += 1;
-                }
-                Some(GameOutcome::Tie) | None => {
-                    wins_per_deck[2] += 1;
-                }
-            }
+            outcomes.push(outcome);
         }
-        self.broadcast(|h| h.on_simulation_end());
+        self.event_handler.on_simulation_end();
 
-        let duration = start.elapsed(); // Measure elapsed time
-        let avg_time_per_game = duration.as_secs_f64() / self.num_simulations as f64;
-        let avg_duration = Duration::from_secs_f64(avg_time_per_game);
-
-        // Calculate averages
-        let avg_turns_per_game = turns_per_game
-            .iter()
-            .map(|&turns| turns as u32)
-            .sum::<u32>() as f32
-            / self.num_simulations as f32;
-
-        let avg_plys_per_game =
-            plys_per_game.iter().sum::<u32>() as f32 / self.num_simulations as f32;
-
-        let avg_degrees_per_ply = if total_degrees.is_empty() {
-            0.0
-        } else {
-            total_degrees.iter().sum::<u32>() as f32 / total_degrees.len() as f32
-        };
-
-        SimulationResults {
-            total_games: self.num_simulations,
-            player_a_wins: wins_per_deck[0],
-            player_b_wins: wins_per_deck[1],
-            ties: wins_per_deck[2],
-            player_a_win_rate: wins_per_deck[0] as f32 / self.num_simulations as f32,
-            player_b_win_rate: wins_per_deck[1] as f32 / self.num_simulations as f32,
-            tie_rate: wins_per_deck[2] as f32 / self.num_simulations as f32,
-            avg_turns_per_game,
-            avg_plys_per_game,
-            avg_degrees_per_ply,
-            duration,
-            avg_time_per_game: avg_duration,
-        }
-    }
-
-    /// Run the simulation and print the results
-    pub fn run_and_print(&mut self) -> SimulationResults {
-        let results = self.run();
-        results.print_stats(&self.deck_a_path, &self.deck_b_path, &self.player_codes);
-        results
-    }
-
-    fn broadcast<F>(&mut self, mut f: F)
-    where
-        F: FnMut(&mut dyn SimulationEventHandler),
-    {
-        for handler in self.event_handlers.iter_mut() {
-            f(handler.as_mut());
-        }
+        outcomes
     }
 }
 
@@ -175,85 +98,17 @@ pub fn simulate(
     num_simulations: u32,
     seed: Option<u64>,
 ) {
+    let stats_collector = Box::new(StatsCollector::new());
+    let mut composite_handler = CompositeSimulationEventHandler::new();
+    composite_handler.add_handler(stats_collector);
     let mut simulation = Simulation::new(
         deck_a_path,
         deck_b_path,
         players,
         num_simulations,
         seed,
-        vec![],
+        composite_handler,
     )
     .expect("Failed to create simulation");
-    simulation.run_and_print();
-}
-
-/// Results from running a simulation
-#[derive(Debug, Clone)]
-pub struct SimulationResults {
-    pub total_games: u32,
-    pub player_a_wins: u32,
-    pub player_b_wins: u32,
-    pub ties: u32,
-    pub player_a_win_rate: f32,
-    pub player_b_win_rate: f32,
-    pub tie_rate: f32,
-    pub avg_turns_per_game: f32,
-    pub avg_plys_per_game: f32,
-    pub avg_degrees_per_ply: f32,
-    pub duration: Duration,
-    pub avg_time_per_game: Duration,
-}
-
-impl SimulationResults {
-    /// Print detailed statistics about the simulation results
-    pub fn print_stats(&self, deck_a_path: &str, deck_b_path: &str, player_codes: &[PlayerCode]) {
-        warn!(
-            "Ran {} simulations in {} ({} per game)!",
-            self.total_games.to_formatted_string(&Locale::en),
-            humantime::format_duration(self.duration),
-            humantime::format_duration(self.avg_time_per_game)
-        );
-        warn!(
-            "Average number of turns per game: {:.2}",
-            self.avg_turns_per_game
-        );
-        warn!(
-            "Average number of plys per game: {:.2}",
-            self.avg_plys_per_game
-        );
-        warn!(
-            "Average number of degrees per ply: {:.2}",
-            self.avg_degrees_per_ply
-        );
-        warn!(
-            "Player {:?} with Deck {} wins: {} ({:.2}%)",
-            player_codes[0],
-            deck_a_path,
-            self.player_a_wins.to_formatted_string(&Locale::en),
-            self.player_a_win_rate * 100.0
-        );
-        warn!(
-            "Player {:?} with Deck {} wins: {} ({:.2}%)",
-            player_codes[1],
-            deck_b_path,
-            self.player_b_wins.to_formatted_string(&Locale::en),
-            self.player_b_win_rate * 100.0
-        );
-        warn!(
-            "Draws: {} ({:.2}%)",
-            self.ties.to_formatted_string(&Locale::en),
-            self.tie_rate * 100.0
-        );
-    }
-}
-
-pub trait SimulationEventHandler {
-    fn on_simulation_start(&mut self) {}
-    fn on_simulation_end(&mut self) {}
-
-    fn on_game_start(&mut self, _state: State) {}
-    fn on_game_end(&mut self, _state: State, _result: Option<GameOutcome>) {}
-
-    // TODO: Implement
-    // fn on_turn(&mut self, _turn: usize, _state: &State) {}
+    simulation.run();
 }

--- a/src/simulate.rs
+++ b/src/simulate.rs
@@ -1,5 +1,7 @@
+use env_logger::{Builder, Env};
 use log::warn;
 use num_format::{Locale, ToFormattedString};
+use std::io::Write;
 use uuid::Uuid;
 
 use crate::{
@@ -102,4 +104,17 @@ pub fn simulate(
     )
     .expect("Failed to create simulation");
     simulation.run();
+}
+
+// Set up the logger according to the given verbosity.
+pub fn initialize_logger(verbose: u8) {
+    let level = match verbose {
+        1 => "warn",
+        2 => "info",
+        3 => "debug",
+        _ => "trace",
+    };
+    Builder::from_env(Env::default().default_filter_or(level))
+        .format(|buf, record| writeln!(buf, "{}", record.args()))
+        .init();
 }

--- a/src/simulation_event_handler.rs
+++ b/src/simulation_event_handler.rs
@@ -1,0 +1,186 @@
+use log::warn;
+use num_format::{Locale, ToFormattedString};
+use std::time::{Duration, Instant};
+
+use crate::{actions::Action, state::GameOutcome, State};
+
+pub trait SimulationEventHandler {
+    fn on_simulation_start(&mut self) {}
+
+    fn on_game_start(&mut self) {}
+    fn on_action(&mut self, _actor: usize, _playable_actions: &Vec<Action>, _action: &Action) {}
+    fn on_game_end(&mut self, _state: State, _result: Option<GameOutcome>) {}
+
+    fn on_simulation_end(&mut self) {}
+}
+
+// A general implementation of the SimulationEventHandler to compose multiple
+pub struct CompositeSimulationEventHandler {
+    handlers: Vec<Box<dyn SimulationEventHandler>>,
+}
+
+impl CompositeSimulationEventHandler {
+    pub fn new() -> Self {
+        Self {
+            handlers: Vec::new(),
+        }
+    }
+
+    pub fn add_handler(&mut self, handler: Box<dyn SimulationEventHandler>) {
+        self.handlers.push(handler);
+    }
+}
+
+impl SimulationEventHandler for CompositeSimulationEventHandler {
+    fn on_simulation_start(&mut self) {
+        for handler in self.handlers.iter_mut() {
+            handler.on_simulation_start();
+        }
+    }
+
+    fn on_game_start(&mut self) {
+        for handler in self.handlers.iter_mut() {
+            handler.on_game_start();
+        }
+    }
+
+    fn on_action(&mut self, actor: usize, playable_actions: &Vec<Action>, action: &Action) {
+        for handler in self.handlers.iter_mut() {
+            handler.on_action(actor, playable_actions, action);
+        }
+    }
+
+    fn on_game_end(&mut self, state: State, result: Option<GameOutcome>) {
+        for handler in self.handlers.iter_mut() {
+            handler.on_game_end(state.clone(), result.clone());
+        }
+    }
+
+    fn on_simulation_end(&mut self) {
+        for handler in self.handlers.iter_mut() {
+            handler.on_simulation_end();
+        }
+    }
+}
+
+// Example: Statistics collector
+pub struct StatsCollector {
+    start: Instant,
+    num_games: u32,
+
+    degrees_per_ply: Vec<u32>,
+
+    player_a_wins: u32,
+    player_b_wins: u32,
+    ties: u32,
+    turns_per_game: Vec<u8>,
+    plys_per_game: Vec<u32>,
+    total_degrees: Vec<u32>,
+}
+
+impl StatsCollector {
+    pub fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            num_games: 0,
+            degrees_per_ply: vec![],
+            player_a_wins: 0,
+            player_b_wins: 0,
+            ties: 0,
+            turns_per_game: vec![],
+            plys_per_game: vec![],
+            total_degrees: vec![],
+        }
+    }
+}
+
+impl SimulationEventHandler for StatsCollector {
+    fn on_simulation_start(&mut self) {
+        self.start = Instant::now(); // Start the timer
+    }
+
+    fn on_game_start(&mut self) {
+        self.degrees_per_ply.clear();
+    }
+
+    fn on_action(&mut self, _actor: usize, playable_actions: &Vec<Action>, _action: &Action) {
+        self.degrees_per_ply.push(playable_actions.len() as u32);
+    }
+
+    fn on_game_end(&mut self, state: State, outcome: Option<GameOutcome>) {
+        self.num_games += 1;
+        self.turns_per_game.push(state.turn_count);
+        self.plys_per_game.push(self.degrees_per_ply.len() as u32);
+        self.total_degrees.extend(self.degrees_per_ply.iter());
+
+        match outcome {
+            Some(GameOutcome::Win(winner_name)) => {
+                if winner_name == 0 {
+                    self.player_a_wins += 1;
+                } else {
+                    self.player_b_wins += 1;
+                }
+            }
+            Some(GameOutcome::Tie) | None => {
+                self.ties += 1;
+            }
+        }
+    }
+
+    fn on_simulation_end(&mut self) {
+        let duration = self.start.elapsed(); // Measure elapsed time
+        let avg_time_per_game = duration.as_secs_f64() / self.num_games as f64;
+        let avg_duration = Duration::from_secs_f64(avg_time_per_game);
+
+        let avg_turns_per_game = self
+            .turns_per_game
+            .iter()
+            .map(|&turns| turns as u32)
+            .sum::<u32>() as f32
+            / self.num_games as f32;
+
+        let avg_plys_per_game =
+            self.plys_per_game.iter().sum::<u32>() as f32 / self.num_games as f32;
+
+        let avg_degrees_per_ply = if self.total_degrees.is_empty() {
+            0.0
+        } else {
+            self.total_degrees.iter().sum::<u32>() as f32 / self.total_degrees.len() as f32
+        };
+
+        warn!(
+            "Ran {} simulations in {} ({} per game)!",
+            self.num_games.to_formatted_string(&Locale::en),
+            humantime::format_duration(duration),
+            humantime::format_duration(avg_duration)
+        );
+        warn!(
+            "Average number of turns per game: {:.2}",
+            avg_turns_per_game
+        );
+        warn!("Average number of plys per game: {:.2}", avg_plys_per_game);
+        warn!(
+            "Average number of degrees per ply: {:.2}",
+            avg_degrees_per_ply
+        );
+
+        let player_a_win_rate = self.player_a_wins as f32 / self.num_games as f32;
+        let player_b_win_rate = self.player_b_wins as f32 / self.num_games as f32;
+        let tie_rate = self.ties as f32 / self.num_games as f32;
+        warn!(
+            "Player 0 won: {} ({:.2}%)",
+            self.player_a_wins.to_formatted_string(&Locale::en),
+            player_a_win_rate * 100.0
+        );
+        warn!(
+            "Player 1 won: {} ({:.2}%)",
+            self.player_b_wins.to_formatted_string(&Locale::en),
+            player_b_win_rate * 100.0
+        );
+        warn!(
+            "Draws: {} ({:.2}%)",
+            self.ties.to_formatted_string(&Locale::en),
+            tie_rate * 100.0
+        );
+    }
+}

--- a/src/simulation_event_handler.rs
+++ b/src/simulation_event_handler.rs
@@ -8,7 +8,7 @@ pub trait SimulationEventHandler {
     fn on_simulation_start(&mut self) {}
 
     fn on_game_start(&mut self, _id: u32) {}
-    fn on_action(&mut self, _actor: usize, _playable_actions: &Vec<Action>, _action: &Action) {}
+    fn on_action(&mut self, _actor: usize, _playable_actions: &[Action], _action: &Action) {}
     fn on_game_end(&mut self, _id: u32, _state: State, _result: Option<GameOutcome>) {}
 
     fn on_simulation_end(&mut self) {}
@@ -50,7 +50,7 @@ impl SimulationEventHandler for CompositeSimulationEventHandler {
         }
     }
 
-    fn on_action(&mut self, actor: usize, playable_actions: &Vec<Action>, action: &Action) {
+    fn on_action(&mut self, actor: usize, playable_actions: &[Action], action: &Action) {
         for handler in self.handlers.iter_mut() {
             handler.on_action(actor, playable_actions, action);
         }
@@ -115,7 +115,7 @@ impl SimulationEventHandler for StatsCollector {
         self.degrees_per_ply.clear();
     }
 
-    fn on_action(&mut self, _actor: usize, playable_actions: &Vec<Action>, _action: &Action) {
+    fn on_action(&mut self, _actor: usize, playable_actions: &[Action], _action: &Action) {
         self.degrees_per_ply.push(playable_actions.len() as u32);
     }
 
@@ -168,13 +168,9 @@ impl SimulationEventHandler for StatsCollector {
             humantime::format_duration(duration),
             humantime::format_duration(avg_duration)
         );
-        warn!(
-            "Average number of turns per game: {avg_turns_per_game:.2}"
-        );
+        warn!("Average number of turns per game: {avg_turns_per_game:.2}");
         warn!("Average number of plys per game: {avg_plys_per_game:.2}");
-        warn!(
-            "Average number of degrees per ply: {avg_degrees_per_ply:.2}"
-        );
+        warn!("Average number of degrees per ply: {avg_degrees_per_ply:.2}");
 
         let player_a_win_rate = self.player_a_wins as f32 / self.num_games as f32;
         let player_b_win_rate = self.player_b_wins as f32 / self.num_games as f32;

--- a/src/simulation_event_handler.rs
+++ b/src/simulation_event_handler.rs
@@ -19,6 +19,12 @@ pub struct CompositeSimulationEventHandler {
     handlers: Vec<Box<dyn SimulationEventHandler>>,
 }
 
+impl Default for CompositeSimulationEventHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl CompositeSimulationEventHandler {
     pub fn new() -> Self {
         Self {
@@ -52,7 +58,7 @@ impl SimulationEventHandler for CompositeSimulationEventHandler {
 
     fn on_game_end(&mut self, id: u32, state: State, result: Option<GameOutcome>) {
         for handler in self.handlers.iter_mut() {
-            handler.on_game_end(id, state.clone(), result.clone());
+            handler.on_game_end(id, state.clone(), result);
         }
     }
 
@@ -76,6 +82,12 @@ pub struct StatsCollector {
     turns_per_game: Vec<u8>,
     plys_per_game: Vec<u32>,
     total_degrees: Vec<u32>,
+}
+
+impl Default for StatsCollector {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl StatsCollector {
@@ -157,13 +169,11 @@ impl SimulationEventHandler for StatsCollector {
             humantime::format_duration(avg_duration)
         );
         warn!(
-            "Average number of turns per game: {:.2}",
-            avg_turns_per_game
+            "Average number of turns per game: {avg_turns_per_game:.2}"
         );
-        warn!("Average number of plys per game: {:.2}", avg_plys_per_game);
+        warn!("Average number of plys per game: {avg_plys_per_game:.2}");
         warn!(
-            "Average number of degrees per ply: {:.2}",
-            avg_degrees_per_ply
+            "Average number of degrees per ply: {avg_degrees_per_ply:.2}"
         );
 
         let player_a_win_rate = self.player_a_wins as f32 / self.num_games as f32;

--- a/src/state.rs
+++ b/src/state.rs
@@ -141,7 +141,7 @@ impl State {
     }
 
     pub(crate) fn end_turn_maintenance(&mut self) {
-        // Reset .played_this_turn and .ability_used for all in-play pokemon
+        // Maintain PlayedCard state for _all_ players
         for i in 0..2 {
             self.in_play_pokemon[i].iter_mut().for_each(|x| {
                 if let Some(played_card) = x {

--- a/src/types.rs
+++ b/src/types.rs
@@ -189,6 +189,13 @@ impl Card {
             _ => false,
         }
     }
+
+    pub(crate) fn as_trainer(&self) -> TrainerCard {
+        match self {
+            Card::Trainer(trainer_card) => trainer_card.clone(),
+            _ => panic!("Card is not a Trainer"),
+        }
+    }
 }
 
 /// This represents a card in the mat. Has a pointer to the card

--- a/src/types.rs
+++ b/src/types.rs
@@ -294,6 +294,10 @@ impl PlayedCard {
         self.attached_tool.is_some()
     }
 
+    /// Duration means:
+    ///   - 0: only during this turn
+    ///   - 1: during opponent's next turn
+    ///   - 2: on your next turn
     pub(crate) fn add_effect(&mut self, effect: CardEffect, duration: u8) {
         self.effects.push((effect, duration));
     }
@@ -310,10 +314,14 @@ impl PlayedCard {
     }
 
     pub(crate) fn end_turn_maintenance(&mut self) {
-        // Decrease the duration of all effects by 1, and remove those that are 0
-        self.effects.retain_mut(|(_, turns_left)| {
-            *turns_left = turns_left.saturating_sub(1);
-            *turns_left > 0
+        // Remove all the ones that are 0, and subtract 1 from the rest
+        self.effects.retain_mut(|(_, duration)| {
+            if *duration > 0 {
+                *duration -= 1;
+                true
+            } else {
+                false
+            }
         });
 
         // Reset played_this_turn and ability_used

--- a/src/types.rs
+++ b/src/types.rs
@@ -244,14 +244,14 @@ impl PlayedCard {
         }
     }
 
-    pub(crate) fn get_id(&self) -> String {
+    pub fn get_id(&self) -> String {
         match &self.card {
             Card::Pokemon(pokemon_card) => pokemon_card.id.clone(),
             Card::Trainer(trainer_card) => trainer_card.id.clone(),
         }
     }
 
-    pub(crate) fn get_name(&self) -> String {
+    pub fn get_name(&self) -> String {
         match &self.card {
             Card::Pokemon(pokemon_card) => pokemon_card.name.clone(),
             Card::Trainer(trainer_card) => trainer_card.name.clone(),

--- a/tests/apply_actions_test.rs
+++ b/tests/apply_actions_test.rs
@@ -212,7 +212,7 @@ fn test_attach_action() {
     ); // 1 grass energy
 }
 
-fn get_initialized_game(seed: u64) -> Game {
+fn get_initialized_game(seed: u64) -> Game<'static> {
     let players = init_random_players();
     let mut game = deckgym::Game::new(players, seed);
     while game.get_state_clone().turn_count == 0 {

--- a/tests/game_api_test.rs
+++ b/tests/game_api_test.rs
@@ -32,7 +32,7 @@ fn test_mcts_player() {
     // This test is flaky, since if we change the order of operations the random
     // number generator is used, then it will change. But we keep it just to
     // keep learning what changes lead to this.
-    assert_eq!(game.get_state_clone().turn_count, 38);
+    assert_eq!(game.get_state_clone().turn_count, 18);
 }
 
 #[test]


### PR DESCRIPTION
## Description
This PR presents the `Simulation` and `SimulationEventHandler` which allow users of the library to "hook into" / "listen" for game events by just specifying several callbacks.

## Changes
- Implements Cosmoem (generalizes damage_and_card_effect_attack to accept player suffering effect).
- Implements Shiinotic (generalizes pokemon_search_outcomes to accept wether basic-only)
- Adds EvolutionRusherPlayer
- Presents the `Simulation` and `SimulationEventHandler`
- Adds an example Rust script on how to use the Simulation Hooks to compute the data for https://medium.com/@bcollazo2010/simulated-1-000-000-games-to-find-fastest-solgaleo-deck-d3cfa0e525c4.