### PR TITLE
Implement all Ninetales cards

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -285,6 +285,9 @@ fn forecast_effect_attack(
             probabilistic_damage_attack(vec![0.25, 0.5, 0.25], vec![0, 30, 60])
         }
         AttackId::A3040AlolanVulpixCallForth => self_charge_active_attack(0, EnergyType::Water, 1),
+        AttackId::A3041AlolanNinetalesBlizzard | AttackId::PA070AlolanNinetalesBlizzard => {
+            alolan_ninetales_blizzard(state)
+        }
         AttackId::A3071SpoinkPsycharge => self_charge_active_attack(0, EnergyType::Psychic, 1),
         AttackId::A3a019TapuKokoExPlasmaHurricane => {
             self_charge_active_attack(20, EnergyType::Lightning, 1)
@@ -324,6 +327,7 @@ fn forecast_effect_attack(
         AttackId::A3b058AipomDoubleHit => {
             probabilistic_damage_attack(vec![0.25, 0.5, 0.25], vec![0, 20, 40])
         }
+        AttackId::A4026NinetalesScorchingBreath => ninetales_scorching_breath(),
         AttackId::A4032MagbyToasty => {
             attach_energy_to_benched_basic(acting_player, EnergyType::Fire)
         }
@@ -838,6 +842,26 @@ fn articuno_ex_blizzard(state: &State) -> (Probabilities, Mutations) {
     // Active Pokémon is always index 0
     targets.push((80, 0));
     damage_effect_doutcome(targets, |_, _, _| {})
+}
+
+fn alolan_ninetales_blizzard(state: &State) -> (Probabilities, Mutations) {
+    // Blizzard: 60 to active, 20 to each opponent's benched Pokémon
+    let opponent = (state.current_player + 1) % 2;
+    let mut targets: Vec<(u32, usize)> = state
+        .enumerate_bench_pokemon(opponent)
+        .map(|(idx, _)| (20, idx))
+        .collect();
+    // Active Pokémon is always index 0
+    targets.push((60, 0));
+    damage_effect_doutcome(targets, |_, _, _| {})
+}
+
+fn ninetales_scorching_breath() -> (Probabilities, Mutations) {
+    // Scorching Breath: 120 damage, then this Pokémon can't attack next turn
+    active_damage_effect_doutcome(120, move |_, state, action| {
+        let active = state.get_active_mut(action.actor);
+        active.add_effect(CardEffect::CannotAttack, 1);
+    })
 }
 
 fn extra_damage_if_hurt(

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -102,6 +102,7 @@ pub enum AttackId {
     A2b044FlamigoDoubleKick,
     A3019SteeneeDoubleSpin,
     A3040AlolanVulpixCallForth,
+    A3041AlolanNinetalesBlizzard,
     A3071SpoinkPsycharge,
     A3a007PheromosaJumpBlues,
     A3a019TapuKokoExPlasmaHurricane,
@@ -116,6 +117,7 @@ pub enum AttackId {
     A3b013IncineroarDarkestLariat,
     A3b020VanilluxeDoubleSpin,
     A3b058AipomDoubleHit,
+    A4026NinetalesScorchingBreath,
     A4032MagbyToasty,
     A4066PichuCrackly,
     A4077CleffaTwinkly,
@@ -131,6 +133,7 @@ pub enum AttackId {
     PA034PiplupHeal,
     PA052SprigatitoCryForHelp,
     PA060ExeggcuteGrowth,
+    PA070AlolanNinetalesBlizzard,
     PA072AlolanGrimerPoison,
 }
 
@@ -298,6 +301,7 @@ lazy_static::lazy_static! {
         // A3
         m.insert(("A3 019", 0), AttackId::A3019SteeneeDoubleSpin);
         m.insert(("A3 040", 0), AttackId::A3040AlolanVulpixCallForth);
+        m.insert(("A3 041", 0), AttackId::A3041AlolanNinetalesBlizzard);
         m.insert(("A3 071", 0), AttackId::A3071SpoinkPsycharge);
         m.insert(("A3 085", 0), AttackId::A3085CosmogTeleport);
         m.insert(("A3 086", 0), AttackId::A3086CosmoemStiffen);
@@ -331,6 +335,7 @@ lazy_static::lazy_static! {
         m.insert(("A3b 087", 0), AttackId::A3b009FlareonExFireSpin);
 
         // A4
+        m.insert(("A4 026", 0), AttackId::A4026NinetalesScorchingBreath);
         m.insert(("A4 032", 0), AttackId::A4032MagbyToasty);
         m.insert(("A4 105", 0), AttackId::A4105BinacleDualChop);
         m.insert(("A4 146", 0), AttackId::A4146UrsaringSwingAround);
@@ -379,6 +384,7 @@ lazy_static::lazy_static! {
         m.insert(("P-A 052", 0), AttackId::PA052SprigatitoCryForHelp);
         m.insert(("P-A 060", 0), AttackId::PA060ExeggcuteGrowth);
         m.insert(("P-A 067", 0), AttackId::A3085CosmogTeleport);
+        m.insert(("P-A 070", 0), AttackId::PA070AlolanNinetalesBlizzard);
         m.insert(("P-A 072", 0), AttackId::PA072AlolanGrimerPoison);
 
 

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 pub enum CardEffect {
     NoRetreat,
     ReducedDamage { amount: u32 },
+    CannotAttack,
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/move_generation/attacks.rs
+++ b/src/move_generation/attacks.rs
@@ -1,9 +1,14 @@
-use crate::{actions::SimpleAction, hooks::contains_energy, State};
+use crate::{actions::SimpleAction, effects::CardEffect, hooks::contains_energy, State};
 
 pub(crate) fn generate_attack_actions(state: &State) -> Vec<SimpleAction> {
     let current_player = state.current_player;
     let mut actions = Vec::new();
     if let Some(active_pokemon) = &state.in_play_pokemon[current_player][0] {
+        // Check if the Pokemon has the CannotAttack effect
+        if active_pokemon.has_effect(CardEffect::CannotAttack) {
+            return actions; // Return empty list if Pokemon cannot attack
+        }
+
         active_pokemon
             .get_attacks()
             .iter()


### PR DESCRIPTION
This commit implements the missing Ninetales card attacks:
- A3 041 Alolan Ninetales - Blizzard attack
- A4 026 Ninetales - Scorching Breath attack
- P-A 070 Alolan Ninetales - Blizzard attack (promo)

Changes made:
1. Added attack IDs to attack_ids.rs enum and hashmap
2. Implemented Alolan Ninetales Blizzard attack (60 damage to active, 20 to each benched)
3. Implemented Ninetales Scorching Breath attack (120 damage, prevents attacker from attacking next turn)
4. Added new CardEffect::CannotAttack to effects.rs
5. Updated move generation to check for CannotAttack effect before allowing attacks

Note: A1 038 Ninetales Flamethrower was already implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)