### PR TITLE
Implement Indeedee ex, Goodra, and Goomy cards

### DIFF
--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -31,7 +31,9 @@ pub enum AbilityId {
     A4a022MiloticHealingRipples,
     A4a025RaikouExLegendaryPulse,
     B1073GreninjaExShiftingStream,
+    B1121IndeedeeExWatchOver,
     B1157HydreigonRoarInUnison,
+    B1177GoomyStickyMembrane,
 }
 
 // Create a static HashMap for fast (pokemon, index) lookup
@@ -118,10 +120,15 @@ lazy_static::lazy_static! {
         m.insert("A4b 370", AbilityId::A3b056EeveeExVeeveeVolve);
         m.insert("A4b 378", AbilityId::A2110DarkraiExNightmareAura);
         m.insert("B1 073", AbilityId::B1073GreninjaExShiftingStream);
+        m.insert("B1 121", AbilityId::B1121IndeedeeExWatchOver);
         m.insert("B1 157", AbilityId::B1157HydreigonRoarInUnison);
+        m.insert("B1 177", AbilityId::B1177GoomyStickyMembrane);
         m.insert("B1 245", AbilityId::B1157HydreigonRoarInUnison);
+        m.insert("B1 247", AbilityId::B1177GoomyStickyMembrane);
         m.insert("B1 256", AbilityId::B1073GreninjaExShiftingStream);
+        m.insert("B1 260", AbilityId::B1121IndeedeeExWatchOver);
         m.insert("B1 275", AbilityId::B1073GreninjaExShiftingStream);
+        m.insert("B1 278", AbilityId::B1121IndeedeeExWatchOver);
         m.insert("P-A 042", AbilityId::A2110DarkraiExNightmareAura);
         m.insert("P-A 110", AbilityId::A4a010EnteiExLegendaryPulse);
         m.insert("P-A 019", AbilityId::A1089GreninjaWaterShuriken);

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -70,9 +70,11 @@ pub(crate) fn forecast_ability(
             panic!("Legendary Pulse is triggered at end of turn")
         }
         AbilityId::B1073GreninjaExShiftingStream => doutcome(greninja_ex_shifting_stream),
+        AbilityId::B1121IndeedeeExWatchOver => doutcome(indeedee_ex_watch_over),
         AbilityId::B1157HydreigonRoarInUnison => {
             doutcome_from_mutation(charge_hydreigon_and_damage_self(in_play_idx))
         }
+        AbilityId::B1177GoomyStickyMembrane => panic!("Sticky Membrane is a passive ability"),
     }
 }
 
@@ -282,4 +284,11 @@ fn combust(_: &mut StdRng, state: &mut State, action: &Action) {
         &[(20, action.actor, in_play_idx)],
         false,
     );
