### PR TITLE
Implement Snorlax and Snorlax ex cards

### DIFF
--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -25,6 +25,7 @@ pub enum AbilityId {
     A3b009FlareonExCombust,
     A3b034SylveonExHappyRibbon,
     A3b056EeveeExVeeveeVolve,
+    A3b057SnorlaxExFullMouthManner,
     A4083EspeonExPsychicHealing,
     A4a010EnteiExLegendaryPulse,
     A4a020SuicuneExLegendaryPulse,
@@ -80,11 +81,14 @@ lazy_static::lazy_static! {
         m.insert("A3b 009", AbilityId::A3b009FlareonExCombust);
         m.insert("A3b 034", AbilityId::A3b034SylveonExHappyRibbon);
         m.insert("A3b 056", AbilityId::A3b056EeveeExVeeveeVolve);
+        m.insert("A3b 057", AbilityId::A3b057SnorlaxExFullMouthManner);
         m.insert("A3b 079", AbilityId::A3b009FlareonExCombust);
         m.insert("A3b 081", AbilityId::A3b034SylveonExHappyRibbon);
         m.insert("A3b 083", AbilityId::A3b056EeveeExVeeveeVolve);
+        m.insert("A3b 084", AbilityId::A3b057SnorlaxExFullMouthManner);
         m.insert("A3b 087", AbilityId::A3b009FlareonExCombust);
         m.insert("A3b 089", AbilityId::A3b034SylveonExHappyRibbon);
+        m.insert("A3b 091", AbilityId::A3b057SnorlaxExFullMouthManner);
         m.insert("A3b 092", AbilityId::A3b056EeveeExVeeveeVolve);
         m.insert("A4 083", AbilityId::A4083EspeonExPsychicHealing);
         m.insert("A4 190", AbilityId::A4083EspeonExPsychicHealing);
@@ -113,6 +117,7 @@ lazy_static::lazy_static! {
         m.insert("A4b 160", AbilityId::A4083EspeonExPsychicHealing);
         m.insert("A4b 245", AbilityId::A2110DarkraiExNightmareAura);
         m.insert("A4b 287", AbilityId::A3b056EeveeExVeeveeVolve);
+        m.insert("A4b 288", AbilityId::A3b057SnorlaxExFullMouthManner);
         m.insert("A4b 304", AbilityId::A3a062CelesteelaUltraThrusters);
         m.insert("A4b 305", AbilityId::A3a062CelesteelaUltraThrusters);
         m.insert("A4b 370", AbilityId::A3b056EeveeExVeeveeVolve);

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -56,6 +56,9 @@ pub(crate) fn forecast_ability(
         AbilityId::A3b009FlareonExCombust => doutcome(combust),
         AbilityId::A3b034SylveonExHappyRibbon => panic!("Happy Ribbon cant be used on demand"),
         AbilityId::A3b056EeveeExVeeveeVolve => panic!("Veevee 'volve is a passive ability"),
+        AbilityId::A3b057SnorlaxExFullMouthManner => {
+            panic!("Full-Mouth Manner is triggered at end of turn")
+        }
         AbilityId::A4083EspeonExPsychicHealing => doutcome(espeon_ex_ability),
         AbilityId::A4a010EnteiExLegendaryPulse => {
             panic!("Legendary Pulse is triggered at end of turn")

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -329,6 +329,9 @@ fn forecast_effect_attack(
         AttackId::A2a001HeracrossSingleHornThrow => {
             probabilistic_damage_attack(vec![0.25, 0.75], vec![120, 50])
         }
+        AttackId::A2a063SnorlaxCollapse => {
+            damage_and_self_status_attack(100, StatusCondition::Asleep)
+        }
         AttackId::A2a057ProbopassExDefensiveUnit => damage_and_card_effect_attack(
             index,
             state.current_player,
@@ -453,6 +456,9 @@ fn forecast_effect_attack(
         }
         AttackId::A3b053DragoniteExGigaImpact => giga_impact_attack(),
         AttackId::A3b055EeveeCollect => draw_and_damage_outcome(0),
+        AttackId::A3b057SnorlaxExFlopDownPunch => {
+            damage_and_self_status_attack(130, StatusCondition::Asleep)
+        }
         AttackId::A3b058AipomDoubleHit => {
             probabilistic_damage_attack(vec![0.25, 0.5, 0.25], vec![0, 20, 40])
         }
@@ -1049,6 +1055,17 @@ fn self_damage_attack(damage: u32, self_damage: u32) -> (Probabilities, Mutation
 /// For attacks that deal damage and apply a status effect (e.g. Wigglituff Ex)
 fn damage_status_attack(damage: u32, status: StatusCondition) -> (Probabilities, Mutations) {
     active_damage_effect_doutcome(damage, build_status_effect(status))
+}
+
+/// For attacks that deal damage to opponent and apply a status effect to the attacker (e.g. Snorlax Collapse)
+fn damage_and_self_status_attack(
+    damage: u32,
+    status: StatusCondition,
+) -> (Probabilities, Mutations) {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let active = state.get_active_mut(action.actor);
+        active.apply_status_condition(status);
+    })
 }
 
 /// For cards like "Meowth Pay Day" that draw a card and deal damage.

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -106,6 +106,7 @@ pub enum AttackId {
     A2131AmbipomDoubleHit,
     A2141ChatotFuryAttack,
     A2a001HeracrossSingleHornThrow,
+    A2a063SnorlaxCollapse,
     A2a057ProbopassExDefensiveUnit,
     A2a071ArceusExUltimateForce,
     A2b001WeedleMultiply,
@@ -161,6 +162,7 @@ pub enum AttackId {
     A3b020VanilluxeDoubleSpin,
     A3b053DragoniteExGigaImpact,
     A3b055EeveeCollect,
+    A3b057SnorlaxExFlopDownPunch,
     A3b058AipomDoubleHit,
     A4001OddishPoisonPowder,
     A4021ShuckleExTripleSlap,
@@ -365,6 +367,7 @@ lazy_static::lazy_static! {
 
         // A2a
         m.insert(("A2a 001", 0), AttackId::A2a001HeracrossSingleHornThrow);
+        m.insert(("A2a 063", 0), AttackId::A2a063SnorlaxCollapse);
         m.insert(("A2a 057", 0), AttackId::A2a057ProbopassExDefensiveUnit);
         m.insert(("A2a 071", 0), AttackId::A2a071ArceusExUltimateForce);
         m.insert(("A2a 085", 0), AttackId::A2a057ProbopassExDefensiveUnit);
@@ -481,12 +484,15 @@ lazy_static::lazy_static! {
         m.insert(("A3b 020", 0), AttackId::A3b020VanilluxeDoubleSpin);
         m.insert(("A3b 053", 0), AttackId::A3b053DragoniteExGigaImpact);
         m.insert(("A3b 055", 0), AttackId::A3b055EeveeCollect);
+        m.insert(("A3b 057", 0), AttackId::A3b057SnorlaxExFlopDownPunch);
         m.insert(("A3b 058", 0), AttackId::A3b058AipomDoubleHit);
         m.insert(("A3b 078", 0), AttackId::A3b055EeveeCollect);
         m.insert(("A3b 079", 0), AttackId::A3b009FlareonExFireSpin);
         m.insert(("A3b 082", 0), AttackId::A3b053DragoniteExGigaImpact);
+        m.insert(("A3b 084", 0), AttackId::A3b057SnorlaxExFlopDownPunch);
         m.insert(("A3b 087", 0), AttackId::A3b009FlareonExFireSpin);
         m.insert(("A3b 090", 0), AttackId::A3b053DragoniteExGigaImpact);
+        m.insert(("A3b 091", 0), AttackId::A3b057SnorlaxExFlopDownPunch);
         m.insert(("A3b 094", 0), AttackId::A1079LaprasHydroPump);
         m.insert(("A3b 101", 0), AttackId::A1165ArbokCorner);
         m.insert(("A3b 103", 0), AttackId::A1047MoltresExInfernoDance);
@@ -620,6 +626,7 @@ lazy_static::lazy_static! {
         m.insert(("A4b 279", 0), AttackId::A1195WigglytuffExSleepySong);
         m.insert(("A4b 285", 0), AttackId::A3b055EeveeCollect);
         m.insert(("A4b 286", 0), AttackId::A3b055EeveeCollect);
+        m.insert(("A4b 288", 0), AttackId::A3b057SnorlaxExFlopDownPunch);
         m.insert(("A4b 289", 0), AttackId::A4149LugiaExElementalBlast);
         m.insert(("A4b 299", 0), AttackId::A2a071ArceusExUltimateForce);
         m.insert(("A4b 300", 0), AttackId::A3a060TypeNullQuickBlow);
@@ -703,6 +710,7 @@ lazy_static::lazy_static! {
         m.insert(("P-A 034", 0), AttackId::A2035PiplupNap);
         m.insert(("P-A 039", 0), AttackId::A2111SkarmoryMetalArms);
         m.insert(("P-A 048", 0), AttackId::A2050ManaphyOceanicGift);
+        m.insert(("P-A 049", 0), AttackId::A2a063SnorlaxCollapse);
         m.insert(("P-A 050", 1), AttackId::A1129MewtwoExPsydrive);
         m.insert(("P-A 052", 0), AttackId::A2b005SprigatitoCryForHelp);
         m.insert(("P-A 056", 0), AttackId::PA056EkansPoisonSting);

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -206,6 +206,12 @@ pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
                 vec![SimpleAction::DrawCard { amount: 1 }],
             ));
         }
+        if ability_id == AbilityId::A3b057SnorlaxExFullMouthManner {
+            // At the end of your turn, if this Pokémon is in the Active Spot, heal 20 damage from it.
+            debug!("Full-Mouth Manner: Healing 20 damage from active");
+            let active = state.get_active_mut(player_ending_turn);
+            active.heal(20);
+        }
     }
 
     // Check for Zeraora's Thunderclap Flash ability (on first turn only)

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -56,6 +56,7 @@ fn can_use_ability(state: &State, (in_play_index, card): (usize, &PlayedCard)) -
         }
         AbilityId::A3b034SylveonExHappyRibbon => false,
         AbilityId::A3b056EeveeExVeeveeVolve => false,
+        AbilityId::A3b057SnorlaxExFullMouthManner => false,
         AbilityId::A4083EspeonExPsychicHealing => is_active && !card.ability_used,
         AbilityId::A4a010EnteiExLegendaryPulse => false,
         AbilityId::A4a020SuicuneExLegendaryPulse => false,


### PR DESCRIPTION
Implements the following Snorlax cards and their attacks/abilities:
- A2a 063 Snorlax with Collapse attack
- P-A 049 Snorlax (promo) with Collapse attack
- A3b 057, A3b 084, A3b 091, A4b 288 Snorlax ex with Flop-Down Punch attack and Full-Mouth Manner ability

Attack implementations:
- Collapse: Deals 100 damage and makes the attacker asleep
- Flop-Down Punch: Deals 130 damage and makes the attacker asleep

Ability implementation:
- Full-Mouth Manner: At the end of your turn, if Snorlax ex is in the Active Spot, heal 20 damage from it

Changes include:
- Added attack IDs for Collapse and Flop-Down Punch
- Added ability ID for Full-Mouth Manner
- Implemented damage_and_self_status_attack helper for attacks that apply status to the attacker
- Added end-of-turn hook for Full-Mouth Manner ability healing