### PR TITLE
Implement Rapidash Ex Sprinting Flare attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -449,6 +449,7 @@ fn forecast_effect_attack(
         AttackId::B1002MegaPinsirExCriticalScissors => {
             probabilistic_damage_attack(vec![0.5, 0.5], vec![80, 150])
         }
+        AttackId::B1031RapidashExSprintingFlare => active_then_choice_bench_attack(110, 20),
         AttackId::B1036MegaBlazikenExMegaBurning => mega_burning_attack(),
         AttackId::B1052MegaGyaradosExMegaBlaster => damage_and_discard_opponent_deck(140, 3),
         AttackId::B1085MegaAmpharosExLightningLancer => mega_ampharos_lightning_lancer(),

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -159,6 +159,7 @@ pub enum AttackId {
     PA060ExeggcuteGrowth,
     PA072AlolanGrimerPoison,
     B1002MegaPinsirExCriticalScissors,
+    B1031RapidashExSprintingFlare,
     B1036MegaBlazikenExMegaBurning,
     B1052MegaGyaradosExMegaBlaster,
     B1085MegaAmpharosExLightningLancer,
@@ -471,18 +472,21 @@ lazy_static::lazy_static! {
 
         // B1
         m.insert(("B1 002", 0), AttackId::B1002MegaPinsirExCriticalScissors);
+        m.insert(("B1 031", 0), AttackId::B1031RapidashExSprintingFlare);
         m.insert(("B1 036", 0), AttackId::B1036MegaBlazikenExMegaBurning);
         m.insert(("B1 052", 0), AttackId::B1052MegaGyaradosExMegaBlaster);
         m.insert(("B1 085", 0), AttackId::B1085MegaAmpharosExLightningLancer);
         m.insert(("B1 102", 0), AttackId::B1102MegaAltariaExMegaHarmony);
         m.insert(("B1 151", 0), AttackId::B1151MegaAbsolExDarknessClaw);
         m.insert(("B1 251", 0), AttackId::B1002MegaPinsirExCriticalScissors);
+        m.insert(("B1 253", 0), AttackId::B1031RapidashExSprintingFlare);
         m.insert(("B1 254", 0), AttackId::B1036MegaBlazikenExMegaBurning);
         m.insert(("B1 255", 0), AttackId::B1052MegaGyaradosExMegaBlaster);
         m.insert(("B1 258", 0), AttackId::B1085MegaAmpharosExLightningLancer);
         m.insert(("B1 259", 0), AttackId::B1102MegaAltariaExMegaHarmony);
         m.insert(("B1 262", 0), AttackId::B1151MegaAbsolExDarknessClaw);
         m.insert(("B1 272", 0), AttackId::B1002MegaPinsirExCriticalScissors);
+        m.insert(("B1 274", 0), AttackId::B1031RapidashExSprintingFlare);
         m.insert(("B1 277", 0), AttackId::B1085MegaAmpharosExLightningLancer);
         m.insert(("B1 280", 0), AttackId::B1151MegaAbsolExDarknessClaw);
         m.insert(("B1 284", 0), AttackId::B1036MegaBlazikenExMegaBurning);


### PR DESCRIPTION
Adds implementation for Rapidash Ex's Sprinting Flare attack which deals 110 damage to the active Pokémon and 20 damage to 1 of the opponent's benched Pokémon.

Changes:
- Added B1031RapidashExSprintingFlare to AttackId enum in attack_ids.rs
- Added map entries for B1 031, B1 253, and B1 274 card IDs
- Implemented attack logic using active_then_choice_bench_attack helper