### PR TITLE
Implement Alolan Golem Super Zap Cannon attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -372,6 +372,9 @@ fn forecast_effect_attack(
             1,
             CardEffect::ReducedDamage { amount: 20 },
         ),
+        AttackId::A3061AlolanGolemSuperZapCannon => {
+            self_energy_discard_attack(0, vec![EnergyType::Lightning, EnergyType::Lightning])
+        }
         AttackId::A3070SableyeCorner => damage_and_card_effect_attack(
             index,
             (state.current_player + 1) % 2,

--- a/src/attack_ids.rs
+++ b/src/attack_ids.rs
@@ -130,6 +130,7 @@ pub enum AttackId {
     A3040AlolanVulpixCallForthCold,
     A3041AlolanNinetalesBlizzard,
     A3043CloysterGuardPress,
+    A3061AlolanGolemSuperZapCannon,
     A3070SableyeCorner,
     A3071SpoinkPsycharge,
     A3085CosmogTeleport,
@@ -409,6 +410,7 @@ lazy_static::lazy_static! {
         m.insert(("A3 040", 0), AttackId::A3040AlolanVulpixCallForthCold);
         m.insert(("A3 041", 0), AttackId::A3041AlolanNinetalesBlizzard);
         m.insert(("A3 043", 0), AttackId::A3043CloysterGuardPress);
+        m.insert(("A3 061", 0), AttackId::A3061AlolanGolemSuperZapCannon);
         m.insert(("A3 070", 0), AttackId::A3070SableyeCorner);
         m.insert(("A3 071", 0), AttackId::A3071SpoinkPsycharge);
         m.insert(("A3 085", 0), AttackId::A3085CosmogTeleport);


### PR DESCRIPTION
Add implementation for A3 061 Alolan Golem's Super Zap Cannon attack:
- Deals 150 damage
- Discards 2 Lightning Energy from the attacking Pokémon

Changes:
- Added A3061AlolanGolemSuperZapCannon to AttackId enum in attack_ids.rs
- Added attack mapping for A3 061 card in ATTACK_ID_MAP
- Implemented attack logic using self_energy_discard_attack helper

All tests pass and card status now shows Alolan Golem as complete.