### PR TITLE
Implement Donphan card skill

### DIFF
--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -33,6 +33,7 @@ pub enum AbilityId {
     A4a020SuicuneExLegendaryPulse,
     A4a022MiloticHealingRipples,
     A4a025RaikouExLegendaryPulse,
+    A4a044DonphanExoskeleton,
     B1073GreninjaExShiftingStream,
     B1121IndeedeeExWatchOver,
     B1157HydreigonRoarInUnison,
@@ -110,6 +111,7 @@ lazy_static::lazy_static! {
         m.insert("A4a 020", AbilityId::A4a020SuicuneExLegendaryPulse);
         m.insert("A4a 022", AbilityId::A4a022MiloticHealingRipples);
         m.insert("A4a 025", AbilityId::A4a025RaikouExLegendaryPulse);
+        m.insert("A4a 044", AbilityId::A4a044DonphanExoskeleton);
         m.insert("A4a 065", AbilityId::A1061PoliwrathCounterattack);
         m.insert("A4a 072", AbilityId::A4a022MiloticHealingRipples);
         m.insert("A4a 079", AbilityId::A4a010EnteiExLegendaryPulse);

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -73,6 +73,7 @@ pub(crate) fn forecast_ability(
         AbilityId::A4a025RaikouExLegendaryPulse => {
             panic!("Legendary Pulse is triggered at end of turn")
         }
+        AbilityId::A4a044DonphanExoskeleton => panic!("Exoskeleton is a passive ability"),
         AbilityId::B1073GreninjaExShiftingStream => doutcome(greninja_ex_shifting_stream),
         AbilityId::B1121IndeedeeExWatchOver => doutcome(indeedee_ex_watch_over),
         AbilityId::B1157HydreigonRoarInUnison => {
@@ -242,6 +243,7 @@ fn charge_hydreigon_and_damage_self(in_play_idx: usize) -> Mutation {
             (action.actor, in_play_idx),
             &[(30, action.actor, in_play_idx)],
             false,
+            None,
         );
     })
 }
@@ -289,6 +291,7 @@ fn combust(_: &mut StdRng, state: &mut State, action: &Action) {
         (action.actor, in_play_idx),
         &[(20, action.actor, in_play_idx)],
         false,
+        None,
     );
 }
 

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -133,7 +133,7 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
             attacking_ref,
             targets,
             is_from_active_attack,
-        } => handle_damage(state, *attacking_ref, targets, *is_from_active_attack),
+        } => handle_damage(state, *attacking_ref, targets, *is_from_active_attack, None),
         // Trainer-Specific Actions
         SimpleAction::Heal {
             in_play_idx,

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -144,6 +144,7 @@ fn apply_pokemon_checkup(
             attacking_ref,
             &[(10, player, in_play_idx)],
             false,
+            None,
         );
     }
 
@@ -166,6 +167,7 @@ fn apply_pokemon_checkup(
             attacking_ref,
             &[(20, *player, *in_play_idx)],
             false,
+            None,
         );
     }
 
@@ -193,6 +195,7 @@ pub(crate) fn handle_damage(
     attacking_ref: (usize, usize), // (attacking_player, attacking_pokemon_idx)
     targets: &[(u32, usize, usize)], // damage, target_player, in_play_idx
     is_from_active_attack: bool,
+    attack_name: Option<&str>,
 ) {
     let attacking_player = attacking_ref.0;
     let mut knockouts: Vec<(usize, usize)> = vec![];
@@ -201,8 +204,13 @@ pub(crate) fn handle_damage(
     let modified_targets = targets
         .iter()
         .map(|target_ref| {
-            let modified_damage =
-                modify_damage(state, attacking_ref, *target_ref, is_from_active_attack);
+            let modified_damage = modify_damage(
+                state,
+                attacking_ref,
+                *target_ref,
+                is_from_active_attack,
+                attack_name,
+            );
             (modified_damage, target_ref.1, target_ref.2)
         })
         .collect::<Vec<(u32, usize, usize)>>();

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -1321,7 +1321,7 @@ fn mega_ampharos_lightning_lancer() -> (Probabilities, Mutations) {
             .collect();
 
         let attacking_ref = (action.actor, 0);
-        handle_damage(state, attacking_ref, &targets, true);
+        handle_damage(state, attacking_ref, &targets, true, None);
     })
 }
 

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -148,12 +148,72 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             duration: 2,
         },
     );
