### PR TITLE
Implement Greninja EX Shifting Stream ability

### DIFF
--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -30,6 +30,7 @@ pub enum AbilityId {
     A4a020SuicuneExLegendaryPulse,
     A4a022MiloticHealingRipples,
     A4a025RaikouExLegendaryPulse,
+    B1073GreninjaExShiftingStream,
 }
 
 // Create a static HashMap for fast (pokemon, index) lookup
@@ -115,6 +116,9 @@ lazy_static::lazy_static! {
         m.insert("A4b 305", AbilityId::A3a062CelesteelaUltraThrusters);
         m.insert("A4b 370", AbilityId::A3b056EeveeExVeeveeVolve);
         m.insert("A4b 378", AbilityId::A2110DarkraiExNightmareAura);
+        m.insert("B1 073", AbilityId::B1073GreninjaExShiftingStream);
+        m.insert("B1 256", AbilityId::B1073GreninjaExShiftingStream);
+        m.insert("B1 275", AbilityId::B1073GreninjaExShiftingStream);
         m.insert("P-A 042", AbilityId::A2110DarkraiExNightmareAura);
         m.insert("P-A 110", AbilityId::A4a010EnteiExLegendaryPulse);
         m.insert("P-A 019", AbilityId::A1089GreninjaWaterShuriken);

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -69,6 +69,7 @@ pub(crate) fn forecast_ability(
         AbilityId::A4a025RaikouExLegendaryPulse => {
             panic!("Legendary Pulse is triggered at end of turn")
         }
+        AbilityId::B1073GreninjaExShiftingStream => doutcome(greninja_ex_shifting_stream),
     }
 }
 
@@ -132,6 +133,17 @@ fn celesteela_ultra_thrusters(_: &mut StdRng, state: &mut State, action: &Action
     if choices.is_empty() {
         return;
     }
+    state.move_generation_stack.push((acting_player, choices));
+}
+
+fn greninja_ex_shifting_stream(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Once during your turn, you may switch your Active [W] Pokémon with 1 of your Benched Pokémon.
+    debug!("Greninja ex's Shifting Stream: Switching active Water Pokemon with a benched Pokemon");
+    let acting_player = action.actor;
+    let choices = state
+        .enumerate_bench_pokemon(acting_player)
+        .map(|(in_play_idx, _)| SimpleAction::Activate { in_play_idx })
+        .collect::<Vec<_>>();
     state.move_generation_stack.push((acting_player, choices));
 }
 

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -61,6 +61,7 @@ fn can_use_ability(state: &State, (in_play_index, card): (usize, &PlayedCard)) -
         AbilityId::A4a020SuicuneExLegendaryPulse => false,
         AbilityId::A4a022MiloticHealingRipples => false,
         AbilityId::A4a025RaikouExLegendaryPulse => false,
+        AbilityId::B1073GreninjaExShiftingStream => can_use_greninja_shifting_stream(state, card),
     }
 }
 
@@ -75,4 +76,18 @@ fn can_use_celesteela_ultra_thrusters(state: &State, card: &PlayedCard) -> bool 
     state
         .enumerate_bench_pokemon(state.current_player)
         .any(|(_, pokemon)| is_ultra_beast(&pokemon.get_name()))
+}
+
+fn can_use_greninja_shifting_stream(state: &State, card: &PlayedCard) -> bool {
+    if card.ability_used {
+        return false;
+    }
+    let active = state.get_active(state.current_player);
+    if active.get_energy_type() != Some(EnergyType::Water) {
+        return false;
+    }
+    state
+        .enumerate_bench_pokemon(state.current_player)
+        .next()
+        .is_some()
 }


### PR DESCRIPTION
Add implementation for Greninja EX's "Shifting Stream" ability which allows
switching the Active Water Pokémon with a Benched Pokémon once per turn.

- Added B1073GreninjaExShiftingStream to ability_ids.rs with mappings for all three card variants (B1 073, B1 256, B1 275)
- Implemented move generation logic to validate ability usage conditions
- Implemented apply action logic to generate switch choices for benched Pokémon

All tests pass and clippy checks pass with no warnings.