### PR TITLE
Implement Greninja, Suicune ex, Giratina ex abilities and trainer cards

### DIFF
--- a/example_decks/suicune-greninja.txt
+++ b/example_decks/suicune-greninja.txt
@@ -1,0 +1,13 @@
+Energy: Water
+2 Froakie A1 87
+2 Greninja A1 89
+1 Giratina ex A2b 35
+2 Suicune ex A4a 20
+1 Giant Cape A2 147
+2 Cyrus A2 150
+1 Mars A2 155
+2 Irida A2a 72
+2 Rare Candy A3 144
+1 Repel A3a 64
+2 Poké Ball P-A 5
+2 Professor's Research P-A 7

--- a/example_decks/venu-leafon.txt
+++ b/example_decks/venu-leafon.txt
@@ -4,9 +4,9 @@ Energy: Grass
 2 Venusaur ex A1 4
 2 Leafeon ex A2a 10
 2 Eevee A4 134
-1 Erika A1 219
+2 Erika A1 266
 2 Rocky Helmet A2 148
 2 Rare Candy A3 144
-2 Leaf Cape A3 147
+1 Lillie A3 197
 2 Poké Ball P-A 5
 2 Professor's Research P-A 7

--- a/example_decks/venu-magby.txt
+++ b/example_decks/venu-magby.txt
@@ -3,10 +3,10 @@ Energy: Grass
 1 Ivysaur A1 2
 2 Venusaur ex A1 4
 2 Magby A4 166
-2 Erika A1 219
+2 Erika A1 266
 2 Rocky Helmet A2 148
 2 Rare Candy A3 144
-2 Leaf Cape A3 147
-1 Lillie A3 155
+2 Lillie A3 197
+1 Potion P-A 1
 2 Poké Ball P-A 5
 2 Professor's Research P-A 7

--- a/example_decks/venu-serperior.txt
+++ b/example_decks/venu-serperior.txt
@@ -4,9 +4,9 @@ Energy: Grass
 2 Venusaur ex A1 4
 2 Snivy A1a 4
 2 Serperior A1a 6
-1 Erika A1 219
+2 Erika A1 266
 2 Rocky Helmet A2 148
 2 Rare Candy A3 144
-2 Leaf Cape A3 147
+1 Lillie A3 197
 2 Poké Ball P-A 5
 2 Professor's Research P-A 7

--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -14,6 +14,7 @@ pub enum AbilityId {
     A3122SolgaleoExRisingRoad,
     A3a027ShiinoticIlluminate,
     A3b034SylveonExHappyRibbon,
+    A4a020SuicuneExLegendaryPulse,
 }
 
 // Create a static HashMap for fast (pokemon, index) lookup
@@ -44,6 +45,9 @@ lazy_static::lazy_static! {
         m.insert("A3b 081", AbilityId::A3b034SylveonExHappyRibbon);
         m.insert("A3b 089", AbilityId::A3b034SylveonExHappyRibbon);
         m.insert("A4 233", AbilityId::A2a010LeafeonExForestBreath);
+        m.insert("A4a 020", AbilityId::A4a020SuicuneExLegendaryPulse);
+        m.insert("A4a 080", AbilityId::A4a020SuicuneExLegendaryPulse);
+        m.insert("A4a 090", AbilityId::A4a020SuicuneExLegendaryPulse);
         m.insert("P-A 019", AbilityId::A1089GreninjaWaterShuriken);
         m
     };