-    // map.insert("During your next turn, this Pokémon's Gear Spinner attack does +70 damage.", todo_implementation);
-    // map.insert("During your next turn, this Pokémon's Insatiable Striking attack does +40 damage.", todo_implementation);
-    // map.insert("During your next turn, this Pokémon's Overacceleration attack does +20 damage.", todo_implementation);
-    // map.insert("During your next turn, this Pokémon's Overdrive Smash attack does +30 damage.", todo_implementation);
-    // map.insert("During your next turn, this Pokémon's Overdrive Smash attack does +60 damage.", todo_implementation);
-    // map.insert("During your next turn, this Pokémon's Rolling Spin attack does +60 damage.", todo_implementation);
+    map.insert(
+        "During your next turn, this Pokémon's Gear Spinner attack does +70 damage.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::IncreasedDamageForAttack {
+                attack_name: "Gear Spinner".to_string(),
+                amount: 70,
+            },
+            duration: 2,
+        },
+    );
+    map.insert(
+        "During your next turn, this Pokémon's Insatiable Striking attack does +40 damage.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::IncreasedDamageForAttack {
+                attack_name: "Insatiable Striking".to_string(),
+                amount: 40,
+            },
+            duration: 2,
+        },
+    );
+    map.insert(
+        "During your next turn, this Pokémon's Overacceleration attack does +20 damage.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::IncreasedDamageForAttack {
+                attack_name: "Overacceleration".to_string(),
+                amount: 20,
+            },
+            duration: 2,
+        },
+    );
+    map.insert(
+        "During your next turn, this Pokémon's Overdrive Smash attack does +30 damage.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::IncreasedDamageForAttack {
+                attack_name: "Overdrive Smash".to_string(),
+                amount: 30,
+            },
+            duration: 2,
+        },
+    );
+    map.insert(
+        "During your next turn, this Pokémon's Overdrive Smash attack does +60 damage.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::IncreasedDamageForAttack {
+                attack_name: "Overdrive Smash".to_string(),
+                amount: 60,
+            },
+            duration: 2,
+        },
+    );
+    map.insert(
+        "During your next turn, this Pokémon's Rolling Spin attack does +60 damage.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::IncreasedDamageForAttack {
+                attack_name: "Rolling Spin".to_string(),
+                amount: 60,
+            },
+            duration: 2,
+        },
+    );
     // map.insert("During your opponent's next turn, attacks used by the Defending Pokémon cost 1 [C] more, and its Retreat Cost is 1 [C] more.", todo_implementation);
     // map.insert("During your opponent's next turn, attacks used by the Defending Pokémon cost 1 [C] more.", todo_implementation);
     // map.insert("During your opponent's next turn, attacks used by the Defending Pokémon do -20 damage.", todo_implementation);

--- a/src/actions/mutations.rs
+++ b/src/actions/mutations.rs
@@ -4,7 +4,7 @@ use crate::{models::StatusCondition, State};
 
 use super::{
     apply_action_helpers::{handle_damage, FnMutation, Mutation, Mutations, Probabilities},
-    Action,
+    Action, SimpleAction,
 };
 
 // These functions should share the common code of
@@ -86,7 +86,30 @@ where
                 .iter()
                 .map(|(damage, in_play_idx)| (*damage, opponent, *in_play_idx))
                 .collect();
