### PR TITLE
Refactor ExpectiMiniMaxPlayer to support pluggable value functions

### DIFF
--- a/examples/value_function_ab_test.rs
+++ b/examples/value_function_ab_test.rs
@@ -1,50 +1,11 @@
 use clap::Parser;
 use colored::Colorize;
 use deckgym::{
-    players::{value_functions, ExpectiMiniMaxPlayer, Player, ValueFunction},
-    simulate::initialize_logger,
-    simulation_event_handler::{SimulationEventHandler, StatsCollector},
-    state::GameOutcome,
-    Deck, Simulation, State,
+    players::{value_functions, ExpectiMiniMaxPlayer, Player},
+    simulate::{initialize_logger, print_stats},
+    simulation_event_handler::StatsCollector,
+    Deck, Simulation,
 };
-use num_format::{Locale, ToFormattedString};
-use uuid::Uuid;
-
-/// Custom event handler to track points scored by each player
-#[derive(Default)]
-struct PointsCollector {
-    total_points: [u32; 2],
-    num_games: u32,
-}
-
-impl SimulationEventHandler for PointsCollector {
-    fn on_game_start(&mut self, _game_id: Uuid) {}
-
-    fn on_game_end(&mut self, _game_id: Uuid, state: State, _outcome: Option<GameOutcome>) {
-        self.total_points[0] += state.points[0] as u32;
-        self.total_points[1] += state.points[1] as u32;
-        self.num_games += 1;
-    }
-
-    fn merge(&mut self, other: &dyn SimulationEventHandler) {
-        if let Some(other_points) = (other as &dyn std::any::Any).downcast_ref::<PointsCollector>()
-        {
-            self.total_points[0] += other_points.total_points[0];
-            self.total_points[1] += other_points.total_points[1];
-            self.num_games += other_points.num_games;
-        }
-    }
-}
-
-impl PointsCollector {
-    fn avg_points(&self, player: usize) -> f64 {
-        if self.num_games == 0 {
-            0.0
-        } else {
-            self.total_points[player] as f64 / self.num_games as f64
-        }
-    }
-}
 
 /// A/B testing tool for comparing different value functions in ExpectiMiniMaxPlayer
 ///
