### PR TITLE
Implement Alakazam and Exeggutor attacks

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -182,6 +182,7 @@ fn forecast_effect_attack(
         AttackId::A1093FrosmothPowderSnow => damage_status_attack(40, StatusCondition::Asleep),
         AttackId::A1095RaichuThunderbolt => thunderbolt_attack(140),
         AttackId::A2b022PikachuExThunderbolt => thunderbolt_attack(150),
+        AttackId::A2b031AlakazamPsychicSuppression => alakazam_psychic_suppression(state),
         AttackId::A1096PikachuExCircleCircuit => {
             bench_count_attack(acting_player, state, 0, 30, Some(EnergyType::Lightning))
         }
@@ -328,6 +329,9 @@ fn forecast_effect_attack(
         AttackId::A2b044FlamigoDoubleKick => {
             probabilistic_damage_attack(vec![0.25, 0.5, 0.25], vec![0, 50, 100])
         }
+        AttackId::A3002AlolanExeggutorTropicalHammer => {
+            probabilistic_damage_attack(vec![0.5, 0.5], vec![0, 150])
+        }
         AttackId::A3019SteeneeDoubleSpin => {
             probabilistic_damage_attack(vec![0.25, 0.5, 0.25], vec![0, 30, 60])
         }
@@ -385,6 +389,9 @@ fn forecast_effect_attack(
             probabilistic_damage_attack(vec![0.5, 0.5], vec![0, 100])
         }
         AttackId::A1a001ExeggcuteGrowthSpurt => self_charge_active_attack(0, EnergyType::Grass, 1),
+        AttackId::A1a002ExeggutorPsychic => {
+            damage_based_on_opponent_energy(acting_player, state, 80, 20)
+        }
         AttackId::A3a007PheromosaJumpBlues => active_then_choice_bench_attack(20, 20),
         AttackId::A3037TurtonatorFireSpin => self_energy_discard_attack(0, vec![EnergyType::Fire]),
         AttackId::A3085CosmogTeleport => teleport_attack(),
@@ -1081,6 +1088,19 @@ fn alolan_ninetales_blizzard(state: &State) -> (Probabilities, Mutations) {
         .collect();
     // Active Pokémon is always index 0
     targets.push((60, 0));
+    damage_effect_doutcome(targets, |_, _, _| {})
+}
+
+fn alakazam_psychic_suppression(state: &State) -> (Probabilities, Mutations) {
+    // Psychic Suppression: 80 to active, 20 to each opponent's benched Pokémon that has energy
+    let opponent = (state.current_player + 1) % 2;
+    let mut targets: Vec<(u32, usize)> = state
+        .enumerate_bench_pokemon(opponent)
+        .filter(|(_, pokemon)| !pokemon.attached_energy.is_empty())
+        .map(|(idx, _)| (20, idx))
+        .collect();
+    // Active Pokémon is always index 0
+    targets.push((80, 0));
     damage_effect_doutcome(targets, |_, _, _| {})
 }
 

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -73,6 +73,7 @@ pub enum AttackId {
     A1203KangaskhanDizzyPunch,
     A1213CinccinoDoTheWave,
     A1a001ExeggcuteGrowthSpurt,
+    A1a002ExeggutorPsychic,
     A1a003CelebiExPowerfulBloom,
     A1a010PonytaStomp,
     A1a011RapidashRisingLunge,
@@ -107,9 +108,11 @@ pub enum AttackId {
     A2b007MeowscaradaFightingClaws,
     A2b010CharizardExStoke,
     A2b022PikachuExThunderbolt,
+    A2b031AlakazamPsychicSuppression,
     A2b032MrMimeJuggling,
     A2b035GiratinaExChaoticImpact,
     A2b044FlamigoDoubleKick,
+    A3002AlolanExeggutorTropicalHammer,
     A3019SteeneeDoubleSpin,
     A3020TsareenaThreeKickCombo,
     A3037TurtonatorFireSpin,
@@ -280,6 +283,7 @@ lazy_static::lazy_static! {
 
         // A1a
         m.insert(("A1a 001", 0), AttackId::A1a001ExeggcuteGrowthSpurt);
+        m.insert(("A1a 002", 0), AttackId::A1a002ExeggutorPsychic);
         m.insert(("A1a 003", 0), AttackId::A1a003CelebiExPowerfulBloom);
         m.insert(("A1a 010", 0), AttackId::A1a010PonytaStomp);
         m.insert(("A1a 011", 0), AttackId::A1a011RapidashRisingLunge);
@@ -291,6 +295,7 @@ lazy_static::lazy_static! {
         m.insert(("A1a 045", 0), AttackId::A1a045GolemGuardPress);
         m.insert(("A1a 061", 0), AttackId::A1a061EeveeContinuousSteps);
         // Full Arts A1a
+        m.insert(("A1a 069", 0), AttackId::A1a002ExeggutorPsychic);
         m.insert(("A1a 073", 0), AttackId::A1a030DedenneThunderShock);
         m.insert(("A1a 075", 0), AttackId::A1a003CelebiExPowerfulBloom);
         m.insert(("A1a 085", 0), AttackId::A1a003CelebiExPowerfulBloom);
@@ -337,6 +342,7 @@ lazy_static::lazy_static! {
         m.insert(("A2b 007", 0), AttackId::A2b007MeowscaradaFightingClaws);
         m.insert(("A2b 010", 0), AttackId::A2b010CharizardExStoke);
         m.insert(("A2b 022", 0), AttackId::A2b022PikachuExThunderbolt);
+        m.insert(("A2b 031", 0), AttackId::A2b031AlakazamPsychicSuppression);
         m.insert(("A2b 032", 0), AttackId::A2b032MrMimeJuggling);
         m.insert(("A2b 035", 0), AttackId::A2b035GiratinaExChaoticImpact);
         m.insert(("A2b 044", 0), AttackId::A2b044FlamigoDoubleKick);
@@ -353,6 +359,7 @@ lazy_static::lazy_static! {
         m.insert(("A2b 108", 0), AttackId::A2b010CharizardExStoke);
 
         // A3
+        m.insert(("A3 002", 0), AttackId::A3002AlolanExeggutorTropicalHammer);
         m.insert(("A3 019", 0), AttackId::A3019SteeneeDoubleSpin);
         m.insert(("A3 020", 0), AttackId::A3020TsareenaThreeKickCombo);
         m.insert(("A3 037", 0), AttackId::A3037TurtonatorFireSpin);
@@ -365,6 +372,7 @@ lazy_static::lazy_static! {
         m.insert(("A3 112", 0), AttackId::A3112AbsolUnseenClaw);
         m.insert(("A3 116", 0), AttackId::A3116ToxapexSpikeCannon);
         m.insert(("A3 122", 0), AttackId::A3122SolgaleoExSolBreaker);
+        m.insert(("A3 156", 0), AttackId::A3002AlolanExeggutorTropicalHammer);
         m.insert(("A3 158", 0), AttackId::A3020TsareenaThreeKickCombo);
         m.insert(("A3 161", 0), AttackId::A3037TurtonatorFireSpin);
         m.insert(("A3 162", 0), AttackId::A3040AlolanVulpixCallForthCold);
@@ -372,6 +380,7 @@ lazy_static::lazy_static! {
         m.insert(("A3 189", 0), AttackId::A3122SolgaleoExSolBreaker);
         m.insert(("A3 207", 0), AttackId::A3122SolgaleoExSolBreaker);
         m.insert(("A3 212", 0), AttackId::A1003VenusaurMegaDrain);
+        m.insert(("A3 214", 0), AttackId::A1a002ExeggutorPsychic);
         m.insert(("A3 217", 0), AttackId::A1055BlastoiseHydroPump);
         m.insert(("A3 230", 1), AttackId::A1004VenusaurExGiantBloom);
         m.insert(("A3 231", 0), AttackId::A1023ExeggutorExTropicalSwing);
@@ -614,6 +623,7 @@ lazy_static::lazy_static! {
         m.insert(("P-A 052", 0), AttackId::A2b005SprigatitoCryForHelp);
         m.insert(("P-A 060", 0), AttackId::A1a001ExeggcuteGrowthSpurt);
         m.insert(("P-A 067", 0), AttackId::A3085CosmogTeleport);
+        m.insert(("P-A 069", 0), AttackId::A3002AlolanExeggutorTropicalHammer);
         m.insert(("P-A 070", 0), AttackId::A3041AlolanNinetalesBlizzard);
         m.insert(("P-A 072", 0), AttackId::PA072AlolanGrimerPoisonGas);
         m.insert(("P-A 079", 0), AttackId::PA079DuskManeNecrozmaBlackMetal);


### PR DESCRIPTION
- Add Alakazam's Psychic Suppression attack (A2b 031)
  - Deals 80 damage to active Pokémon
  - Deals 20 damage to each benched Pokémon that has energy attached

- Add Exeggutor's Psychic attack (A1a 002, A1a 069, A3 214)
  - Deals 80 base damage + 20 more for each energy on opponent's active

- Add Alolan Exeggutor's Tropical Hammer attack (A3 002, A3 156, P-A 069)
  - Flip a coin; if tails does nothing, if heads does 150 damage