--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum AbilityId {
     A1020VictreebelFragranceTrap,
+    A1089GreninjaWaterShuriken,
     A1177Weezing,
     A1007Butterfree,
     A1132Gardevoir,
@@ -21,6 +22,7 @@ lazy_static::lazy_static! {
         let mut m = HashMap::new();
         m.insert("A1 007", AbilityId::A1007Butterfree);
         m.insert("A1 020", AbilityId::A1020VictreebelFragranceTrap);
+        m.insert("A1 089", AbilityId::A1089GreninjaWaterShuriken);
         m.insert("A1 177", AbilityId::A1177Weezing);
         m.insert("A1 132", AbilityId::A1132Gardevoir);
         m.insert("A1a 006", AbilityId::A1a006SerperiorJungleTotem);
@@ -37,10 +39,12 @@ lazy_static::lazy_static! {
         m.insert("A3 207", AbilityId::A3122SolgaleoExRisingRoad);
         m.insert("A3 239", AbilityId::A3122SolgaleoExRisingRoad);
         m.insert("A3a 027", AbilityId::A3a027ShiinoticIlluminate);
+        m.insert("A3a 093", AbilityId::A1089GreninjaWaterShuriken);
         m.insert("A3b 034", AbilityId::A3b034SylveonExHappyRibbon);
         m.insert("A3b 081", AbilityId::A3b034SylveonExHappyRibbon);
         m.insert("A3b 089", AbilityId::A3b034SylveonExHappyRibbon);
         m.insert("A4 233", AbilityId::A2a010LeafeonExForestBreath);
+        m.insert("P-A 019", AbilityId::A1089GreninjaWaterShuriken);
         m
     };
 }

--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -11,6 +11,7 @@ pub enum AbilityId {
     A1a006SerperiorJungleTotem,
     A2a010LeafeonExForestBreath,
     A2a071Arceus,
+    A2b035GiratinaExBrokenSpaceBellow,
     A3122SolgaleoExRisingRoad,
     A3a027ShiinoticIlluminate,
     A3b034SylveonExHappyRibbon,
@@ -35,6 +36,9 @@ lazy_static::lazy_static! {
         m.insert("A2a 086", AbilityId::A2a071Arceus);
         m.insert("A2a 095", AbilityId::A2a071Arceus);
         m.insert("A2a 096", AbilityId::A2a071Arceus);
+        m.insert("A2b 035", AbilityId::A2b035GiratinaExBrokenSpaceBellow);
+        m.insert("A2b 083", AbilityId::A2b035GiratinaExBrokenSpaceBellow);
+        m.insert("A2b 096", AbilityId::A2b035GiratinaExBrokenSpaceBellow);
         m.insert("A3 122", AbilityId::A3122SolgaleoExRisingRoad);
         m.insert("A3 189", AbilityId::A3122SolgaleoExRisingRoad);
         m.insert("A3 207", AbilityId::A3122SolgaleoExRisingRoad);

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -32,6 +32,7 @@ pub(crate) fn forecast_ability(
         AbilityId::A1a006SerperiorJungleTotem => panic!("Serperior's ability is passive"),
         AbilityId::A2a010LeafeonExForestBreath => charge_grass_pokemon(action.actor),
         AbilityId::A2a071Arceus => panic!("Arceus's ability cant be used on demand"),
+        AbilityId::A2b035GiratinaExBrokenSpaceBellow => charge_giratina_and_end_turn(index),
         AbilityId::A3122SolgaleoExRisingRoad => rising_road(index),
         AbilityId::A3a027ShiinoticIlluminate => pokemon_search_outcomes(action.actor, state, false),
         AbilityId::A3b034SylveonExHappyRibbon => panic!("Happy Ribbon cant be used on demand"),
@@ -132,5 +133,21 @@ fn damage_opponent_pokemon(acting_player: usize, damage: u32) -> (Probabilities,
         state
             .move_generation_stack
             .push((acting_player, possible_moves));
+    }))
+}
+
+fn charge_giratina_and_end_turn(index: usize) -> (Probabilities, Mutations) {
+    ability_doutcome(ability_mutation(move |_, state, action| {
+        // Once during your turn, you may take a Psychic Energy from your Energy Zone and attach it to this Pokémon. If you use this Ability, your turn ends.
+        debug!("Giratina ex's ability: Attaching 1 Psychic Energy and ending turn");
+        let pokemon = state.in_play_pokemon[action.actor][index]
+            .as_mut()
+            .expect("Pokemon should be there");
+        pokemon.attach_energy(&EnergyType::Psychic, 1);
+
+        // End the turn after using this ability
+        state
+            .move_generation_stack
+            .push((action.actor, vec![SimpleAction::EndTurn]));
     }))
 }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -26,6 +26,7 @@ pub(crate) fn forecast_ability(
     match ability_id {
         AbilityId::A1007Butterfree => heal_your_pokemon(20),
         AbilityId::A1020VictreebelFragranceTrap => switch_opponent_basic_to_active(action.actor),
+        AbilityId::A1089GreninjaWaterShuriken => damage_opponent_pokemon(action.actor, 20),
         AbilityId::A1177Weezing => poison_opponent_active_pokemon(),
         AbilityId::A1132Gardevoir => charge_active(EnergyType::Psychic),
         AbilityId::A1a006SerperiorJungleTotem => panic!("Serperior's ability is passive"),
@@ -103,6 +104,26 @@ fn charge_grass_pokemon(acting_player: usize) -> (Probabilities, Mutations) {
             .map(|(in_play_idx, _)| SimpleAction::Attach {
                 attachments: vec![(1, EnergyType::Grass, in_play_idx)],
                 is_turn_energy: false,
+            })
+            .collect::<Vec<_>>();
+        state
+            .move_generation_stack
+            .push((acting_player, possible_moves));
+    }))
+}
+
+fn damage_opponent_pokemon(acting_player: usize, damage: u32) -> (Probabilities, Mutations) {
+    ability_doutcome(ability_mutation(move |_, state, _| {
+        // Once during your turn, you may do 20 damage to 1 of your opponent's Pokémon.
+        debug!(
+            "Greninja's ability: Dealing {} damage to 1 opponent's Pokemon",
+            damage
+        );
+        let opponent = (acting_player + 1) % 2;
+        let possible_moves = state
+            .enumerate_in_play_pokemon(opponent)
+            .map(|(in_play_idx, _)| SimpleAction::ApplyDamage {
+                targets: vec![(damage, in_play_idx)],
             })
             .collect::<Vec<_>>();
         state

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -35,6 +35,9 @@ pub(crate) fn forecast_ability(
         AbilityId::A3122SolgaleoExRisingRoad => rising_road(index),
         AbilityId::A3a027ShiinoticIlluminate => pokemon_search_outcomes(action.actor, state, false),
         AbilityId::A3b034SylveonExHappyRibbon => panic!("Happy Ribbon cant be used on demand"),
+        AbilityId::A4a020SuicuneExLegendaryPulse => {
+            panic!("Legendary Pulse is triggered at end of turn")
+        }
     }
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -115,6 +115,7 @@ fn forecast_effect_attack(
         AttackId::A2b007MeowscaradaFightingClaws => {
             extra_damage_if_opponent_is_ex(acting_player, state, 60, 70)
         }
+        AttackId::A2b035GiratinaExChaoticImpact => self_damage_attack(130, 20),
         AttackId::A1017VenomothPoisonPowder => damage_status_attack(30, StatusCondition::Poisoned),
         AttackId::A1022ExeggutorStomp => probabilistic_damage_attack(vec![0.5, 0.5], vec![30, 60]),
         AttackId::A1023ExeggutorExTropicalSwing => {
@@ -275,6 +276,7 @@ fn forecast_effect_attack(
             attach_energy_to_benched_basic(acting_player, EnergyType::Fire)
         }
         AttackId::A4134EeveeFindAFriend => pokemon_search_outcomes(acting_player, state, false),
+        AttackId::A4a020SuicuneExCrystalWaltz => all_bench_count_attack(acting_player, state, 20),
         AttackId::PA072AlolanGrimerPoison => damage_status_attack(0, StatusCondition::Poisoned),
         AttackId::A1213CinccinoDoTheWave | AttackId::PA031CinccinoDoTheWave => {
             bench_count_attack(acting_player, state, 0, 30, None)
@@ -466,6 +468,20 @@ fn bench_count_attack(
         }
     }
     active_damage_doutcome(base_damage + damage_per * bench_count)
+}
+
+/// For attacks that do damage for each benched Pokémon on both sides.
+///  e.g. "Suicune Ex Crystal Waltz".
+fn all_bench_count_attack(
+    acting_player: usize,
+    state: &State,
+    damage_per: u32,
+) -> (Probabilities, Mutations) {
+    let opponent = (acting_player + 1) % 2;
+    let your_bench_count = state.enumerate_bench_pokemon(acting_player).count() as u32;
+    let opponent_bench_count = state.enumerate_bench_pokemon(opponent).count() as u32;
+    let total_bench_count = your_bench_count + opponent_bench_count;
+    active_damage_doutcome(damage_per * total_bench_count)
 }
 
 /// Used for attacks that can go directly to one of your own benched Pokémon.

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -34,6 +34,7 @@ pub fn forecast_trainer_action(
         CardId::PA007ProfessorsResearch => doutcome(professor_oak_effect),
         CardId::A1219Erika | CardId::A1266Erika => doutcome(erika_effect),
         CardId::A1220Misty | CardId::A1267Misty => misty_outcomes(),
+        CardId::A2a072Irida | CardId::A2a087Irida => doutcome(irida_effect),
         CardId::A3155Lillie | CardId::A3197Lillie | CardId::A3209Lillie => doutcome(lillie_effect),
         CardId::A1222Koga | CardId::A1269Koga => doutcome(koga_effect),
         CardId::A1223Giovanni | CardId::A1270Giovanni => doutcome(giovanni_effect),
@@ -52,6 +53,16 @@ pub fn forecast_trainer_action(
 
 fn erika_effect(rng: &mut StdRng, state: &mut State, action: &Action) {
     inner_healing_effect(rng, state, action, 50, Some(EnergyType::Grass));
+}
+
+fn irida_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Heal 40 damage from each of your Pokémon that has any Water Energy attached.
+    debug!("Irida: Healing 40 damage from each Pokemon with Water Energy attached");
+    for pokemon in state.in_play_pokemon[action.actor].iter_mut().flatten() {
+        if pokemon.attached_energy.contains(&EnergyType::Water) {
+            pokemon.heal(40);
+        }
+    }
 }
 
 fn lillie_effect(_: &mut StdRng, state: &mut State, action: &Action) {

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -44,6 +44,7 @@ pub fn forecast_trainer_action(
             doutcome(attach_tool)
         }
         CardId::A2150Cyrus | CardId::A2190Cyrus => doutcome(cyrus_effect),
+        CardId::A2155Mars | CardId::A2195Mars => doutcome(mars_effect),
         CardId::A3144RareCandy => doutcome(rare_candy_effect),
         _ => panic!("Unsupported Trainer Card"),
     }
@@ -157,6 +158,31 @@ fn cyrus_effect(_: &mut StdRng, state: &mut State, action: &Action) {
     state
         .move_generation_stack
         .push((opponent_player, possible_moves));
+}
+
+fn mars_effect(rng: &mut StdRng, state: &mut State, action: &Action) {
+    // Your opponent shuffles their hand into their deck and draws a card for each of their remaining points needed to win.
+    let opponent_player = (action.actor + 1) % 2;
+    let opponent_points = state.points[opponent_player];
+    let cards_to_draw = (3 - opponent_points) as usize;
+
+    debug!(
+        "Mars: Opponent has {} points, shuffling hand and drawing {} cards",
+        opponent_points, cards_to_draw
+    );
+
+    // Shuffle opponent's hand back into deck
+    state.decks[opponent_player]
+        .cards
+        .append(&mut state.hands[opponent_player]);
+    state.decks[opponent_player].shuffle(false, rng);
+
+    // Draw cards
+    for _ in 0..cards_to_draw {
+        if let Some(card) = state.decks[opponent_player].draw() {
+            state.hands[opponent_player].push(card);
+        }
+    }
 }
 
 fn giovanni_effect(_: &mut StdRng, state: &mut State, _: &Action) {

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -47,6 +47,7 @@ pub fn forecast_trainer_action(
         CardId::A2150Cyrus | CardId::A2190Cyrus => doutcome(cyrus_effect),
         CardId::A2155Mars | CardId::A2195Mars => doutcome(mars_effect),
         CardId::A3144RareCandy => doutcome(rare_candy_effect),
+        CardId::A3a064Repel => doutcome(repel_effect),
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -148,6 +149,18 @@ fn leaf_effect(_: &mut StdRng, state: &mut State, _: &Action) {
 
 fn sabrina_effect(_: &mut StdRng, state: &mut State, action: &Action) {
     // Switch out your opponent's Active Pokémon to the Bench. (Your opponent chooses the new Active Pokémon.)
+    let opponent_player = (action.actor + 1) % 2;
+    let possible_moves = state
+        .enumerate_bench_pokemon(opponent_player)
+        .map(|(i, _)| SimpleAction::Activate { in_play_idx: i })
+        .collect::<Vec<_>>();
+    state
+        .move_generation_stack
+        .push((opponent_player, possible_moves));
+}
+
+fn repel_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Switch out your opponent's Active Basic Pokémon to the Bench. (Your opponent chooses the new Active Pokémon.)
     let opponent_player = (action.actor + 1) % 2;
     let possible_moves = state
         .enumerate_bench_pokemon(opponent_player)

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -87,12 +87,14 @@ pub enum AttackId {
     A2b003BeedrillExCrushingSpear,
     A2b005SprigatitoCryForHelp,
     A2b007MeowscaradaFightingClaws,
+    A2b035GiratinaExChaoticImpact,
     A3085CosmogTeleport,
     A3086CosmoemStiffen,
     A3122SolgaleoExSolBreaker,
     A3a094JynxPsychic,
     A4032MagbyToasty,
     A4134EeveeFindAFriend,
+    A4a020SuicuneExCrystalWaltz,
     PA031CinccinoDoTheWave,
     PA034PiplupHeal,
     PA052SprigatitoCryForHelp,
@@ -238,6 +240,9 @@ lazy_static::lazy_static! {
         m.insert(("A2b 005", 0), AttackId::A2b005SprigatitoCryForHelp);
         m.insert(("A2b 007", 0), AttackId::A2b007MeowscaradaFightingClaws);
         m.insert(("A2b 073", 0), AttackId::A2b007MeowscaradaFightingClaws);
+        m.insert(("A2b 035", 0), AttackId::A2b035GiratinaExChaoticImpact);
+        m.insert(("A2b 083", 0), AttackId::A2b035GiratinaExChaoticImpact);
+        m.insert(("A2b 096", 0), AttackId::A2b035GiratinaExChaoticImpact);
 
         // A3
         m.insert(("A3 085", 0), AttackId::A3085CosmogTeleport);
@@ -260,6 +265,9 @@ lazy_static::lazy_static! {
         m.insert(("A4 166", 0), AttackId::A4032MagbyToasty);
         m.insert(("A4 134", 0), AttackId::A4134EeveeFindAFriend);
         m.insert(("A4 231", 0), AttackId::A4134EeveeFindAFriend);
+        m.insert(("A4a 020", 0), AttackId::A4a020SuicuneExCrystalWaltz);
+        m.insert(("A4a 080", 0), AttackId::A4a020SuicuneExCrystalWaltz);
+        m.insert(("A4a 090", 0), AttackId::A4a020SuicuneExCrystalWaltz);
 
         // Promo
         m.insert(("P-A 012", 0), AttackId::A1196MeowthPayDay);

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -94,8 +94,19 @@ pub(crate) fn on_evolve(actor: usize, state: &mut State, to_card: &Card) {
     }
 }
 
-pub(crate) fn on_end_turn(_player_ending_turn: usize, _state: &mut State) {
-    // TODO: Implement Suicune, Zeraora, etc... that trigger on turn end
+pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
+    // Check if active Pokémon has an end-of-turn ability
+    let active = state.get_active(player_ending_turn);
+    if let Some(ability_id) = AbilityId::from_pokemon_id(&active.card.get_id()[..]) {
+        if ability_id == AbilityId::A4a020SuicuneExLegendaryPulse {
+            // At the end of your turn, if this Pokémon is in the Active Spot, draw a card.
+            debug!("Suicune ex's Legendary Pulse: Drawing a card");
+            state.move_generation_stack.push((
+                player_ending_turn,
+                vec![SimpleAction::DrawCard { amount: 1 }],
+            ));
+        }
+    }
 }
 
 // TODO: Implement Gengars ability that disallow playing support cards.

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -7,6 +7,7 @@ mod retreat;
 
 pub(crate) use core::can_play_support;
 pub(crate) use core::contains_energy;
+pub(crate) use core::energy_missing;
 pub(crate) use core::get_damage_from_attack;
 pub(crate) use core::get_stage;
 pub(crate) use core::on_attach_tool;

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,9 @@ enum Commands {
         /// Path to the second deck file
         deck_b: String,
 
-        /// Players' strategies as a comma-separated list
+        /// Players' strategies as a comma-separated list (e.g., "e2,e4" or "r,e5")
+        /// Available codes: aa, et, r, h, w, m, v, e<depth>, er
+        /// Example: e2 = ExpectiMiniMax with depth 2
         #[arg(long, value_delimiter = ',', value_parser = parse_player_code)]
         players: Option<Vec<PlayerCode>>,
 
@@ -53,7 +55,9 @@ enum Commands {
         #[arg(short, long)]
         num: u32,
 
-        /// Players' strategies as a comma-separated list (e.g. "e,e")
+        /// Players' strategies as a comma-separated list (e.g., "e2,e4" or "r,e5")
+        /// Available codes: aa, et, r, h, w, m, v, e<depth>, er
+        /// Example: e2 = ExpectiMiniMax with depth 2
         #[arg(long, value_delimiter = ',', value_parser = parse_player_code)]
         players: Option<Vec<PlayerCode>>,
 

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -34,5 +34,6 @@ fn can_use_ability((in_play_index, card): &(usize, &PlayedCard)) -> bool {
         AbilityId::A3a027ShiinoticIlluminate => !card.ability_used,
         AbilityId::A2a071Arceus => false,
         AbilityId::A3b034SylveonExHappyRibbon => false,
+        AbilityId::A4a020SuicuneExLegendaryPulse => false,
     }
 }

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -25,6 +25,7 @@ fn can_use_ability((in_play_index, card): &(usize, &PlayedCard)) -> bool {
     match ability {
         AbilityId::A1007Butterfree => !card.ability_used,
         AbilityId::A1020VictreebelFragranceTrap => is_active && !card.ability_used,
+        AbilityId::A1089GreninjaWaterShuriken => !card.ability_used,
         AbilityId::A1177Weezing => is_active && !card.ability_used,
         AbilityId::A1132Gardevoir => !card.ability_used,
         AbilityId::A1a006SerperiorJungleTotem => false,

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -30,6 +30,7 @@ fn can_use_ability((in_play_index, card): &(usize, &PlayedCard)) -> bool {
         AbilityId::A1132Gardevoir => !card.ability_used,
         AbilityId::A1a006SerperiorJungleTotem => false,
         AbilityId::A2a010LeafeonExForestBreath => is_active && !card.ability_used,
+        AbilityId::A2b035GiratinaExBrokenSpaceBellow => !card.ability_used,
         AbilityId::A3122SolgaleoExRisingRoad => !is_active && !card.ability_used,
         AbilityId::A3a027ShiinoticIlluminate => !card.ability_used,
         AbilityId::A2a071Arceus => false,

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -49,6 +49,7 @@ pub fn generate_possible_trainer_actions(
         CardId::A1222Koga | CardId::A1269Koga => can_play_koga(state, trainer_card),
         CardId::A1225Sabrina | CardId::A1272Sabrina => can_play_sabrina(state, trainer_card),
         CardId::A2150Cyrus | CardId::A2190Cyrus => can_play_cyrus(state, trainer_card),
+        CardId::A2155Mars | CardId::A2195Mars => can_play_trainer(state, trainer_card),
         CardId::A3144RareCandy => can_play_rare_candy(state, trainer_card),
         CardId::PA002XSpeed
         | CardId::PA005PokeBall

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -52,6 +52,7 @@ pub fn generate_possible_trainer_actions(
         CardId::A2150Cyrus | CardId::A2190Cyrus => can_play_cyrus(state, trainer_card),
         CardId::A2155Mars | CardId::A2195Mars => can_play_trainer(state, trainer_card),
         CardId::A3144RareCandy => can_play_rare_candy(state, trainer_card),
+        CardId::A3a064Repel => can_play_repel(state, trainer_card),
         CardId::PA002XSpeed
         | CardId::PA005PokeBall
         | CardId::PA006RedCard
@@ -178,6 +179,17 @@ fn can_play_cyrus(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simpl
         .filter(|(_, x)| x.is_damaged())
         .count();
     if damaged_bench_count > 0 {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
+}
+
+/// Check if Repel can be played (requires opponent's active to be a Basic pokemon)
+fn can_play_repel(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let opponent = (state.current_player + 1) % 2;
+    let opponent_active = state.get_active(opponent);
+    if opponent_active.card.is_basic() {
         can_play_trainer(state, trainer_card)
     } else {
         cannot_play_trainer()

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -43,6 +43,7 @@ pub fn generate_possible_trainer_actions(
         CardId::PA001Potion => can_play_potion(state, trainer_card),
         CardId::A1219Erika | CardId::A1266Erika => can_play_erika(state, trainer_card),
         CardId::A1220Misty | CardId::A1267Misty => can_play_misty(state, trainer_card),
+        CardId::A2a072Irida | CardId::A2a087Irida => can_play_irida(state, trainer_card),
         CardId::A3155Lillie | CardId::A3197Lillie | CardId::A3209Lillie => {
             can_play_lillie(state, trainer_card)
         }
@@ -100,6 +101,19 @@ fn can_play_erika(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simpl
         .filter(|(_, x)| x.is_damaged() && x.get_energy_type() == Some(EnergyType::Grass))
         .count();
     if damaged_grass_count > 0 {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
+}
+
+/// Check if Irida can be played (requires at least 1 damaged pokemon with Water energy attached)
+fn can_play_irida(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let damaged_water_count = state
+        .enumerate_in_play_pokemon(state.current_player)
+        .filter(|(_, x)| x.is_damaged() && x.attached_energy.contains(&EnergyType::Water))
+        .count();
+    if damaged_water_count > 0 {
         can_play_trainer(state, trainer_card)
     } else {
         cannot_play_trainer()

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -192,7 +192,8 @@ fn can_play_cyrus(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simpl
 fn can_play_repel(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
     let opponent = (state.current_player + 1) % 2;
     let opponent_active = state.get_active(opponent);
-    if opponent_active.card.is_basic() {
+    let opponent_bench_count = state.enumerate_bench_pokemon(opponent).count();
+    if opponent_active.card.is_basic() && opponent_bench_count > 0 {
         can_play_trainer(state, trainer_card)
     } else {
         cannot_play_trainer()

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -29,8 +29,11 @@ pub fn generate_possible_trainer_actions(
     state: &State,
     trainer_card: &TrainerCard,
 ) -> Option<Vec<SimpleAction>> {
+    if state.turn_count == 0 {
+        return cannot_play_trainer(); // No trainers on initial setup phase
+    }
     if trainer_card.trainer_card_type == TrainerType::Supporter && !can_play_support(state) {
-        return Some(vec![]); // dont even check which type it is
+        return cannot_play_trainer(); // dont even check which type it is
     }
 
     // Pokemon tools can be played if there is a space in the mat for them.

--- a/src/players/expectiminimax_player.rs
+++ b/src/players/expectiminimax_player.rs
@@ -219,7 +219,7 @@ fn value_function(state: &State, myself: usize) -> f64 {
         .enumerate_in_play_pokemon(myself)
         .map(|(pos, card)| {
             let relevant_energy = get_relevant_energy(state, opponent, card);
-            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0) as f64;
+            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
             if pos == 0 {
                 hp_energy_product * active_factor
             } else {

--- a/src/players/expectiminimax_player.rs
+++ b/src/players/expectiminimax_player.rs
@@ -105,15 +105,15 @@ fn expected_value_function(
     depth: usize,
     myself: usize,
 ) -> (f64, DebugActionNode) {
-    let indent = "  ".repeat(depth);
+    let indent = "\t".repeat(3 - depth);
     trace!("{indent}E({myself}) depth left: {depth} action: {action:?}");
 
     let (probabilities, mutations) = forecast_action(state, action);
     let mut outcomes: Vec<State> = vec![];
     for mutation in mutations {
-        let mut state = state.clone();
-        mutation(rng, &mut state, action);
-        outcomes.push(state);
+        let mut state_copy = state.clone();
+        mutation(rng, &mut state_copy, action);
+        outcomes.push(state_copy);
     }
 
     // Mantain node
@@ -243,13 +243,10 @@ fn value_function(state: &State, myself: usize) -> f64 {
     let hand_size = state.hands[myself].len() as f64;
     let opponent_hand_size = state.hands[opponent].len() as f64;
 
-    trace!(
-        "Value function: points: {points}, opponent_points: {opponent_points}, my_value: {my_value}, opponent_value: {opponent_value}, hand_size: {hand_size}, opponent_hand_size: {opponent_hand_size}"
-    );
     let score = (points - opponent_points) * 10000.0
         + (my_value - opponent_value)
         + (hand_size - opponent_hand_size) * 1.0;
-    trace!("Value function: {score}");
+    trace!("ValueFunction: {score} (points: {points}, opponent_points: {opponent_points}, my_value: {my_value}, opponent_value: {opponent_value}, hand_size: {hand_size}, opponent_hand_size: {opponent_hand_size})");
     score
 }
 

--- a/src/players/expectiminimax_player.rs
+++ b/src/players/expectiminimax_player.rs
@@ -105,7 +105,7 @@ fn expected_value_function(
     depth: usize,
     myself: usize,
 ) -> (f64, DebugActionNode) {
-    let indent = "\t".repeat(3 - depth);
+    let indent = "\t".repeat(10 - depth.min(10));
     trace!("{indent}E({myself}) depth left: {depth} action: {action:?}");
 
     let (probabilities, mutations) = forecast_action(state, action);


### PR DESCRIPTION
## Summary
- Implements Greninja's Water Shuriken ability (deal 20 damage to any opponent's Pokémon)
- Implements Suicune ex's Legendary Pulse ability (draw a card at end of turn when active)
- Implements Giratina ex's Broken-Space Bellow ability (attach Psychic Energy and end turn)
- Implements Mars Trainer Card (opponent shuffles hand and draws based on remaining points)
- Implements Irida Trainer Card (heal 40 damage from Pokémon with Water Energy)
- Implements Repel Trainer Card (switch opponent's active Basic Pokémon to bench)
- Adds example Suicune-Greninja deck

## Test plan
- [x] All 54 existing tests pass
- [x] Release build succeeds
- [x] TUI feature build succeeds
- [x] All binaries compile successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)