### PR TITLE
Add card implementation status tool

### DIFF
--- a/.github/prompts/ability.prompt.md
+++ b/.github/prompts/ability.prompt.md
@@ -2,6 +2,11 @@
 mode: agent
 ---
 
+- Decide what ability you want to implement. You can use:
+  ```bash
+  cargo run --bin card_status
+  ```
+  to see what cards are missing abilities.
 - Get the details of all the cards that have the ability you want to implement by using the following script:
 
   ```bash

--- a/.github/prompts/attack.prompt.md
+++ b/.github/prompts/attack.prompt.md
@@ -2,13 +2,18 @@
 mode: agent
 ---
 
+- Decide what attack you want to implement. You can use:
+  ```bash
+  cargo run --bin card_status
+  ```
+  to see what cards are missing attacks.
 - Get the details of all the cards that have the attack you want to implement by using the following script:
 
   ```bash
   cargo run --bin search "Venusaur" --attack "Giant Bloom"
   ```
 
-- Copy the ids of cards to implement (including full art versions) in the given JSON.
+- Copy the ids of cards to implement (including full art versions) in the above JSON.
 - In `attack_ids.rs` add the attack to the `AttackId` enum and the `ATTACK_ID_MAP` map (with the correct index).
   - Only implement attacks with effects.
   - Keep the file ordered by set and number.

--- a/.github/prompts/tool.prompt.md
+++ b/.github/prompts/tool.prompt.md
@@ -2,6 +2,11 @@
 mode: agent
 ---
 
+- Decide what tool you want to implement. You can use:
+  ```bash
+  cargo run --bin card_status
+  ```
+  to see what tools are missing implementation.
 - Get the details of the tool card that you want to implement by using the following script:
 
   ```bash

--- a/.github/prompts/trainer.prompt.md
+++ b/.github/prompts/trainer.prompt.md
@@ -2,6 +2,11 @@
 mode: agent
 ---
 
+- Decide what trainer you want to implement. You can use:
+  ```bash
+  cargo run --bin card_status
+  ```
+  to see what trainers are missing implementation.
 - Get the details of the trainer card that you want to implement by using the following script:
 
   ```bash

--- a/README.md
+++ b/README.md
@@ -107,6 +107,23 @@ cargo run --bin search "Charizard"
 cargo run --bin search "Venusaur" --attack "Giant Bloom"
 ```
 
+**Card Implementation Status Tool**
+
+Check which cards are fully implemented versus which are missing attack effects, abilities, or trainer logic. This tool helps contributors identify cards that need implementation work.
+
+```bash
+# Show all cards with their implementation status
+cargo run --bin card_status
+
+# Show only incomplete cards
+cargo run --bin card_status -- --incomplete-only
+
+# Get the first incomplete card (useful for automation)
+cargo run --bin card_status -- --first-incomplete
+```
+
+The tool displays a summary showing total cards, completion percentage, and a breakdown of missing implementations by type (attacks, abilities, tools, trainer logic).
+
 **Generating database.rs**
 
 Ensure database.json is up-to-date with latest data. Mock the `get_card_by_enum` in `database.rs` with a `_ => panic` so that

