### PR TITLE
Implement Darkrai ex

### DIFF
--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -11,6 +11,7 @@ pub enum AbilityId {
     A1a006SerperiorJungleTotem,
     A2a010LeafeonExForestBreath,
     A2a071Arceus,
+    A2110DarkraiExNightmareAura,
     A2b035GiratinaExBrokenSpaceBellow,
     A3122SolgaleoExRisingRoad,
     A3a027ShiinoticIlluminate,
@@ -36,6 +37,9 @@ lazy_static::lazy_static! {
         m.insert("A2a 086", AbilityId::A2a071Arceus);
         m.insert("A2a 095", AbilityId::A2a071Arceus);
         m.insert("A2a 096", AbilityId::A2a071Arceus);
+        m.insert("A2 110", AbilityId::A2110DarkraiExNightmareAura);
+        m.insert("A2 187", AbilityId::A2110DarkraiExNightmareAura);
+        m.insert("A2 202", AbilityId::A2110DarkraiExNightmareAura);
         m.insert("A2b 035", AbilityId::A2b035GiratinaExBrokenSpaceBellow);
         m.insert("A2b 083", AbilityId::A2b035GiratinaExBrokenSpaceBellow);
         m.insert("A2b 096", AbilityId::A2b035GiratinaExBrokenSpaceBellow);
@@ -52,6 +56,9 @@ lazy_static::lazy_static! {
         m.insert("A4a 020", AbilityId::A4a020SuicuneExLegendaryPulse);
         m.insert("A4a 080", AbilityId::A4a020SuicuneExLegendaryPulse);
         m.insert("A4a 090", AbilityId::A4a020SuicuneExLegendaryPulse);
+        m.insert("A4b 245", AbilityId::A2110DarkraiExNightmareAura);
+        m.insert("A4b 378", AbilityId::A2110DarkraiExNightmareAura);
+        m.insert("P-A 042", AbilityId::A2110DarkraiExNightmareAura);
         m.insert("P-A 019", AbilityId::A1089GreninjaWaterShuriken);
         m
     };

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -32,6 +32,7 @@ pub(crate) fn forecast_ability(
         AbilityId::A1a006SerperiorJungleTotem => panic!("Serperior's ability is passive"),
         AbilityId::A2a010LeafeonExForestBreath => charge_grass_pokemon(action.actor),
         AbilityId::A2a071Arceus => panic!("Arceus's ability cant be used on demand"),
+        AbilityId::A2110DarkraiExNightmareAura => panic!("Darkrai ex's ability is passive"),
         AbilityId::A2b035GiratinaExBrokenSpaceBellow => charge_giratina_and_end_turn(index),
         AbilityId::A3122SolgaleoExRisingRoad => rising_road(index),
         AbilityId::A3a027ShiinoticIlluminate => pokemon_search_outcomes(action.actor, state, false),

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -7,7 +7,7 @@ use crate::{
         apply_abilities_action::forecast_ability,
         apply_action_helpers::{apply_common_mutation, Mutation},
     },
-    hooks::{get_retreat_cost, on_attach_tool, on_evolve, to_playable_card},
+    hooks::{get_retreat_cost, on_attach_energy, on_attach_tool, on_evolve, to_playable_card},
     models::{Card, EnergyType},
     state::State,
 };
@@ -92,6 +92,10 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
                     .expect("Pokemon should be there if attaching energy to it")
                     .attached_energy
                     .extend(std::iter::repeat_n(*energy, *amount as usize));
+                // Call hook for each energy attached
+                for _ in 0..*amount {
+                    on_attach_energy(state, action.actor, *in_play_idx, *energy, *is_turn_energy);
+                }
             }
             if *is_turn_energy {
                 state.current_energy = None;

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -81,6 +81,34 @@ pub(crate) fn on_attach_tool(state: &mut State, actor: usize, in_play_idx: usize
     }
 }
 
+/// Called when energy is attached to a Pokémon
+pub(crate) fn on_attach_energy(
+    state: &mut State,
+    actor: usize,
+    in_play_idx: usize,
+    energy_type: EnergyType,
+    is_turn_energy: bool,
+) {
+    let pokemon = state.in_play_pokemon[actor][in_play_idx]
+        .as_ref()
+        .expect("Pokemon should be there if attaching energy to it");
+
+    // Check for Darkrai ex's Nightmare Aura ability
+    if let Some(ability_id) = AbilityId::from_pokemon_id(&pokemon.card.get_id()[..]) {
+        if ability_id == AbilityId::A2110DarkraiExNightmareAura
+            && energy_type == EnergyType::Darkness
+            && is_turn_energy
+        {
+            // Deal 20 damage to opponent's active Pokémon
+            debug!("Darkrai ex's Nightmare Aura: Dealing 20 damage to opponent's active Pokemon");
+            let opponent = (actor + 1) % 2;
+            if let Some(opponent_active) = state.in_play_pokemon[opponent][0].as_mut() {
+                opponent_active.apply_damage(20);
+            }
+        }
+    }
+}
+
 /// Called when a Pokémon evolves
 pub(crate) fn on_evolve(actor: usize, state: &mut State, to_card: &Card) {
     if let Some(ability_id) = AbilityId::from_pokemon_id(&to_card.get_id()[..]) {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use core::contains_energy;
 pub(crate) use core::energy_missing;
 pub(crate) use core::get_damage_from_attack;
 pub(crate) use core::get_stage;
+pub(crate) use core::on_attach_energy;
 pub(crate) use core::on_attach_tool;
 pub(crate) use core::on_end_turn;
 pub(crate) use core::on_evolve;

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -30,10 +30,11 @@ fn can_use_ability((in_play_index, card): &(usize, &PlayedCard)) -> bool {
         AbilityId::A1132Gardevoir => !card.ability_used,
         AbilityId::A1a006SerperiorJungleTotem => false,
         AbilityId::A2a010LeafeonExForestBreath => is_active && !card.ability_used,
+        AbilityId::A2a071Arceus => false,
+        AbilityId::A2110DarkraiExNightmareAura => false,
         AbilityId::A2b035GiratinaExBrokenSpaceBellow => !card.ability_used,
         AbilityId::A3122SolgaleoExRisingRoad => !is_active && !card.ability_used,
         AbilityId::A3a027ShiinoticIlluminate => !card.ability_used,
-        AbilityId::A2a071Arceus => false,
         AbilityId::A3b034SylveonExHappyRibbon => false,
         AbilityId::A4a020SuicuneExLegendaryPulse => false,
     }

--- a/tests/darkrai_ex_test.rs
+++ b/tests/darkrai_ex_test.rs
@@ -1,0 +1,178 @@
+use common::get_initialized_game;
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+};
+
+mod common;
+
+#[test]
+fn test_darkrai_ex_nightmare_aura() {
+    // Darkrai ex's Nightmare Aura: Whenever you attach a Darkness Energy from your Energy Zone to this Pokémon, do 20 damage to your opponent's Active Pokémon.
+
+    let darkrai_ex_card = get_card_by_enum(CardId::A2110DarkraiEx);
+    let opponent_active_card = get_card_by_enum(CardId::A1001Bulbasaur);
+
+    // Initialize with basic decks
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    let test_player = state.current_player;
+    let opponent_player = (test_player + 1) % 2;
+
+    // Set up Darkrai ex in active position
+    let darkrai = PlayedCard::new(
+        darkrai_ex_card.clone(),
+        140, // remaining_hp
+        140, // total_hp
+        vec![],
+        false,
+        vec![],
+    );
+    state.in_play_pokemon[test_player][0] = Some(darkrai);
+
+    // Set up opponent's active Pokémon
+    let opponent_active = PlayedCard::new(
+        opponent_active_card.clone(),
+        70, // remaining_hp
+        70, // total_hp
+        vec![],
+        false,
+        vec![],
+    );
+    state.in_play_pokemon[opponent_player][0] = Some(opponent_active);
+
+    game.set_state(state);
+
+    // Attach Darkness energy from Energy Zone to Darkrai ex
+    let attach_action = Action {
+        actor: test_player,
+        action: SimpleAction::Attach {
+            attachments: vec![(1, EnergyType::Darkness, 0)],
+            is_turn_energy: true,
+        },
+        is_stack: false,
+    };
+
+    // Apply the action
+    game.apply_action(&attach_action);
+
+    let state = game.get_state_clone();
+
+    // Check that Darkrai ex has the energy attached
+    assert_eq!(
+        state.in_play_pokemon[test_player][0]
+            .as_ref()
+            .unwrap()
+            .attached_energy
+            .len(),
+        1,
+        "Darkrai ex should have 1 energy attached"
+    );
+
+    // Check that opponent's active took 20 damage
+    assert_eq!(
+        state.in_play_pokemon[opponent_player][0]
+            .as_ref()
+            .unwrap()
+            .remaining_hp,
+        50,
+        "Opponent's active should have taken 20 damage (70 - 20 = 50)"
+    );
+}
+
+#[test]
+fn test_darkrai_ex_nightmare_aura_only_darkness() {
+    // Test that non-Darkness energy doesn't trigger the ability
+
+    let darkrai_ex_card = get_card_by_enum(CardId::A2110DarkraiEx);
+    let opponent_active_card = get_card_by_enum(CardId::A1001Bulbasaur);
+
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    let test_player = state.current_player;
+    let opponent_player = (test_player + 1) % 2;
+
+    let darkrai = PlayedCard::new(darkrai_ex_card.clone(), 140, 140, vec![], false, vec![]);
+    state.in_play_pokemon[test_player][0] = Some(darkrai);
+
+    let opponent_active =
+        PlayedCard::new(opponent_active_card.clone(), 70, 70, vec![], false, vec![]);
+    state.in_play_pokemon[opponent_player][0] = Some(opponent_active);
+
+    game.set_state(state);
+
+    // Attach Fire energy from Energy Zone to Darkrai ex
+    let attach_action = Action {
+        actor: test_player,
+        action: SimpleAction::Attach {
+            attachments: vec![(1, EnergyType::Fire, 0)],
+            is_turn_energy: true,
+        },
+        is_stack: false,
+    };
+
+    game.apply_action(&attach_action);
+
+    let state = game.get_state_clone();
+
+    // Check that opponent's active did NOT take damage
+    assert_eq!(
+        state.in_play_pokemon[opponent_player][0]
+            .as_ref()
+            .unwrap()
+            .remaining_hp,
+        70,
+        "Opponent's active should not have taken damage from non-Darkness energy"
+    );
+}
+
+#[test]
+fn test_darkrai_ex_nightmare_aura_only_turn_energy() {
+    // Test that the ability only triggers for energy from Energy Zone (is_turn_energy = true)
+
+    let darkrai_ex_card = get_card_by_enum(CardId::A2110DarkraiEx);
+    let opponent_active_card = get_card_by_enum(CardId::A1001Bulbasaur);
+
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    let test_player = state.current_player;
+    let opponent_player = (test_player + 1) % 2;
+
+    let darkrai = PlayedCard::new(darkrai_ex_card.clone(), 140, 140, vec![], false, vec![]);
+    state.in_play_pokemon[test_player][0] = Some(darkrai);
+
+    let opponent_active =
+        PlayedCard::new(opponent_active_card.clone(), 70, 70, vec![], false, vec![]);
+    state.in_play_pokemon[opponent_player][0] = Some(opponent_active);
+
+    game.set_state(state);
+
+    // Attach Darkness energy NOT from Energy Zone (is_turn_energy = false, e.g., from an ability)
+    let attach_action = Action {
+        actor: test_player,
+        action: SimpleAction::Attach {
+            attachments: vec![(1, EnergyType::Darkness, 0)],
+            is_turn_energy: false,
+        },
+        is_stack: false,
+    };
+
+    game.apply_action(&attach_action);
+
+    let state = game.get_state_clone();
+
+    // Check that opponent's active did NOT take damage
+    assert_eq!(
+        state.in_play_pokemon[opponent_player][0]
+            .as_ref()
+            .unwrap()
+            .remaining_hp,
+        70,
+        "Opponent's active should not have taken damage when energy is not from Energy Zone"
+    );
+}


### PR DESCRIPTION
## Summary

Implements Darkrai ex's **Nightmare Aura** ability: "Whenever you attach a Darkness Energy from your Energy Zone to this Pokémon, do 20 damage to your opponent's Active Pokémon."

This PR covers all 6 Darkrai ex card variants:
- A2 110 (◊◊◊◊)
- A2 187 (☆☆)
- A2 202 (☆☆)
- A4b 245 (◊◊◊◊)
- A4b 378 (☆☆)
- P-A 042 (Promo)

## Changes

- **Added `A2110DarkraiExNightmareAura`** to the ability system in `ability_ids.rs`
- **Created `on_attach_energy` hook** in `hooks/core.rs` for handling energy attachment events
- **Integrated hook** into energy attachment logic in `apply_action.rs`
- **Marked as passive ability** in move generation (cannot be manually activated)
- **Added comprehensive tests** in `tests/darkrai_ex_test.rs`

## Test Plan

Three test cases cover all scenarios:
1. ✅ Attaching Darkness energy from Energy Zone triggers 20 damage
2. ✅ Attaching non-Darkness energy doesn't trigger the ability
3. ✅ Attaching Darkness energy from abilities (not Energy Zone) doesn't trigger

All tests pass:
- 60 total tests passing
- No clippy warnings
- All Darkrai ex variants marked as "✓ Complete" in card_status tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)