### PR TITLE
Implement card component for Phanpy

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -310,6 +310,10 @@ fn forecast_effect_attack_by_mechanic(
             extra_damage,
             opponent,
         } => extra_damage_if_hurt(state, attack.fixed_damage, *extra_damage, *opponent),
+        Mechanic::DamageEqualToSelfDamage => damage_equal_to_self_damage(state),
+        Mechanic::ExtraDamageEqualToSelfDamage => {
+            extra_damage_equal_to_self_damage(state, attack.fixed_damage)
+        }
         Mechanic::BenchCountDamage {
             include_fixed_damage,
             damage_per,
@@ -1215,6 +1219,21 @@ fn extra_damage_if_hurt(
     } else {
         active_damage_doutcome(base)
     }
+}
+
+fn damage_equal_to_self_damage(state: &State) -> (Probabilities, Mutations) {
+    let attacker = state.get_active(state.current_player);
+    let damage = attacker.total_hp - attacker.remaining_hp;
+    active_damage_doutcome(damage)
+}
+
+fn extra_damage_equal_to_self_damage(
+    state: &State,
+    base_damage: u32,
+) -> (Probabilities, Mutations) {
+    let attacker = state.get_active(state.current_player);
+    let self_damage = attacker.total_hp - attacker.remaining_hp;
+    active_damage_doutcome(base_damage + self_damage)
 }
 
 fn extra_damage_per_energy(

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -98,6 +98,8 @@ pub enum Mechanic {
         extra_damage: u32,
         opponent: bool,
     },
+    DamageEqualToSelfDamage,
+    ExtraDamageEqualToSelfDamage,
     ExtraDamageIfKnockedOutLastTurn {
         extra_damage: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1084,8 +1084,11 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             bench_only: false,
         },
     );
-    // map.insert("This attack does damage to your opponent's Active Pokémon equal to the damage this Pokémon has on it.", todo_implementation);
-    // map.insert("This attack does more damage equal to the damage this Pokémon has on it.", todo_implementation);
+    map.insert("This attack does damage to your opponent's Active Pokémon equal to the damage this Pokémon has on it.", Mechanic::DamageEqualToSelfDamage);
+    map.insert(
+        "This attack does more damage equal to the damage this Pokémon has on it.",
+        Mechanic::ExtraDamageEqualToSelfDamage,
+    );
     // map.insert("This attack's damage isn't affected by Weakness.", todo_implementation);
     // map.insert("This attack's damage isn't affected by any effects on your opponent's Active Pokémon.", todo_implementation);
     // map.insert("Until this Pokémon leaves the Active Spot, this Pokémon's Rolling Frenzy attack does +30 damage. This effect stacks.", todo_implementation);


### PR DESCRIPTION
Added support for attacks that deal damage equal to the attacker's own damage. Implemented two new mechanics:
- DamageEqualToSelfDamage: damage equals the damage on the attacking Pokémon
- ExtraDamageEqualToSelfDamage: adds the attacker's damage to base damage

This completes all Phanpy cards (A4a 043, A4a 076, P-A 108).