### PR TITLE
feat: implement multiple Pokemon EX cards and attacks

### DIFF
--- a/src/ability_ids.rs
+++ b/src/ability_ids.rs
@@ -58,6 +58,7 @@ pub enum AbilityId {
     B1a034ReuniclusInfiniteIncrease,
     B1a065FurfrouFurCoat,
     A4a032MisdreavusInfiltratingInspection,
+    B1081JolteonExElectromagneticWall,
 }
 
 // Create a static HashMap for fast (pokemon, index) lookup
@@ -212,12 +213,15 @@ lazy_static::lazy_static! {
         m.insert("B1 160", AbilityId::B1160DragalgeExPoisonPoint);
         m.insert("B1 172", AbilityId::B1172AegislashCursedMetal);
         m.insert("B1 177", AbilityId::B1177GoomyStickyMembrane);
+        m.insert("B1 081", AbilityId::B1081JolteonExElectromagneticWall);
         m.insert("B1 184", AbilityId::B1184EeveeBoostedEvolution);
         m.insert("B1 263", AbilityId::B1160DragalgeExPoisonPoint);
         m.insert("B1 281", AbilityId::B1160DragalgeExPoisonPoint);
         m.insert("B1 245", AbilityId::B1157HydreigonRoarInUnison);
         m.insert("B1 247", AbilityId::B1177GoomyStickyMembrane);
         m.insert("B1 256", AbilityId::B1073GreninjaExShiftingStream);
+        m.insert("B1 257", AbilityId::B1081JolteonExElectromagneticWall);
+        m.insert("B1 276", AbilityId::B1081JolteonExElectromagneticWall);
         m.insert("B1 260", AbilityId::B1121IndeedeeExWatchOver);
         m.insert("B1 275", AbilityId::B1073GreninjaExShiftingStream);
         m.insert("B1 278", AbilityId::B1121IndeedeeExWatchOver);

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -111,6 +111,9 @@ pub(crate) fn forecast_ability(
         AbilityId::A4a032MisdreavusInfiltratingInspection => {
             panic!("Infiltrating Inspection is triggered when played to bench")
         }
+        AbilityId::B1081JolteonExElectromagneticWall => {
+            panic!("Electromagnetic Wall is a passive ability triggered on energy attachment")
+        }
     }
 }
 

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -90,6 +90,10 @@ pub enum Mechanic {
         target_benched_type: Option<EnergyType>,
     },
     VaporeonHyperWhirlpool,
+    CoinFlipEnergyDiscard {
+        num_coins: usize,
+    },
+    MegaAbsolDarknessClaw,
     ConditionalBenchDamage {
         required_extra_energy: Vec<EnergyType>,
         bench_damage: u32,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -319,7 +319,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             probability: None,
         },
     );