-            handle_damage(state, (action.actor, 0), &targets, true);
+
+            // Extract attack name if this is an attack action
+            let attack_name: Option<String> =
+                if let SimpleAction::Attack(attack_index) = &action.action {
+                    state.in_play_pokemon[action.actor][0]
+                        .as_ref()
+                        .and_then(|pokemon| {
+                            pokemon
+                                .card
+                                .get_attacks()
+                                .get(*attack_index)
+                                .map(|attack| attack.title.clone())
+                        })
+                } else {
+                    None
+                };
+
+            handle_damage(
+                state,
+                (action.actor, 0),
+                &targets,
+                true,
+                attack_name.as_deref(),
+            );
         }
     })
 }

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -7,6 +7,7 @@ pub enum CardEffect {
     ReducedDamage { amount: u32 },
     CannotAttack,
     CannotUseAttack(String),
+    IncreasedDamageForAttack { attack_name: String, amount: u32 },
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -370,12 +370,124 @@ fn get_fighting_coach_boost(
     lucario_count * 20
 }
 
+fn get_exoskeleton_reduction(
+    receiving_pokemon: &crate::models::PlayedCard,
+    is_from_active_attack: bool,
+) -> u32 {
+    if let Some(ability_id) = AbilityId::from_pokemon_id(&receiving_pokemon.card.get_id()[..]) {
+        if ability_id == AbilityId::A4a044DonphanExoskeleton && is_from_active_attack {
+            return 20;
+        }
+    }
+    0
+}
+
+fn get_increased_turn_effect_modifiers(
+    state: &State,
+    is_active_to_active: bool,
+    target_is_ex: bool,
+    attacker_is_eevee_evolution: bool,
+) -> u32 {
+    if !is_active_to_active {
+        return 0;
+    }
+    state
+        .get_current_turn_effects()
+        .iter()
+        .map(|effect| match effect {
+            TurnEffect::IncreasedDamage { amount } => *amount,
+            TurnEffect::IncreasedDamageAgainstEx { amount } if target_is_ex => *amount,
+            TurnEffect::IncreasedDamageForEeveeEvolutions { amount }
+                if attacker_is_eevee_evolution =>
+            {
+                *amount
+            }
+            _ => 0,
+        })
+        .sum::<u32>()
+}
+
+fn get_increased_attack_specific_modifiers(
+    attacking_pokemon: &crate::models::PlayedCard,
+    is_active_to_active: bool,
+    attack_name: Option<&str>,
+) -> u32 {
+    if !is_active_to_active {
+        return 0;
+    }
+    attacking_pokemon
+        .get_active_effects()
+        .iter()
+        .filter_map(|effect| match effect {
+            CardEffect::IncreasedDamageForAttack {
+                attack_name: effect_attack_name,
+                amount,
+            } => {
+                if let Some(current_attack_name) = attack_name {
+                    if current_attack_name == effect_attack_name {
+                        Some(*amount)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+        .sum::<u32>()
+}
+
+fn get_reduced_card_effect_modifiers(
+    state: &State,
+    is_active_to_active: bool,
+    target_player: usize,
+) -> u32 {
+    if !is_active_to_active {
+        return 0;
+    }
+    state
+        .get_active(target_player)
+        .get_active_effects()
+        .iter()
+        .filter(|effect| matches!(effect, CardEffect::ReducedDamage { .. }))
+        .map(|effect| match effect {
+            CardEffect::ReducedDamage { amount } => *amount,
+            _ => 0,
+        })
+        .sum::<u32>()
+}
+
+fn get_weakness_modifier(
+    state: &State,
+    is_active_to_active: bool,
+    target_player: usize,
+    attacking_pokemon: &crate::models::PlayedCard,
+) -> u32 {
+    if !is_active_to_active {
+        return 0;
+    }
+    let receiving = state.get_active(target_player);
+    if let Card::Pokemon(pokemon_card) = &receiving.card {
+        if pokemon_card.weakness == attacking_pokemon.card.get_type() {
+            debug!(
+                "Weakness! {:?} is weak to {:?}",
+                pokemon_card,
+                attacking_pokemon.card.get_type()
+            );
+            return 20;
+        }
+    }
+    0
+}
+
 // TODO: Confirm is_from_attack and goes to enemy active
 pub(crate) fn modify_damage(
     state: &State,
     attacking_ref: (usize, usize),
     target_ref: (u32, usize, usize),
     is_from_active_attack: bool,
+    attack_name: Option<&str>,
 ) -> u32 {
     // If attack is 0, not even Giovanni takes it to 10.
     let (attacking_player, attacking_idx) = attacking_ref;
@@ -403,85 +515,60 @@ pub(crate) fn modify_damage(
         }
     }
 
-    // Intimidating Fang ability damage reduction
-    let intimidating_fang_reduction =
-        get_intimidating_fang_reduction(state, attacking_ref, target_ref, is_from_active_attack);
-    // Heavy Helmet damage reduction
-    let heavy_helmet_reduction = get_heavy_helmet_reduction(state, (target_player, target_idx));
-    // Fighting Coach ability damage boost
-    let fighting_coach_boost =
-        get_fighting_coach_boost(state, attacking_ref, target_ref, is_from_active_attack);
-
-    // Modifiers by effect (like Giovanni, Red, Eevee Bag), most apply just to active-to-active attacks
+    // Calculate all modifiers
     let is_active_to_active = target_idx == 0 && attacking_idx == 0 && is_from_active_attack;
     let target_is_ex = receiving_pokemon.card.is_ex();
     let attacker_is_eevee_evolution = attacking_pokemon.evolved_from("Eevee");
-    let increased_turn_effect_modifiers = if !is_active_to_active {
-        0
-    } else {
-        state
-            .get_current_turn_effects()
-            .iter()
-            .map(|effect| match effect {
-                TurnEffect::IncreasedDamage { amount } => *amount,
-                TurnEffect::IncreasedDamageAgainstEx { amount } if target_is_ex => *amount,
-                TurnEffect::IncreasedDamageForEeveeEvolutions { amount }
-                    if attacker_is_eevee_evolution =>
-                {
-                    *amount
-                }
-                _ => 0,
-            })
-            .sum::<u32>()
-    };
 
-    // Modifiers by receiving card effects
-    let reduced_card_effect_modifiers = if !is_active_to_active {
-        0
-    } else {
-        state
-            .get_active(target_player)
-            .get_active_effects()
-            .iter()
-            .filter(|effect| matches!(effect, CardEffect::ReducedDamage { .. }))
-            .map(|effect| match effect {
-                CardEffect::ReducedDamage { amount } => *amount,
-                _ => 0,
-            })
-            .sum::<u32>()
-    };
+    let intimidating_fang_reduction =
+        get_intimidating_fang_reduction(state, attacking_ref, target_ref, is_from_active_attack);
+    let heavy_helmet_reduction = get_heavy_helmet_reduction(state, (target_player, target_idx));
+    let exoskeleton_reduction = get_exoskeleton_reduction(receiving_pokemon, is_from_active_attack);
+    let fighting_coach_boost =
+        get_fighting_coach_boost(state, attacking_ref, target_ref, is_from_active_attack);
+    let increased_turn_effect_modifiers = get_increased_turn_effect_modifiers(
+        state,
+        is_active_to_active,
+        target_is_ex,
+        attacker_is_eevee_evolution,
+    );
+    let increased_attack_specific_modifiers = get_increased_attack_specific_modifiers(
+        attacking_pokemon,
+        is_active_to_active,
+        attack_name,
+    );
+    let reduced_card_effect_modifiers =
+        get_reduced_card_effect_modifiers(state, is_active_to_active, target_player);
+    let weakness_modifier =
+        get_weakness_modifier(state, is_active_to_active, target_player, attacking_pokemon);
 
-    // Weakness Modifier
-    let weakness_modifier = if !is_active_to_active {
-        0
-    } else {
-        let receiving = state.get_active(target_player);
-        if let Card::Pokemon(pokemon_card) = &receiving.card {
-            if pokemon_card.weakness == attacking_pokemon.card.get_type() {
-                debug!(
-                    "Weakness! {:?} is weak to {:?}",
-                    pokemon_card,
-                    attacking_pokemon.card.get_type()
-                );
-                return 20;
-            }
-        }
-        0
-    };
+    // Early return if weakness applies (overrides all other calculations)
+    if weakness_modifier > 0 {
+        return weakness_modifier;
+    }
 
     debug!(
-        "Attack: {:?}, Weakness: {}, IncreasedDamage: {}, ReducedDamage: {}, HeavyHelmet: {}, IntimidatingFang: {}, FightingCoach: {}",
+        "Attack: {:?}, Weakness: {}, IncreasedDamage: {}, IncreasedAttackSpecific: {}, ReducedDamage: {}, HeavyHelmet: {}, IntimidatingFang: {}, Exoskeleton: {}, FightingCoach: {}",
         base_damage,
         weakness_modifier,
         increased_turn_effect_modifiers,
+        increased_attack_specific_modifiers,
         reduced_card_effect_modifiers,
         heavy_helmet_reduction,
         intimidating_fang_reduction,
+        exoskeleton_reduction,
         fighting_coach_boost
     );
-    (base_damage + weakness_modifier + increased_turn_effect_modifiers + fighting_coach_boost)
+    (base_damage
+        + weakness_modifier
+        + increased_turn_effect_modifiers
+        + increased_attack_specific_modifiers
+        + fighting_coach_boost)
         .saturating_sub(
-            reduced_card_effect_modifiers + heavy_helmet_reduction + intimidating_fang_reduction,
+            reduced_card_effect_modifiers
+                + heavy_helmet_reduction
+                + intimidating_fang_reduction
+                + exoskeleton_reduction,
         )
 }
 
@@ -709,13 +796,14 @@ mod tests {
 
         // Get base damage without Giovanni effect
         let attack = attacker.get_attacks()[0].clone();
-        let base_damage = modify_damage(&state, (0, 0), (attack.fixed_damage, 1, 0), true);
+        let base_damage = modify_damage(&state, (0, 0), (attack.fixed_damage, 1, 0), true, None);
 
         // Add Giovanni effect
         state.add_turn_effect(TurnEffect::IncreasedDamage { amount: 10 }, 0);
 
         // Get damage with Giovanni effect
-        let damage_with_giovanni = modify_damage(&state, (0, 0), (attack.fixed_damage, 1, 0), true);
+        let damage_with_giovanni =
+            modify_damage(&state, (0, 0), (attack.fixed_damage, 1, 0), true, None);
 
         // Verify Giovanni adds exactly 10 damage
         assert_eq!(
@@ -734,9 +822,10 @@ mod tests {
         non_ex_state.in_play_pokemon[0][0] = Some(to_playable_card(&attacker_card, false));
         let non_ex_defender = get_card_by_enum(CardId::A1033Charmander);
         non_ex_state.in_play_pokemon[1][0] = Some(to_playable_card(&non_ex_defender, false));
-        let base_damage_non_ex = modify_damage(&non_ex_state, (0, 0), (40, 1, 0), true);
+        let base_damage_non_ex = modify_damage(&non_ex_state, (0, 0), (40, 1, 0), true, None);
         non_ex_state.add_turn_effect(TurnEffect::IncreasedDamageAgainstEx { amount: 20 }, 0);
-        let damage_with_red_vs_non_ex = modify_damage(&non_ex_state, (0, 0), (40, 1, 0), true);
+        let damage_with_red_vs_non_ex =
+            modify_damage(&non_ex_state, (0, 0), (40, 1, 0), true, None);
         assert_eq!(
             damage_with_red_vs_non_ex, base_damage_non_ex,
             "Red should not increase damage against non-EX Pokémon"
@@ -747,9 +836,9 @@ mod tests {
         ex_state.in_play_pokemon[0][0] = Some(to_playable_card(&attacker_card, false));
         let ex_defender = get_card_by_enum(CardId::A3122SolgaleoEx);
         ex_state.in_play_pokemon[1][0] = Some(to_playable_card(&ex_defender, false));
-        let base_damage_ex = modify_damage(&ex_state, (0, 0), (40, 1, 0), true);
+        let base_damage_ex = modify_damage(&ex_state, (0, 0), (40, 1, 0), true, None);
         ex_state.add_turn_effect(TurnEffect::IncreasedDamageAgainstEx { amount: 20 }, 0);
-        let damage_with_red_vs_ex = modify_damage(&ex_state, (0, 0), (40, 1, 0), true);
+        let damage_with_red_vs_ex = modify_damage(&ex_state, (0, 0), (40, 1, 0), true, None);
         assert_eq!(
             damage_with_red_vs_ex,
             base_damage_ex + 20,
@@ -773,7 +862,7 @@ mod tests {
             .add_effect(crate::effects::CardEffect::ReducedDamage { amount: 50 }, 1);
 
         // Act
-        let damage_with_stiffen = modify_damage(&state, (0, 0), (120, 1, 0), true);
+        let damage_with_stiffen = modify_damage(&state, (0, 0), (120, 1, 0), true, None);
 
         // Assert
         assert_eq!(

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -63,6 +63,7 @@ fn can_use_ability(state: &State, (in_play_index, card): (usize, &PlayedCard)) -
         AbilityId::A4a020SuicuneExLegendaryPulse => false,
         AbilityId::A4a022MiloticHealingRipples => false,
         AbilityId::A4a025RaikouExLegendaryPulse => false,
+        AbilityId::A4a044DonphanExoskeleton => false, // Passive ability, triggers via hooks
         AbilityId::B1073GreninjaExShiftingStream => can_use_greninja_shifting_stream(state, card),
         AbilityId::B1121IndeedeeExWatchOver => is_active && !card.ability_used,
         AbilityId::B1157HydreigonRoarInUnison => !card.ability_used,


### PR DESCRIPTION
This commit implements both Donphan variants:

1. A2a 038 Donphan - Rolling Spin attack
   - Attack does 60 base damage
   - Effect: During your next turn, this Pokémon's Rolling Spin attack does +60 damage
   - Added new CardEffect::IncreasedDamageForAttack variant to handle attack-specific damage boosts
   - Modified damage calculation to extract and apply attack names
   - Also implemented similar attacks for Gear Spinner, Insatiable Striking, Overacceleration, and Overdrive Smash

2. A4a 044 Donphan - Exoskeleton ability
   - Passive ability that reduces incoming damage by 20
   - Implemented in damage calculation hooks

Key changes:
- Added CardEffect::IncreasedDamageForAttack to track per-attack damage bonuses
- Enhanced modify_damage() to accept and use attack names for damage calculation
- Enhanced handle_damage() to accept and pass attack names
- Updated damage_effect_mutation() to extract attack names from game state
- Added A4a044DonphanExoskeleton to ability system with passive damage reduction
- Updated all existing handle_damage/modify_damage call sites to include attack_name parameter