### PR TITLE
Implement Rowlet's Skill Dive attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -344,6 +344,7 @@ fn forecast_effect_attack(
         AttackId::A3002AlolanExeggutorTropicalHammer => {
             probabilistic_damage_attack(vec![0.5, 0.5], vec![0, 150])
         }
+        AttackId::A3010RowletSkillDive => direct_damage(10, false),
         AttackId::A3019SteeneeDoubleSpin => {
             probabilistic_damage_attack(vec![0.25, 0.5, 0.25], vec![0, 30, 60])
         }

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -116,6 +116,7 @@ pub enum AttackId {
     A2b035GiratinaExChaoticImpact,
     A2b044FlamigoDoubleKick,
     A3002AlolanExeggutorTropicalHammer,
+    A3010RowletSkillDive,
     A3019SteeneeDoubleSpin,
     A3020TsareenaThreeKickCombo,
     A3037TurtonatorFireSpin,
@@ -371,6 +372,7 @@ lazy_static::lazy_static! {
 
         // A3
         m.insert(("A3 002", 0), AttackId::A3002AlolanExeggutorTropicalHammer);
+        m.insert(("A3 010", 0), AttackId::A3010RowletSkillDive);
         m.insert(("A3 019", 0), AttackId::A3019SteeneeDoubleSpin);
         m.insert(("A3 020", 0), AttackId::A3020TsareenaThreeKickCombo);
         m.insert(("A3 037", 0), AttackId::A3037TurtonatorFireSpin);
@@ -510,6 +512,8 @@ lazy_static::lazy_static! {
         m.insert(("A4b 013", 0), AttackId::A1023ExeggutorExTropicalSwing);
         m.insert(("A4b 023", 0), AttackId::A4021ShuckleExTripleSlap);
         m.insert(("A4b 024", 0), AttackId::A1a003CelebiExPowerfulBloom);
+        m.insert(("A4b 038", 0), AttackId::A3010RowletSkillDive);
+        m.insert(("A4b 039", 0), AttackId::A3010RowletSkillDive);
         m.insert(("A4b 044", 1), AttackId::A3a006BuzzwoleExBigBeat);
         m.insert(("A4b 045", 0), AttackId::A3a007PheromosaJumpBlues);
         m.insert(("A4b 046", 0), AttackId::A3a007PheromosaJumpBlues);
@@ -613,6 +617,7 @@ lazy_static::lazy_static! {
         m.insert(("B1 284", 0), AttackId::B1036MegaBlazikenExMegaBurning);
         m.insert(("B1 285", 0), AttackId::B1052MegaGyaradosExMegaBlaster);
         m.insert(("B1 286", 0), AttackId::B1102MegaAltariaExMegaHarmony);
+        m.insert(("B1 290", 0), AttackId::A3010RowletSkillDive);
         m.insert(("B1 292", 0), AttackId::A1046MoltresSkyAttack);
         m.insert(("B1 298", 0), AttackId::A1083ArticunoIceBeam);
         m.insert(("B1 299", 0), AttackId::A2050ManaphyOceanicGift);


### PR DESCRIPTION
Implement the "Skill Dive" attack for Rowlet cards (A3 010, A4b 038, A4b 039, B1 290).
This attack does 10 damage to 1 of the opponent's Pokémon (player can choose any opponent's Pokémon to target).

Changes:
- Add A3010RowletSkillDive to AttackId enum in attack_ids.rs
- Add attack ID mappings for all Rowlet cards with Skill Dive
- Implement attack logic using direct_damage(10, false) in apply_attack_action.rs

All tests pass. Cards now show as complete in card_status.