-    // map.insert("Flip 2 coins. For each heads, discard a random Energy from your opponent's Active Pokémon. If both of them are tails, this attack does nothing.", todo_implementation);
+    map.insert(
+        "Flip 2 coins. For each heads, discard a random Energy from your opponent's Active Pokémon. If both of them are tails, this attack does nothing.",
+        Mechanic::CoinFlipEnergyDiscard { num_coins: 2 },
+    );
+    map.insert(
+        "Flip 3 coins. For each heads, discard a random Energy from your opponent's Active Pokémon. If all of them are tails, this attack does nothing.",
+        Mechanic::CoinFlipEnergyDiscard { num_coins: 3 },
+    );
     map.insert(
         "Flip 2 coins. If both of them are heads, this attack does 70 more damage.",
         Mechanic::ExtraDamageIfBothHeads { extra_damage: 70 },
@@ -560,8 +567,20 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("Flip a coin. If heads, your opponent's Active Pokémon's remaining HP is now 10.", todo_implementation);
     // map.insert("Flip a coin. If tails, discard 2 random Energy from this Pokémon.", todo_implementation);
     // map.insert("Flip a coin. If tails, during your next turn, this Pokémon can't attack.", todo_implementation);
-    // map.insert("Flip a coin. If tails, this Pokémon also does 20 damage to itself.", todo_implementation);
-    // map.insert("Flip a coin. If tails, this Pokémon also does 30 damage to itself.", todo_implementation);
+    map.insert(
+        "Flip a coin. If tails, this Pokémon also does 20 damage to itself.",
+        Mechanic::CoinFlipExtraDamageOrSelfDamage {
+            extra_damage: 0,
+            self_damage: 20,
+        },
+    );
+    map.insert(
+        "Flip a coin. If tails, this Pokémon also does 30 damage to itself.",
+        Mechanic::CoinFlipExtraDamageOrSelfDamage {
+            extra_damage: 0,
+            self_damage: 30,
+        },
+    );
     map.insert(
         "Flip a coin. If tails, this attack does nothing.",
         Mechanic::CoinFlipNoEffect,
@@ -1245,7 +1264,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("Your opponent reveals a random card from their hand and shuffles it into their deck.", todo_implementation);
     // map.insert("Your opponent reveals their hand.", todo_implementation);
-    // map.insert("Your opponent reveals their hand. Choose a Supporter card you find there and discard it.", todo_implementation);
+    map.insert(
+        "Your opponent reveals their hand. Choose a Supporter card you find there and discard it.",
+        Mechanic::MegaAbsolDarknessClaw,
+    );
     // map.insert("Your opponent reveals their hand. Choose a card you find there and shuffle it into your opponent's deck.", todo_implementation);
     map.insert(
         "Your opponent's Active Pokémon is now Asleep.",

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -152,6 +152,25 @@ pub(crate) fn on_attach_energy(
             pokemon.heal(20);
         }
     }
+
+    // Check for opponent's Jolteon ex's Electromagnetic Wall ability
+    // "As long as this Pokémon is in the Active Spot, whenever your opponent attaches an Energy
+    // from their Energy Zone to 1 of their Pokémon, do 20 damage to that Pokémon."
+    let opponent = (actor + 1) % 2;
+    if let Some(opponent_active) = state.in_play_pokemon[opponent][0].as_ref() {
+        if let Some(ability_id) = AbilityId::from_pokemon_id(&opponent_active.card.get_id()[..]) {
+            if ability_id == AbilityId::B1081JolteonExElectromagneticWall && is_turn_energy {
+                debug!(
+                    "Jolteon ex's Electromagnetic Wall: Dealing 20 damage to Pokemon at position {}",
+                    in_play_idx
+                );
+                let target = state.in_play_pokemon[actor][in_play_idx]
+                    .as_mut()
+                    .expect("Pokemon should be there if attaching energy to it");
+                target.apply_damage(20);
+            }
+        }
+    }
 }
 
 /// Called when a Pokémon evolves

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -95,6 +95,7 @@ fn can_use_ability(state: &State, (in_play_index, card): (usize, &PlayedCard)) -
         AbilityId::B1a034ReuniclusInfiniteIncrease => false, // Passive ability
         AbilityId::B1a065FurfrouFurCoat => false,       // Passive ability
         AbilityId::A4a032MisdreavusInfiltratingInspection => false, // Triggered when played to bench
+        AbilityId::B1081JolteonExElectromagneticWall => false, // Passive ability on energy attachment
     }
 }
 


### PR DESCRIPTION
- Add Mega Pidgeot ex Giant Twister attack (coin flip energy discard)
- Add Mega Absol ex Darkness Claw attack (discard supporter from opponent)
- Add Jolteon ex Electromagnetic Wall ability (passive energy attachment damage)
- Add Tauros ex Wild Tackle attack (coin flip self damage)
- Add CoinFlipEnergyDiscard mechanic for coin-based energy removal
- Also implements Pidgeot B1 182 Twister attack (2 coin variant)
- Also implements attacks with "coin flip self damage" effect

https://claude.ai/code/session_01SCH8wfSweRESXG1pNJ9v93