### PR TITLE
Implement Gengar ex Shadowy Spellbind ability

### DIFF
--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -6,6 +6,7 @@ pub enum AbilityId {
     A1020VictreebelFragranceTrap,
     A1089GreninjaWaterShuriken,
     A1098MagnetonVoltCharge,
+    A1123GengarExShadowySpellbind,
     A1177Weezing,
     A1007Butterfree,
     A1132Gardevoir,
@@ -38,8 +39,11 @@ lazy_static::lazy_static! {
         m.insert("A1 020", AbilityId::A1020VictreebelFragranceTrap);
         m.insert("A1 089", AbilityId::A1089GreninjaWaterShuriken);
         m.insert("A1 098", AbilityId::A1098MagnetonVoltCharge);
+        m.insert("A1 123", AbilityId::A1123GengarExShadowySpellbind);
         m.insert("A1 177", AbilityId::A1177Weezing);
         m.insert("A1 132", AbilityId::A1132Gardevoir);
+        m.insert("A1 261", AbilityId::A1123GengarExShadowySpellbind);
+        m.insert("A1 277", AbilityId::A1123GengarExShadowySpellbind);
         m.insert("A1a 006", AbilityId::A1a006SerperiorJungleTotem);
         m.insert("A1a 070", AbilityId::A1a006SerperiorJungleTotem);
         m.insert("A2a 010", AbilityId::A2a010LeafeonExForestBreath);
@@ -58,6 +62,7 @@ lazy_static::lazy_static! {
         m.insert("A3 066", AbilityId::A3066OricoricSafeguard);
         m.insert("A3 122", AbilityId::A3122SolgaleoExRisingRoad);
         m.insert("A3 141", AbilityId::A3141KomalaComatose);
+        m.insert("A3 234", AbilityId::A1123GengarExShadowySpellbind);
         m.insert("A3 165", AbilityId::A3066OricoricSafeguard);
         m.insert("A3 179", AbilityId::A3141KomalaComatose);
         m.insert("A3 189", AbilityId::A3122SolgaleoExRisingRoad);
@@ -97,6 +102,7 @@ lazy_static::lazy_static! {
         m.insert("A4b 135", AbilityId::A1098MagnetonVoltCharge);
         m.insert("A4b 136", AbilityId::A1098MagnetonVoltCharge);
         m.insert("A4b 146", AbilityId::A3066OricoricSafeguard);
+        m.insert("A4b 155", AbilityId::A1123GengarExShadowySpellbind);
         m.insert("A4b 147", AbilityId::A3066OricoricSafeguard);
         m.insert("A4b 149", AbilityId::A3a021ZeraoraThunderclapFlash);
         m.insert("A4b 150", AbilityId::A3a021ZeraoraThunderclapFlash);

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -30,6 +30,9 @@ pub(crate) fn forecast_ability(
         AbilityId::A1020VictreebelFragranceTrap => doutcome(victreebel_ability),
         AbilityId::A1089GreninjaWaterShuriken => doutcome(greninja_shuriken),
         AbilityId::A1098MagnetonVoltCharge => doutcome_from_mutation(charge_magneton(in_play_idx)),
+        AbilityId::A1123GengarExShadowySpellbind => {
+            panic!("Shadowy Spellbind is a passive ability")
+        }
         AbilityId::A1177Weezing => doutcome(weezing_ability),
         AbilityId::A1132Gardevoir => doutcome(gardevoir_ability),
         AbilityId::A1a006SerperiorJungleTotem => panic!("Serperior's ability is passive"),

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -236,14 +236,21 @@ pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
     }
 }
 
-// TODO: Implement Gengars ability that disallow playing support cards.
 pub(crate) fn can_play_support(state: &State) -> bool {
     let has_modifiers = state
         .get_current_turn_effects()
         .iter()
         .any(|x| matches!(x, TurnEffect::NoSupportCards));
 
-    !state.has_played_support && !has_modifiers
+    // Check if opponent has Gengar ex with Shadowy Spellbind in active spot
+    let opponent = (state.current_player + 1) % 2;
+    let blocked_by_gengar = state.in_play_pokemon[opponent][0]
+        .as_ref()
+        .and_then(|opponent_active| AbilityId::from_pokemon_id(&opponent_active.get_id()))
+        .map(|id| id == AbilityId::A1123GengarExShadowySpellbind)
+        .unwrap_or(false);
+
+    !state.has_played_support && !has_modifiers && !blocked_by_gengar
 }
 
 fn get_heavy_helmet_reduction(state: &State, opponent: usize) -> u32 {

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -33,6 +33,7 @@ fn can_use_ability(state: &State, (in_play_index, card): (usize, &PlayedCard)) -
         AbilityId::A1020VictreebelFragranceTrap => is_active && !card.ability_used,
         AbilityId::A1089GreninjaWaterShuriken => !card.ability_used,
         AbilityId::A1098MagnetonVoltCharge => !card.ability_used,
+        AbilityId::A1123GengarExShadowySpellbind => false,
         AbilityId::A1177Weezing => is_active && !card.ability_used,
         AbilityId::A1132Gardevoir => !card.ability_used,
         AbilityId::A1a006SerperiorJungleTotem => false,


### PR DESCRIPTION
Adds support for Gengar ex's Shadowy Spellbind passive ability which
prevents the opponent from using Supporter cards while Gengar ex is
in the Active Spot.

Changes:
- Added A1123GengarExShadowySpellbind to AbilityId enum
- Mapped all 5 Gengar ex variants (A1 123, A1 261, A1 277, A3 234, A4b 155)
- Updated can_play_support() to check for opponent's Gengar ex
- Added ability to move generation and apply action with passive handling
- Removed TODO comment for Gengar's ability implementation

All tests pass successfully.