@@ -70,14 +31,6 @@ struct Args {
     #[arg(short, long, default_value_t = 2)]
     depth: usize,
 
-    /// Baseline value function name (defaults to "baseline")
-    #[arg(short, long, default_value = "baseline")]
-    baseline: String,
-
-    /// Test value function name (defaults to all variants)
-    #[arg(short, long)]
-    test: Option<String>,
-
     /// Random seed for reproducibility
     #[arg(short, long)]
     seed: Option<u64>,
@@ -91,28 +44,8 @@ struct Args {
     verbosity: u8,
 }
 
-fn get_value_function(name: &str) -> Result<ValueFunction, String> {
-    match name {
-        "baseline" => Ok(value_functions::baseline_value_function),
-        "hand" => Ok(value_functions::hand_value_function),
-        "bench_depth" => Ok(value_functions::bench_depth_value_function),
-        _ => Err(format!("Unknown value function: {}", name)),
-    }
-}
-
-fn list_available_functions() {
-    println!("Available value functions:");
-    println!("  baseline    - Original value function (active_factor=2.0, hand_weight=1.0)");
-    println!("  hand        - Values hand cards more (hand_weight=2.0) [+4.8% win rate]");
-    println!("  bench_depth - Considers bench depth as a feature [+5.2% win rate - BEST]");
-}
-
 struct ComparisonConfig<'a> {
     deck_path: &'a str,
-    baseline_fn: ValueFunction,
-    test_fn: ValueFunction,
-    baseline_name: &'a str,
-    test_name: &'a str,
     depth: usize,
     num_games: u32,
     seed: Option<u64>,
@@ -124,8 +57,8 @@ fn run_comparison(config: ComparisonConfig) -> Result<(), Box<dyn std::error::Er
     println!(
         "{} {} vs {}",
         "Testing:".blue().bold(),
-        config.baseline_name.green(),
-        config.test_name.yellow()
+        "baseline".green(),
+        "variant".yellow()
     );
     println!("{}", "=".repeat(70).blue().bold());
 
@@ -133,8 +66,8 @@ fn run_comparison(config: ComparisonConfig) -> Result<(), Box<dyn std::error::Er
     let deck = Deck::from_file(config.deck_path)?;
 
     // Create player factory that builds ExpectiMiniMaxPlayers with different value functions
-    let baseline_fn = config.baseline_fn;
-    let test_fn = config.test_fn;
+    let baseline_fn = value_functions::baseline_value_function;
+    let test_fn = value_functions::variant_value_function;
     let depth = config.depth;
 
     let player_factory = move |deck_a: Deck, deck_b: Deck| -> Vec<Box<dyn Player>> {
@@ -164,8 +97,7 @@ fn run_comparison(config: ComparisonConfig) -> Result<(), Box<dyn std::error::Er
         config.parallel,
         None, // use default threads
     )?
-    .register::<StatsCollector>()
-    .register::<PointsCollector>();
+    .register::<StatsCollector>();
 
     simulation.run();
 
@@ -173,82 +105,28 @@ fn run_comparison(config: ComparisonConfig) -> Result<(), Box<dyn std::error::Er
     let stats_collector = simulation
         .get_event_handler::<StatsCollector>()
         .ok_or("Failed to retrieve StatsCollector")?;
-    let points_collector = simulation
-        .get_event_handler::<PointsCollector>()
-        .ok_or("Failed to retrieve PointsCollector")?;
 
     let summary = stats_collector.compute_stats();
-
-    println!("\n{}", "Results:".cyan().bold());
-    println!(
-        "  Games played: {}",
-        config.num_games.to_formatted_string(&Locale::en)
-    );
-    println!(
-        "  Average game length: {:.1} turns",
-        summary.avg_turns_per_game
-    );
-    println!();
-
-    // Player A (baseline) stats
-    println!(
-        "  {} ({}):",
-        "Player A".green().bold(),
-        config.baseline_name
-    );
-    println!(
-        "    Wins: {} ({:.1}%)",
-        summary.player_a_wins.to_formatted_string(&Locale::en),
-        summary.player_a_win_rate * 100.0
-    );
-    println!("    Avg points: {:.2}", points_collector.avg_points(0));
-    println!();
-
-    // Player B (test) stats
-    println!("  {} ({}):", "Player B".yellow().bold(), config.test_name);
-    println!(
-        "    Wins: {} ({:.1}%)",
-        summary.player_b_wins.to_formatted_string(&Locale::en),
-        summary.player_b_win_rate * 100.0
-    );
-    println!("    Avg points: {:.2}", points_collector.avg_points(1));
-    println!();
+    print_stats(&summary);
 
     // Comparison
     let win_rate_diff = (summary.player_b_win_rate - summary.player_a_win_rate) * 100.0;
-    let point_diff = points_collector.avg_points(1) - points_collector.avg_points(0);
 
     println!("{}", "Comparison:".cyan().bold());
     if win_rate_diff > 0.0 {
         println!(
             "  {} wins {:.1}% more games",
-            config.test_name.yellow(),
+            "variant".yellow(),
             win_rate_diff.abs()
         );
     } else if win_rate_diff < 0.0 {
         println!(
             "  {} wins {:.1}% more games",
-            config.baseline_name.green(),
+            "baseline".green(),
             win_rate_diff.abs()
         );
     } else {
         println!("  Tie!");
-    }
-
-    if point_diff.abs() > 0.01 {
-        if point_diff > 0.0 {
-            println!(
-                "  {} scores {:.2} more points on average",
-                config.test_name.yellow(),
-                point_diff.abs()
-            );
-        } else {
-            println!(
-                "  {} scores {:.2} more points on average",
-                config.baseline_name.green(),
-                point_diff.abs()
-            );
-        }
     }
 
     // Statistical significance (basic check)
@@ -279,57 +157,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize logger
     initialize_logger(args.verbosity);
 
-    // List available functions and validate
-    if args.baseline == "list" {
-        list_available_functions();
-        return Ok(());
-    }
-
-    // Get value functions
-    let baseline_fn = get_value_function(&args.baseline)?;
-
-    // If test function is specified, run single comparison
-    if let Some(test_name) = &args.test {
-        let test_fn = get_value_function(test_name)?;
-        run_comparison(ComparisonConfig {
-            deck_path: &args.deck,
-            baseline_fn,
-            test_fn,
-            baseline_name: &args.baseline,
-            test_name,
-            depth: args.depth,
-            num_games: args.num,
-            seed: args.seed,
-            parallel: args.parallel,
-        })?;
-    } else {
-        // Run against top performing variants
-        let variant_names = vec!["hand", "bench_depth"];
-
-        println!(
-            "\n{} Running A/B tests against top performing variants...\n",
-            "●".blue().bold()
-        );
-
-        for test_name in variant_names {
-            let test_fn = get_value_function(test_name)?;
-            run_comparison(ComparisonConfig {
-                deck_path: &args.deck,
-                baseline_fn,
-                test_fn,
-                baseline_name: &args.baseline,
-                test_name,
-                depth: args.depth,
-                num_games: args.num,
-                seed: args.seed,
-                parallel: args.parallel,
-            })?;
-        }
-
-        println!("\n{}", "=".repeat(70).blue().bold());
-        println!("{}", "All tests complete!".green().bold());
-        println!("{}", "=".repeat(70).blue().bold());
-    }
+    run_comparison(ComparisonConfig {
+        deck_path: &args.deck,
+        depth: args.depth,
+        num_games: args.num,
+        seed: args.seed,
+        parallel: args.parallel,
+    })?;
 
     Ok(())
 }

