### PR TITLE
Implement Skarmory Metal Arms attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -291,6 +291,9 @@ fn forecast_effect_attack(
         AttackId::A2098SneaselDoubleScratch => {
             probabilistic_damage_attack(vec![0.25, 0.5, 0.25], vec![0, 20, 40])
         }
+        AttackId::A2111SkarmoryMetalArms => {
+            extra_damage_if_tool_attached(acting_player, state, 20, 30)
+        }
         AttackId::A2117BronzongGuardPress => damage_and_card_effect_attack(
             index,
             state.current_player,
@@ -1150,6 +1153,21 @@ fn extra_damage_if_opponent_is_ex(
     let opponent = (acting_player + 1) % 2;
     let opponent_active = state.get_active(opponent);
     let damage = if opponent_active.card.is_ex() {
+        base_damage + extra_damage
+    } else {
+        base_damage
+    };
+    active_damage_doutcome(damage)
+}
+
+fn extra_damage_if_tool_attached(
+    acting_player: usize,
+    state: &State,
+    base_damage: u32,
+    extra_damage: u32,
+) -> (Probabilities, Mutations) {
+    let active = state.get_active(acting_player);
+    let damage = if active.has_tool_attached() {
         base_damage + extra_damage
     } else {
         base_damage

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -92,6 +92,7 @@ pub enum AttackId {
     A2073DrifloonExpand,
     A2084GliscorAcrobatics,
     A2098SneaselDoubleScratch,
+    A2111SkarmoryMetalArms,
     A2117BronzongGuardPress,
     A2118ProbopassTripleNose,
     A2119DialgaExMetallicTurbo,
@@ -305,6 +306,7 @@ lazy_static::lazy_static! {
         m.insert(("A2 073", 0), AttackId::A2073DrifloonExpand);
         m.insert(("A2 084", 0), AttackId::A2084GliscorAcrobatics);
         m.insert(("A2 098", 0), AttackId::A2098SneaselDoubleScratch);
+        m.insert(("A2 111", 0), AttackId::A2111SkarmoryMetalArms);
         m.insert(("A2 117", 0), AttackId::A2117BronzongGuardPress);
         m.insert(("A2 118", 0), AttackId::A2118ProbopassTripleNose);
         m.insert(("A2 119", 0), AttackId::A2119DialgaExMetallicTurbo);
@@ -609,6 +611,7 @@ lazy_static::lazy_static! {
         m.insert(("P-A 031", 0), AttackId::A1213CinccinoDoTheWave);
         m.insert(("P-A 032", 0), AttackId::A1033CharmanderEmber);
         m.insert(("P-A 034", 0), AttackId::A2035PiplupNap);
+        m.insert(("P-A 039", 0), AttackId::A2111SkarmoryMetalArms);
         m.insert(("P-A 048", 0), AttackId::A2050ManaphyOceanicGift);
         m.insert(("P-A 050", 1), AttackId::A1129MewtwoExPsydrive);
         m.insert(("P-A 052", 0), AttackId::A2b005SprigatitoCryForHelp);


### PR DESCRIPTION
Add implementation for Skarmory's Metal Arms attack which deals 20 base damage
plus 30 additional damage if the Pokémon has a tool attached. This applies to
both A2 111 Skarmory and P-A 039 Skarmory promo cards.

Changes:
- Added A2111SkarmoryMetalArms to AttackId enum
- Added mappings for both card variants to ATTACK_ID_MAP
- Implemented extra_damage_if_tool_attached helper function
- Added Metal Arms case to forecast_effect_attack