### PR TITLE
Implement Dartrix Skill Dive attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -368,6 +368,7 @@ fn forecast_effect_attack(
         AttackId::A3a003RowletFuryAttack => {
             probabilistic_damage_attack(vec![0.125, 0.375, 0.375, 0.125], vec![0, 10, 20, 30])
         }
+        AttackId::A3a004DartrixSkillDive => direct_damage(20, false),
         AttackId::A3a006BuzzwoleExBigBeat => {
             cannot_use_attack_next_turn(index, acting_player, AttackId::A3a006BuzzwoleExBigBeat)
         }

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -129,6 +129,7 @@ pub enum AttackId {
     A3116ToxapexSpikeCannon,
     A3122SolgaleoExSolBreaker,
     A3a003RowletFuryAttack,
+    A3a004DartrixSkillDive,
     A3a006BuzzwoleExBigBeat,
     A3a007PheromosaJumpBlues,
     A3a019TapuKokoExPlasmaHurricane,
@@ -402,6 +403,7 @@ lazy_static::lazy_static! {
 
         // A3a
         m.insert(("A3a 003", 0), AttackId::A3a003RowletFuryAttack);
+        m.insert(("A3a 004", 0), AttackId::A3a004DartrixSkillDive);
         m.insert(("A3a 006", 1), AttackId::A3a006BuzzwoleExBigBeat);
         m.insert(("A3a 007", 0), AttackId::A3a007PheromosaJumpBlues);
         m.insert(("A3a 019", 0), AttackId::A3a019TapuKokoExPlasmaHurricane);
@@ -599,6 +601,7 @@ lazy_static::lazy_static! {
         m.insert(("B1 232", 0), AttackId::B1050MagikarpWaterfallEvolution);
         m.insert(("B1 237", 0), AttackId::B1088LuxrayFlashImpact);
         m.insert(("B1 245", 0), AttackId::B1157HydreigonHyperRay);
+        m.insert(("B1 291", 0), AttackId::A3a004DartrixSkillDive);
         m.insert(("B1 251", 0), AttackId::B1002MegaPinsirExCriticalScissors);
         m.insert(("B1 253", 0), AttackId::B1031RapidashExSprintingFlare);
         m.insert(("B1 254", 0), AttackId::B1036MegaBlazikenExMegaBurning);


### PR DESCRIPTION
Add implementation for Dartrix's "Skill Dive" attack which does 20 damage to 1 of the opponent's Pokémon.

Changes:
- Add A3a004DartrixSkillDive to AttackId enum
- Add mappings for A3a 004 and B1 291 Dartrix cards
- Implement attack logic using direct_damage(20, false)