--- a/src/players/mod.rs
+++ b/src/players/mod.rs
@@ -17,6 +17,7 @@ pub use human_player::HumanPlayer;
 pub use mcts_player::MctsPlayer;
 pub use random_player::RandomPlayer;
 pub use value_function_player::ValueFunctionPlayer;
+pub use value_functions::*;
 pub use weighted_random_player::WeightedRandomPlayer;
 
 use crate::{actions::Action, Deck, State};
@@ -118,7 +119,7 @@ fn get_player(deck: Deck, player: &PlayerCode) -> Box<dyn Player> {
             deck,
             max_depth: *max_depth,
             write_debug_trees: false,
-            value_function: expectiminimax_player::baseline_value_function,
+            value_function: value_functions::baseline_value_function,
         }),
         PlayerCode::ER => Box::new(EvolutionRusherPlayer { deck }),
     }

--- a/src/players/value_functions.rs
+++ b/src/players/value_functions.rs
@@ -3,12 +3,112 @@
 // Each value function evaluates a game state from a player's perspective
 // and returns a score (higher is better for that player)
 
+use log::trace;
+
 use crate::hooks::energy_missing;
 use crate::models::{EnergyType, PlayedCard};
 use crate::State;
 
-// Re-export the baseline for convenience
-pub use super::expectiminimax_player::baseline_value_function;
+pub fn baseline_value_function(state: &State, myself: usize) -> f64 {
+    let opponent = (myself + 1) % 2;
+    let active_factor = 2.0; // Weight for active pokemon
+
+    // Points
+    let points = state.points[myself] as f64;
+    let opponent_points = state.points[opponent] as f64;
+
+    // HP * Energy for my pokemon
+    let my_value = state
+        .enumerate_in_play_pokemon(myself)
+        .map(|(pos, card)| {
+            let relevant_energy = get_relevant_energy(state, opponent, card);
+            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
+            if pos == 0 {
+                hp_energy_product * active_factor
+            } else {
+                hp_energy_product
+            }
+        })
+        .sum::<f64>();
+
+    // HP * Energy for opponent's pokemon
+    let opponent_value = state
+        .enumerate_in_play_pokemon(opponent)
+        .map(|(pos, card)| {
+            let relevant_energy = get_relevant_energy(state, opponent, card);
+            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
+            if pos == 0 {
+                hp_energy_product * active_factor
+            } else {
+                hp_energy_product
+            }
+        })
+        .sum::<f64>();
+
+    // Hand size advantage
+    let hand_size = state.hands[myself].len() as f64;
+    let opponent_hand_size = state.hands[opponent].len() as f64;
+
+    let score = (points - opponent_points) * 1000000.0
+        + (my_value - opponent_value)
+        + (hand_size - opponent_hand_size) * 1.0;
+    trace!("ValueFunction: {score} (points: {points}, opponent_points: {opponent_points}, my_value: {my_value}, opponent_value: {opponent_value}, hand_size: {hand_size}, opponent_hand_size: {opponent_hand_size})");
+    score
+}
+
+/// A variant of the baseline value function
+pub fn variant_value_function(state: &State, myself: usize) -> f64 {
+    let opponent = (myself + 1) % 2;
+    let active_factor = 2.0; // Weight for active pokemon
+
+    // Points
+    let points = state.points[myself] as f64;
+    let opponent_points = state.points[opponent] as f64;
+
+    // HP * Energy for my pokemon
+    let my_value = state
+        .enumerate_in_play_pokemon(myself)
+        .map(|(pos, card)| {
+            let relevant_energy = get_relevant_energy(state, opponent, card);
+            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
+            if pos == 0 {
+                hp_energy_product * active_factor
+            } else {
+                hp_energy_product
+            }
+        })
+        .sum::<f64>();
+
+    // HP * Energy for opponent's pokemon
+    let opponent_value = state
+        .enumerate_in_play_pokemon(opponent)
+        .map(|(pos, card)| {
+            let relevant_energy = get_relevant_energy(state, opponent, card);
+            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
+            if pos == 0 {
+                hp_energy_product * active_factor
+            } else {
+                hp_energy_product
+            }
+        })
+        .sum::<f64>();
+
+    // Hand size advantage
+    let hand_size = state.hands[myself].len() as f64;
+    let opponent_hand_size = state.hands[opponent].len() as f64;
+
+    // NEW FEATURE: Deck size advantage (more cards left in deck = worse)
+    let my_deck_size = state.decks[myself].cards.len() as f64;
+    let opponent_deck_size = state.decks[opponent].cards.len() as f64;
+    let deck_advantage = (opponent_deck_size - my_deck_size) * 0.5;
+
+    let score = (points - opponent_points) * 1000000.0
+        + (my_value - opponent_value)
+        + (hand_size - opponent_hand_size) * 1.0
+        + deck_advantage;
+    trace!("ValueFunction: {score} (points: {points}, opponent_points: {opponent_points}, my_value: {my_value}, opponent_value: {opponent_value}, hand_size: {hand_size}, opponent_hand_size: {opponent_hand_size})");
+    score
+}
 
 /// Helper function to calculate relevant energy for a Pokemon
 fn get_relevant_energy(state: &State, player: usize, card: &PlayedCard) -> f64 {
@@ -24,252 +124,4 @@ fn get_relevant_energy(state: &State, player: usize, card: &PlayedCard) -> f64 {
 
     let total = most_expensive_attack_cost.len() as f64;
     total - missing.len() as f64
-}
-
-/// Variant 1: Emphasize active Pokemon more (3x instead of 2x)
-pub fn aggressive_active_value_function(state: &State, myself: usize) -> f64 {
-    let opponent = (myself + 1) % 2;
-    let active_factor = 3.0; // Increased from 2.0
-
-    // Points
-    let points = state.points[myself] as f64;
-    let opponent_points = state.points[opponent] as f64;
-
-    // HP * Energy for my pokemon
-    let my_value = state
-        .enumerate_in_play_pokemon(myself)
-        .map(|(pos, card)| {
-            let relevant_energy = get_relevant_energy(state, myself, card);
-            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
-            if pos == 0 {
-                hp_energy_product * active_factor
-            } else {
-                hp_energy_product
-            }
-        })
-        .sum::<f64>();
-
-    // HP * Energy for opponent's pokemon
-    let opponent_value = state
-        .enumerate_in_play_pokemon(opponent)
-        .map(|(pos, card)| {
-            let relevant_energy = get_relevant_energy(state, opponent, card);
-            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
-            if pos == 0 {
-                hp_energy_product * active_factor
-            } else {
-                hp_energy_product
-            }
-        })
-        .sum::<f64>();
-
-    // Hand size advantage
-    let hand_size = state.hands[myself].len() as f64;
-    let opponent_hand_size = state.hands[opponent].len() as f64;
-
-    (points - opponent_points) * 1000000.0
-        + (my_value - opponent_value)
-        + (hand_size - opponent_hand_size) * 1.0
-}
-
-/// Variant 2: Value hand cards more (2.0 weight instead of 1.0)
-pub fn hand_value_function(state: &State, myself: usize) -> f64 {
-    let opponent = (myself + 1) % 2;
-    let active_factor = 2.0;
-    let hand_weight = 2.0; // Increased from 1.0
-
-    // Points
-    let points = state.points[myself] as f64;
-    let opponent_points = state.points[opponent] as f64;
-
-    // HP * Energy for my pokemon
-    let my_value = state
-        .enumerate_in_play_pokemon(myself)
-        .map(|(pos, card)| {
-            let relevant_energy = get_relevant_energy(state, myself, card);
-            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
-            if pos == 0 {
-                hp_energy_product * active_factor
-            } else {
-                hp_energy_product
-            }
-        })
-        .sum::<f64>();
-
-    // HP * Energy for opponent's pokemon
-    let opponent_value = state
-        .enumerate_in_play_pokemon(opponent)
-        .map(|(pos, card)| {
-            let relevant_energy = get_relevant_energy(state, opponent, card);
-            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
-            if pos == 0 {
-                hp_energy_product * active_factor
-            } else {
-                hp_energy_product
-            }
-        })
-        .sum::<f64>();
-
-    // Hand size advantage (weighted more)
-    let hand_size = state.hands[myself].len() as f64;
-    let opponent_hand_size = state.hands[opponent].len() as f64;
-
-    (points - opponent_points) * 1000000.0
-        + (my_value - opponent_value)
-        + (hand_size - opponent_hand_size) * hand_weight
-}
-
-/// Variant 3: Add bench depth as a new feature (more bench Pokemon = better board position)
-pub fn bench_depth_value_function(state: &State, myself: usize) -> f64 {
-    let opponent = (myself + 1) % 2;
-    let active_factor = 2.0;
-
-    // Points
-    let points = state.points[myself] as f64;
-    let opponent_points = state.points[opponent] as f64;
-
-    // HP * Energy for my pokemon
-    let my_value = state
-        .enumerate_in_play_pokemon(myself)
-        .map(|(pos, card)| {
-            let relevant_energy = get_relevant_energy(state, myself, card);
-            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
-            if pos == 0 {
-                hp_energy_product * active_factor
-            } else {
-                hp_energy_product
-            }
-        })
-        .sum::<f64>();
-
-    // HP * Energy for opponent's pokemon
-    let opponent_value = state
-        .enumerate_in_play_pokemon(opponent)
-        .map(|(pos, card)| {
-            let relevant_energy = get_relevant_energy(state, opponent, card);
-            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
-            if pos == 0 {
-                hp_energy_product * active_factor
-            } else {
-                hp_energy_product
-            }
-        })
-        .sum::<f64>();
-
-    // Hand size advantage
-    let hand_size = state.hands[myself].len() as f64;
-    let opponent_hand_size = state.hands[opponent].len() as f64;
-
-    // NEW FEATURE: Bench depth (number of benched Pokemon)
-    // in_play_pokemon[player][0] is active, [1..4] are bench
-    let my_bench_count = state.in_play_pokemon[myself][1..4]
-        .iter()
-        .filter(|p| p.is_some())
-        .count() as f64;
-    let opponent_bench_count = state.in_play_pokemon[opponent][1..4]
-        .iter()
-        .filter(|p| p.is_some())
-        .count() as f64;
-    let bench_advantage = (my_bench_count - opponent_bench_count) * 10.0;
-
-    (points - opponent_points) * 1000000.0
-        + (my_value - opponent_value)
-        + (hand_size - opponent_hand_size) * 1.0
-        + bench_advantage
-}
-
-/// Variant 4: Emphasize raw HP more (don't multiply by energy)
-pub fn hp_focused_value_function(state: &State, myself: usize) -> f64 {
-    let opponent = (myself + 1) % 2;
-    let active_factor = 2.0;
-
-    // Points
-    let points = state.points[myself] as f64;
-    let opponent_points = state.points[opponent] as f64;
-
-    // Total HP for my pokemon (not multiplied by energy)
-    let my_value = state
-        .enumerate_in_play_pokemon(myself)
-        .map(|(pos, card)| {
-            let hp = card.remaining_hp as f64;
-            if pos == 0 {
-                hp * active_factor
-            } else {
-                hp
-            }
-        })
-        .sum::<f64>();
-
-    // Total HP for opponent's pokemon
-    let opponent_value = state
-        .enumerate_in_play_pokemon(opponent)
-        .map(|(pos, card)| {
-            let hp = card.remaining_hp as f64;
-            if pos == 0 {
-                hp * active_factor
-            } else {
-                hp
-            }
-        })
-        .sum::<f64>();
-
-    // Hand size advantage
-    let hand_size = state.hands[myself].len() as f64;
-    let opponent_hand_size = state.hands[opponent].len() as f64;
-
-    (points - opponent_points) * 1000000.0
-        + (my_value - opponent_value) * 2.0 // Weight HP more since not multiplied by energy
-        + (hand_size - opponent_hand_size) * 1.0
-}
-
-/// Variant 5: Consider deck size (more cards left = better late game potential)
-pub fn deck_awareness_value_function(state: &State, myself: usize) -> f64 {
-    let opponent = (myself + 1) % 2;
-    let active_factor = 2.0;
-
-    // Points
-    let points = state.points[myself] as f64;
-    let opponent_points = state.points[opponent] as f64;
-
-    // HP * Energy for my pokemon
-    let my_value = state
-        .enumerate_in_play_pokemon(myself)
-        .map(|(pos, card)| {
-            let relevant_energy = get_relevant_energy(state, myself, card);
-            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
-            if pos == 0 {
-                hp_energy_product * active_factor
-            } else {
-                hp_energy_product
-            }
-        })
-        .sum::<f64>();
-
-    // HP * Energy for opponent's pokemon
-    let opponent_value = state
-        .enumerate_in_play_pokemon(opponent)
-        .map(|(pos, card)| {
-            let relevant_energy = get_relevant_energy(state, opponent, card);
-            let hp_energy_product = card.remaining_hp as f64 * (relevant_energy + 1.0);
-            if pos == 0 {
-                hp_energy_product * active_factor
-            } else {
-                hp_energy_product
-            }
-        })
-        .sum::<f64>();
-
-    // Hand size advantage
-    let hand_size = state.hands[myself].len() as f64;
-    let opponent_hand_size = state.hands[opponent].len() as f64;
-
-    // NEW FEATURE: Deck size advantage (more cards left in deck = better)
-    let my_deck_size = state.decks[myself].cards.len() as f64;
-    let opponent_deck_size = state.decks[opponent].cards.len() as f64;
-    let deck_advantage = (my_deck_size - opponent_deck_size) * 0.5;
-
-    (points - opponent_points) * 1000000.0
-        + (my_value - opponent_value)
-        + (hand_size - opponent_hand_size) * 1.0
-        + deck_advantage
 }

--- a/src/simulate.rs
+++ b/src/simulate.rs
@@ -316,7 +316,7 @@ pub fn create_progress_bar(total: u64) -> ProgressBar {
 }
 
 /// Print simulation statistics to the console
-fn print_stats(stats: &crate::simulation_event_handler::ComputedStats) {
+pub fn print_stats(stats: &crate::simulation_event_handler::ComputedStats) {
     warn!(
         "Ran {} simulations in {} ({} per game)!",
         stats.num_games.to_formatted_string(&Locale::en),


### PR DESCRIPTION
This commit enables experimentation with different value functions for the
ExpectiMiniMaxPlayer by making the value function a configurable parameter.

Changes:
- Add ValueFunction type alias for fn(&State, usize) -> f64
- Refactor ExpectiMiniMaxPlayer to accept value_function parameter
- Extract original value function as baseline_value_function
- Create value_functions module with 5 example variants:
  * aggressive_active: Higher active Pokemon weight (3.0x vs 2.0x)
  * hand: Higher hand size weight (2.0 vs 1.0)
  * bench_depth: Considers number of benched Pokemon
  * hp_focused: Emphasizes raw HP over HP*energy
  * deck_awareness: Considers remaining deck size
- Add A/B testing script (examples/value_function_ab_test.rs) for comparing
  value functions in mirror matches with statistical analysis

Usage:
  cargo run --example value_function_ab_test -- deck.txt --num 1000
  cargo run --example value_function_ab_test -- deck.txt --num 1000 --test hand
  cargo run --example value_function_ab_test -- deck.txt --num 100 --baseline aggressive_active --test bench_depth