--- a/src/bin/card_status.rs
+++ b/src/bin/card_status.rs
@@ -1,0 +1,163 @@
+use clap::Parser;
+use deckgym::card_ids::CardId;
+use deckgym::card_validation::{get_implementation_status, ImplementationStatus};
+use deckgym::database::get_card_by_enum;
+use std::collections::HashMap;
+use strum::IntoEnumIterator;
+
+#[derive(Parser)]
+#[command(name = "card_status")]
+#[command(about = "Check implementation status of all cards in the database")]
+struct Args {
+    /// Return only the first incomplete card
+    #[arg(long)]
+    first_incomplete: bool,
+
+    /// Skip complete cards, show only incomplete ones
+    #[arg(long)]
+    incomplete_only: bool,
+}
+
+struct CardStatusInfo {
+    id: String,
+    name: String,
+    status: ImplementationStatus,
+}
+
+// Filtering logic: collect all card statuses
+fn collect_card_statuses() -> Vec<CardStatusInfo> {
+    CardId::iter()
+        .map(|card_id| {
+            let card = get_card_by_enum(card_id);
+            let status = get_implementation_status(card_id);
+
+            CardStatusInfo {
+                id: card.get_id(),
+                name: card.get_name(),
+                status,
+            }
+        })
+        .collect()
+}
+
+// Filtering logic: filter based on flags
+fn filter_results(results: Vec<CardStatusInfo>, incomplete_only: bool) -> Vec<CardStatusInfo> {
+    if incomplete_only {
+        results
+            .into_iter()
+            .filter(|info| !info.status.is_complete())
+            .collect()
+    } else {
+        results
+    }
+}
+
+// Presentation logic: render results in human-readable format
+fn render_results(results: &[CardStatusInfo]) {
+    if results.is_empty() {
+        println!("No cards found.");
+        return;
+    }
+
+    // Calculate column widths
+    let max_id_len = results.iter().map(|r| r.id.len()).max().unwrap_or(0);
+    let max_name_len = results.iter().map(|r| r.name.len()).max().unwrap_or(0);
+
+    // Print header
+    println!(
+        "{:width_id$}  {:width_name$}  Status",
+        "ID",
+        "Name",
+        width_id = max_id_len,
+        width_name = max_name_len
+    );
+    println!("{}", "-".repeat(max_id_len + max_name_len + 20));
+
+    // Print each card
+    for info in results {
+        let status_display = match info.status {
+            ImplementationStatus::Complete => "✓ Complete",
+            _ => info.status.description(),
+        };
+
+        println!(
+            "{:width_id$}  {:width_name$}  {}",
+            info.id,
+            info.name,
+            status_display,
+            width_id = max_id_len,
+            width_name = max_name_len
+        );
+    }
+
+    // Print summary statistics
+    print_summary(results);
+}
+
+fn print_summary(results: &[CardStatusInfo]) {
+    let total = results.len();
+    let complete = results.iter().filter(|r| r.status.is_complete()).count();
+    let incomplete = total - complete;
+
+    // Count by status type
+    let mut status_counts: HashMap<&str, usize> = HashMap::new();
+    for info in results {
+        if !info.status.is_complete() {
+            let desc = info.status.description();
+            *status_counts.entry(desc).or_insert(0) += 1;
+        }
+    }
+
+    println!("\n{}", "=".repeat(50));
+    println!("Summary:");
+    println!("  Total cards:      {}", total);
+    println!(
+        "  Complete:         {} ({:.1}%)",
+        complete,
+        (complete as f64 / total as f64) * 100.0
+    );
+    println!(
+        "  Incomplete:       {} ({:.1}%)",
+        incomplete,
+        (incomplete as f64 / total as f64) * 100.0
+    );
+
+    if !status_counts.is_empty() {
+        println!("\n  Breakdown by issue:");
+        let mut sorted_counts: Vec<_> = status_counts.iter().collect();
+        sorted_counts.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+        for (desc, count) in sorted_counts {
+            println!("    {}: {}", desc, count);
+        }
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = Args::parse();
+
+    // Collect all card statuses
+    let all_results = collect_card_statuses();
+
+    // Handle first-incomplete flag
+    if args.first_incomplete {
+        if let Some(first_incomplete) = all_results.iter().find(|r| !r.status.is_complete()) {
+            println!(
+                "{} - {} ({})",
+                first_incomplete.id,
+                first_incomplete.name,
+                first_incomplete.status.description()
+            );
+        } else {
+            println!("All cards are complete!");
+        }
+        return Ok(());
+    }
+
+    // Filter results based on flags
+    let filtered_results = filter_results(all_results, args.incomplete_only);
+
+    // Render results
+    render_results(&filtered_results);
+
+    Ok(())
+}

--- a/src/card_validation.rs
+++ b/src/card_validation.rs
@@ -1,0 +1,74 @@
+use crate::{
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, TrainerType},
+    move_generation::generate_possible_trainer_actions,
+    state::State,
+    AbilityId, AttackId,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ImplementationStatus {
+    Complete,
+    CardNotFound,
+    MissingAttack,
+    MissingAbility,
+    MissingTrainer,
+    MissingTool,
+}
+
+impl ImplementationStatus {
+    pub fn is_complete(&self) -> bool {
+        matches!(self, ImplementationStatus::Complete)
+    }
+
+    pub fn description(&self) -> &'static str {
+        match self {
+            ImplementationStatus::Complete => "Fully implemented",
+            ImplementationStatus::CardNotFound => "Card ID not found",
+            ImplementationStatus::MissingAttack => "Attack effect not implemented",
+            ImplementationStatus::MissingAbility => "Ability not implemented",
+            ImplementationStatus::MissingTrainer => "Trainer logic not implemented",
+            ImplementationStatus::MissingTool => "Tool not implemented",
+        }
+    }
+}
+
+pub fn get_implementation_status(card_id: CardId) -> ImplementationStatus {
+    let card = get_card_by_enum(card_id);
+    let card_id_string = card.get_id();
+
+    match card {
+        Card::Pokemon(pokemon) => {
+            // Verify attacks have no effects or effects are implemented
+            for (index, attack) in pokemon.attacks.iter().enumerate() {
+                if attack.effect.is_some()
+                    && AttackId::from_pokemon_index(&card_id_string, index).is_none()
+                {
+                    return ImplementationStatus::MissingAttack;
+                }
+            }
+
+            // Verify ability is implemented
+            if pokemon.ability.is_some() && AbilityId::from_pokemon_id(&card_id_string).is_none() {
+                return ImplementationStatus::MissingAbility;
+            }
+        }
+        Card::Trainer(trainer_card) => {
+            if trainer_card.trainer_card_type == TrainerType::Tool
+                && crate::tool_ids::ToolId::from_trainer_card(&trainer_card).is_none()
+            {
+                return ImplementationStatus::MissingTool;
+            }
+
+            // Verify it can generate moves
+            let moves = generate_possible_trainer_actions(&State::default(), &trainer_card);
+            if moves.is_none() {
+                return ImplementationStatus::MissingTrainer;
+            };
+        }
+    }
+
+    ImplementationStatus::Complete
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub mod actions;
 mod attack_ids;
 pub mod card_ids;
 pub mod card_logic;
+pub mod card_validation;
 pub mod database;
 pub mod deck;
 pub mod effects;


### PR DESCRIPTION
## Summary

This PR adds a new CLI tool (`card_status`) to check the implementation status of all cards in the database. This makes it easier for contributors to identify cards that need implementation work.

## Features

- **New `card_validation` module** with `ImplementationStatus` enum to check if cards are fully implemented
- **CLI tool (`card_status`)** with human-readable table output
- **Summary statistics** showing:
  - Total cards count
  - Completion percentage
  - Breakdown by issue type (missing attacks, abilities, tools, trainer logic)
- **Filtering flags**:
  - `--incomplete-only`: Show only cards that need implementation
  - `--first-incomplete`: Get just the first incomplete card (useful for automation)
- **Updated README** with usage examples and documentation

## Example Output

```
ID       Name                    Status
-------------------------------------------------
A1 001   Bulbasaur               ✓ Complete
A1 037   Vulpix                  Attack effect not implemented
...

==================================================
Summary:
  Total cards:      2033
  Complete:         1005 (49.4%)
  Incomplete:       1028 (50.6%)

  Breakdown by issue:
    Attack effect not implemented: 842
    Ability not implemented: 168
    Tool not implemented: 18
```

## Usage

```bash
# Show all cards
cargo run --bin card_status

# Show only incomplete cards
cargo run --bin card_status -- --incomplete-only

# Get first incomplete card
cargo run --bin card_status -- --first-incomplete
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)