### PR TITLE
Update card implementation progress badge to 71.0%

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # deckgym-core: Pokémon TCG Pocket Simulator
 
-![Card Implemented](https://img.shields.io/badge/Cards_Implemented-1392_%2F_2408_%2857.8%25%29-yellow)
+![Card Implemented](https://img.shields.io/badge/Cards_Implemented-1709_%2F_2408_%2871.0%25%29-yellow)
 
 **deckgym-core** is a high-performance Rust library designed for simulating Pokémon TCG Pocket games. It features a command-line interface (CLI) capable of running 10,000 simulations in approximately 3 seconds. This is the library that powers https://www.deckgym.com.
 


### PR DESCRIPTION
Updated the README badge to reflect current implementation status:
- Complete cards: 1709 / 2408 (71.0%)
- Previous: 1392 / 2408 (57.8%)

Generated using: cargo run --bin card_status