+}
+
+fn indeedee_ex_watch_over(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Once during your turn, you may heal 20 damage from your Active Pokémon.
+    debug!("Indeedee ex's Watch Over: Healing 20 damage from Active Pokemon");
+    let active = state.get_active_mut(action.actor);
+    active.heal(20);
 }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -533,10 +533,14 @@ fn forecast_effect_attack(
         AttackId::B1109ChinglingJinglyNoise => {
             damage_and_turn_effect_attack(0, 1, TurnEffect::NoItemCards)
         }
+        AttackId::B1121IndeedeeExPsychic => {
+            damage_based_on_opponent_energy(acting_player, state, 30, 30)
+        }
         AttackId::B1150AbsolOminousClaw => ominous_claw_attack(acting_player, state),
         AttackId::B1151MegaAbsolExDarknessClaw => darkness_claw_attack(acting_player, state),
         AttackId::B1161MareaniePoisonSting => damage_status_attack(0, StatusCondition::Poisoned),
         AttackId::B1157HydreigonHyperRay => thunderbolt_attack(130),
+        AttackId::B1179GoodraSpiralDrain => self_heal_attack(40, 0),
         AttackId::B1196SwabluSing => damage_status_attack(0, StatusCondition::Asleep),
         AttackId::PA056EkansPoisonSting => damage_status_attack(0, StatusCondition::Poisoned),
     }

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -198,6 +198,8 @@ pub enum AttackId {
     B1102MegaAltariaExMegaHarmony,
     B1106JirachiStarDrop,
     B1109ChinglingJinglyNoise,
+    B1121IndeedeeExPsychic,
+    B1179GoodraSpiralDrain,
     B1150AbsolOminousClaw,
     B1151MegaAbsolExDarknessClaw,
     B1157HydreigonHyperRay,
@@ -653,10 +655,12 @@ lazy_static::lazy_static! {
         m.insert(("B1 102", 0), AttackId::B1102MegaAltariaExMegaHarmony);
         m.insert(("B1 106", 0), AttackId::B1106JirachiStarDrop);
         m.insert(("B1 109", 0), AttackId::B1109ChinglingJinglyNoise);
+        m.insert(("B1 121", 0), AttackId::B1121IndeedeeExPsychic);
         m.insert(("B1 150", 0), AttackId::B1150AbsolOminousClaw);
         m.insert(("B1 151", 0), AttackId::B1151MegaAbsolExDarknessClaw);
         m.insert(("B1 157", 0), AttackId::B1157HydreigonHyperRay);
         m.insert(("B1 161", 0), AttackId::B1161MareaniePoisonSting);
+        m.insert(("B1 179", 0), AttackId::B1179GoodraSpiralDrain);
         m.insert(("B1 196", 0), AttackId::B1196SwabluSing);
         m.insert(("B1 232", 0), AttackId::B1050MagikarpWaterfallEvolution);
         m.insert(("B1 237", 0), AttackId::B1088LuxrayFlashImpact);
@@ -667,10 +671,12 @@ lazy_static::lazy_static! {
         m.insert(("B1 255", 0), AttackId::B1052MegaGyaradosExMegaBlaster);
         m.insert(("B1 258", 0), AttackId::B1085MegaAmpharosExLightningLancer);
         m.insert(("B1 259", 0), AttackId::B1102MegaAltariaExMegaHarmony);
+        m.insert(("B1 260", 0), AttackId::B1121IndeedeeExPsychic);
         m.insert(("B1 262", 0), AttackId::B1151MegaAbsolExDarknessClaw);
         m.insert(("B1 272", 0), AttackId::B1002MegaPinsirExCriticalScissors);
         m.insert(("B1 274", 0), AttackId::B1031RapidashExSprintingFlare);
         m.insert(("B1 277", 0), AttackId::B1085MegaAmpharosExLightningLancer);
+        m.insert(("B1 278", 0), AttackId::B1121IndeedeeExPsychic);
         m.insert(("B1 280", 0), AttackId::B1151MegaAbsolExDarknessClaw);
         m.insert(("B1 284", 0), AttackId::B1036MegaBlazikenExMegaBurning);
         m.insert(("B1 285", 0), AttackId::B1052MegaGyaradosExMegaBlaster);

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -413,6 +413,29 @@ pub(crate) fn modify_damage(
     )
 }
 
+// Get the attack cost, considering opponent's abilities that modify attack costs (like Goomy's Sticky Membrane)
+pub(crate) fn get_attack_cost(
+    base_cost: &[EnergyType],
+    state: &State,
+    attacking_player: usize,
+) -> Vec<EnergyType> {
+    use crate::ability_ids::AbilityId;
+    let mut modified_cost = base_cost.to_vec();
+
+    // Check if opponent has Goomy with Sticky Membrane in the active spot
+    let opponent = (attacking_player + 1) % 2;
+    if let Some(opponent_active) = &state.in_play_pokemon[opponent][0] {
+        if let Some(ability_id) = AbilityId::from_pokemon_id(&opponent_active.get_id()[..]) {
+            if ability_id == AbilityId::B1177GoomyStickyMembrane {
+                // Add 1 Colorless energy to the attack cost
+                modified_cost.push(EnergyType::Colorless);
+            }
+        }
+    }
+
+    modified_cost
+}
+
 // Check if attached satisfies cost (considering Colorless and Serperior's ability)
 pub(crate) fn contains_energy(
     pokemon: &PlayedCard,

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -10,6 +10,7 @@ pub(crate) use core::can_play_item;
 pub(crate) use core::can_play_support;
 pub(crate) use core::contains_energy;
 pub(crate) use core::energy_missing;
+pub(crate) use core::get_attack_cost;
 pub(crate) use core::get_stage;
 pub(crate) use core::is_ultra_beast;
 pub(crate) use core::modify_damage;

--- a/src/move_generation/attacks.rs
+++ b/src/move_generation/attacks.rs
@@ -1,5 +1,9 @@
 use crate::{
-    actions::SimpleAction, attack_ids::AttackId, effects::CardEffect, hooks::contains_energy, State,
+    actions::SimpleAction,
+    attack_ids::AttackId,
+    effects::CardEffect,
+    hooks::{contains_energy, get_attack_cost},
+    State,
 };
 
 pub(crate) fn generate_attack_actions(state: &State) -> Vec<SimpleAction> {
@@ -25,12 +29,8 @@ pub(crate) fn generate_attack_actions(state: &State) -> Vec<SimpleAction> {
 
         let pokemon_id = active_pokemon.get_id();
         for (i, attack) in active_pokemon.get_attacks().iter().enumerate() {
-            if contains_energy(
-                active_pokemon,
-                &attack.energy_required,
-                state,
-                current_player,
-            ) {
+            let modified_cost = get_attack_cost(&attack.energy_required, state, current_player);
+            if contains_energy(active_pokemon, &modified_cost, state, current_player) {
                 let attack_is_restricted = AttackId::from_pokemon_index(&pokemon_id[..], i)
                     .map(|attack_id| restricted_attacks.contains(&attack_id))
                     .unwrap_or(false);

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -62,7 +62,9 @@ fn can_use_ability(state: &State, (in_play_index, card): (usize, &PlayedCard)) -
         AbilityId::A4a022MiloticHealingRipples => false,
         AbilityId::A4a025RaikouExLegendaryPulse => false,
         AbilityId::B1073GreninjaExShiftingStream => can_use_greninja_shifting_stream(state, card),
+        AbilityId::B1121IndeedeeExWatchOver => is_active && !card.ability_used,
         AbilityId::B1157HydreigonRoarInUnison => !card.ability_used,
+        AbilityId::B1177GoomyStickyMembrane => false,
     }
 }
 


### PR DESCRIPTION
This commit implements the following Pokemon cards from the B1 set:

1. **Indeedee ex (B1 121, B1 260, B1 278)**:
   - Ability "Watch Over": Once during your turn, heal 20 damage from your Active Pokemon
   - Attack "Psychic": Does 30 + 30 more damage for each Energy attached to opponent's Active Pokemon

2. **Goodra (B1 179)**:
   - Attack "Spiral Drain": Does 100 damage and heals 40 damage from this Pokemon

3. **Goomy (B1 177, B1 247)**:
   - Ability "Sticky Membrane": As long as this Pokemon is in the Active Spot, attacks used by opponent's Active Pokemon cost 1 [C] more

Changes:
- Added ability IDs for Indeedee ex and Goomy to ability_ids.rs
- Implemented move generation and apply logic for Indeedee ex's "Watch Over" ability
- Added attack IDs for Indeedee ex and Goodra to attack_ids.rs
- Implemented Indeedee ex's "Psychic" attack using damage_based_on_opponent_energy
- Implemented Goodra's "Spiral Drain" attack using self_heal_attack
- Implemented Goomy's "Sticky Membrane" ability by adding get_attack_cost hook that modifies attack costs
- Updated move generation for attacks to use the new get_attack_cost function

All tests pass and code passes clippy checks.