### PR TITLE
Implement Forretress Enormous Explosion attack (B2b 046, B2b 104)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -529,6 +529,15 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::CoinFlipShuffleRandomOpponentHandCardIntoDeck => {
             coin_flip_shuffle_random_opponent_hand_card_into_deck()
         }
+        Mechanic::SelfAndBothBenchDamage {
+            self_damage,
+            bench_damage,
+        } => self_and_both_bench_damage_attack(
+            state,
+            attack.fixed_damage,
+            *self_damage,
+            *bench_damage,
+        ),
     }
 }
 
@@ -1326,6 +1335,36 @@ fn self_damage_attack(damage: u32, self_damage: u32) -> Outcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let active = state.get_active_mut(action.actor);
         active.apply_damage(self_damage);
+    })
+}
+
+/// For attacks like Enormous Explosion: deal damage to opponent's active,
+/// self-damage, and splash damage to all Benched Pokémon on both sides.
+fn self_and_both_bench_damage_attack(
+    state: &State,
+    active_damage: u32,
+    self_damage: u32,
+    bench_damage: u32,
+) -> Outcomes {
+    let opponent = (state.current_player + 1) % 2;
+    let mut targets: Vec<(u32, usize)> = state
+        .enumerate_bench_pokemon(opponent)
+        .map(|(idx, _)| (bench_damage, idx))
+        .collect();
+    targets.push((active_damage, 0));
+    let own_bench_indices: Vec<usize> = state
+        .enumerate_bench_pokemon(state.current_player)
+        .map(|(idx, _)| idx)
+        .collect();
+    damage_effect_doutcome(targets, move |_, state, action| {
+        for &idx in &own_bench_indices {
+            if let Some(pokemon) = state.in_play_pokemon[action.actor][idx].as_mut() {
+                pokemon.apply_damage(bench_damage);
+            }
+        }
+        if let Some(active) = state.in_play_pokemon[action.actor][0].as_mut() {
+            active.apply_damage(self_damage);
+        }
     })
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -28,6 +28,7 @@ use super::{
     mutations::{
         active_damage_doutcome, active_damage_effect_doutcome, active_damage_effect_mutation,
         active_damage_mutation, build_status_effect, damage_effect_doutcome,
+        full_targets_damage_doutcome,
     },
     outcomes::{CoinSeq, Outcomes},
     shared_mutations::{
@@ -1346,26 +1347,21 @@ fn self_and_both_bench_damage_attack(
     self_damage: u32,
     bench_damage: u32,
 ) -> Outcomes {
-    let opponent = (state.current_player + 1) % 2;
-    let mut targets: Vec<(u32, usize)> = state
-        .enumerate_bench_pokemon(opponent)
-        .map(|(idx, _)| (bench_damage, idx))
-        .collect();
-    targets.push((active_damage, 0));
-    let own_bench_indices: Vec<usize> = state
-        .enumerate_bench_pokemon(state.current_player)
-        .map(|(idx, _)| idx)
-        .collect();
-    damage_effect_doutcome(targets, move |_, state, action| {
-        for &idx in &own_bench_indices {
-            if let Some(pokemon) = state.in_play_pokemon[action.actor][idx].as_mut() {
-                pokemon.apply_damage(bench_damage);
-            }
-        }
-        if let Some(active) = state.in_play_pokemon[action.actor][0].as_mut() {
-            active.apply_damage(self_damage);
-        }
-    })
+    let attacker = state.current_player;
+    let opponent = (attacker + 1) % 2;
+    let mut targets: Vec<(u32, usize, usize)> =
+        vec![(active_damage, opponent, 0), (self_damage, attacker, 0)];
+    targets.extend(
+        state
+            .enumerate_bench_pokemon(opponent)
+            .map(|(idx, _)| (bench_damage, opponent, idx)),
+    );
+    targets.extend(
+        state
+            .enumerate_bench_pokemon(attacker)
+            .map(|(idx, _)| (bench_damage, attacker, idx)),
+    );
+    full_targets_damage_doutcome(targets)
 }
 
 /// For attacks that deal damage and apply multiple status effects to opponent (e.g. Mega Venusaur Critical Bloom)

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -270,4 +270,8 @@ pub enum Mechanic {
         extra_damage: u32,
     },
     CoinFlipShuffleRandomOpponentHandCardIntoDeck,
+    SelfAndBothBenchDamage {
+        self_damage: u32,
+        bench_damage: u32,
+    },
 }

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1673,7 +1673,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     // map.insert("Take a [W] and a [L] Energy from your Energy Zone and attach them to this Pokémon.", todo_implementation);
-    // map.insert("This Pokémon also does 100 damage to itself and 50 damage to all Benched Pokémon (both yours and your opponent's).", todo_implementation);
+    map.insert(
+        "This Pokémon also does 100 damage to itself and 50 damage to all Benched Pokémon (both yours and your opponent's).",
+        Mechanic::SelfAndBothBenchDamage {
+            self_damage: 100,
+            bench_damage: 50,
+        },
+    );
     // map.insert("This attack does 20 more damage for each Benched Pokémon (both yours and your opponent's).", todo_implementation);
     map.insert(
         "This attack does 30 more damage for each point you have gotten.",

--- a/src/actions/mutations.rs
+++ b/src/actions/mutations.rs
@@ -41,7 +41,7 @@ where
 /// Like `damage_effect_doutcome` but targets include an explicit player index,
 /// allowing damage to be dealt to any player's Pokémon (e.g. self-damage, own bench).
 pub(crate) fn full_targets_damage_doutcome(targets: Vec<(u32, usize, usize)>) -> Outcomes {
-    Outcomes::single(full_targets_damage_mutation(targets))
+    Outcomes::single(full_targets_damage_mutation(targets, |_, _, _| {}))
 }
 
 // ===== Helper functions for building Mutations
@@ -63,92 +63,82 @@ pub(crate) fn damage_effect_mutation<F>(
 where
     F: Fn(&mut StdRng, &mut State, &Action) + 'static,
 {
-    Box::new({
-        move |rng, state, action| {
-            let opponent = (action.actor + 1) % 2;
-            let targets: Vec<(u32, usize, usize)> = targets
-                .iter()
-                .map(|(damage, in_play_idx)| (*damage, opponent, *in_play_idx))
-                .collect();
-
-            let attack_name: String = match &action.action {
-                SimpleAction::Attack(attack_index) => state.in_play_pokemon[action.actor][0]
-                    .as_ref()
-                    .expect("Attacking Pokemon must be there if attacking")
-                    .card
-                    .get_attacks()
-                    .get(*attack_index)
-                    .unwrap_or_else(|| {
-                        panic!("Index must exist if attacking with {}", attack_index)
-                    })
-                    .title
-                    .clone(),
-                SimpleAction::UseCopiedAttack {
-                    source_player,
-                    source_in_play_idx,
-                    attack_index,
-                    ..
-                } => state.in_play_pokemon[*source_player][*source_in_play_idx]
-                    .as_ref()
-                    .expect("Copied-attack source Pokemon must exist")
-                    .card
-                    .get_attacks()
-                    .get(*attack_index)
-                    .unwrap_or_else(|| {
-                        panic!(
-                            "Copied attack index must exist for source {}:{}",
-                            source_player, source_in_play_idx
-                        )
-                    })
-                    .title
-                    .clone(),
-                _ => panic!("This codepath should come from an attack."),
-            };
-
-            let attacking_ref = (action.actor, 0);
-            let is_from_active_attack = true;
-            handle_damage_only(
-                state,
-                attacking_ref,
-                &targets,
-                is_from_active_attack,
-                Some(&attack_name),
-            );
-            additional_effect(rng, state, action);
-            handle_knockouts(state, attacking_ref, is_from_active_attack);
-        }
+    // Convert (damage, in_play_idx) to full targets at execution time, then delegate.
+    Box::new(move |rng, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        let full_targets: Vec<(u32, usize, usize)> = targets
+            .iter()
+            .map(|(damage, in_play_idx)| (*damage, opponent, *in_play_idx))
+            .collect();
+        apply_full_targets(rng, state, action, &full_targets, &additional_effect);
     })
 }
 
-fn full_targets_damage_mutation(targets: Vec<(u32, usize, usize)>) -> Mutation {
-    Box::new({
-        move |_, state, action| {
-            let attack_name: String = match &action.action {
-                SimpleAction::Attack(attack_index) => state.in_play_pokemon[action.actor][0]
-                    .as_ref()
-                    .expect("Attacking Pokemon must be there if attacking")
-                    .card
-                    .get_attacks()
-                    .get(*attack_index)
-                    .unwrap_or_else(|| {
-                        panic!("Index must exist if attacking with {}", attack_index)
-                    })
-                    .title
-                    .clone(),
-                _ => panic!("This codepath should come from an attack."),
-            };
-            let attacking_ref = (action.actor, 0);
-            let is_from_active_attack = true;
-            handle_damage_only(
-                state,
-                attacking_ref,
-                &targets,
-                is_from_active_attack,
-                Some(&attack_name),
-            );
-            handle_knockouts(state, attacking_ref, is_from_active_attack);
-        }
+fn full_targets_damage_mutation<F>(
+    targets: Vec<(u32, usize, usize)>,
+    additional_effect: F,
+) -> Mutation
+where
+    F: Fn(&mut StdRng, &mut State, &Action) + 'static,
+{
+    Box::new(move |rng, state, action| {
+        apply_full_targets(rng, state, action, &targets, &additional_effect);
     })
+}
+
+/// Shared execution core: resolve attack name, apply damage to all targets, run
+/// any extra effect, then handle knockouts.
+fn apply_full_targets<F>(
+    rng: &mut StdRng,
+    state: &mut State,
+    action: &Action,
+    targets: &[(u32, usize, usize)],
+    additional_effect: &F,
+) where
+    F: Fn(&mut StdRng, &mut State, &Action),
+{
+    let attack_name: String = match &action.action {
+        SimpleAction::Attack(attack_index) => state.in_play_pokemon[action.actor][0]
+            .as_ref()
+            .expect("Attacking Pokemon must be there if attacking")
+            .card
+            .get_attacks()
+            .get(*attack_index)
+            .unwrap_or_else(|| panic!("Index must exist if attacking with {}", attack_index))
+            .title
+            .clone(),
+        SimpleAction::UseCopiedAttack {
+            source_player,
+            source_in_play_idx,
+            attack_index,
+            ..
+        } => state.in_play_pokemon[*source_player][*source_in_play_idx]
+            .as_ref()
+            .expect("Copied-attack source Pokemon must exist")
+            .card
+            .get_attacks()
+            .get(*attack_index)
+            .unwrap_or_else(|| {
+                panic!(
+                    "Copied attack index must exist for source {}:{}",
+                    source_player, source_in_play_idx
+                )
+            })
+            .title
+            .clone(),
+        _ => panic!("This codepath should come from an attack."),
+    };
+    let attacking_ref = (action.actor, 0);
+    let is_from_active_attack = true;
+    handle_damage_only(
+        state,
+        attacking_ref,
+        targets,
+        is_from_active_attack,
+        Some(&attack_name),
+    );
+    additional_effect(rng, state, action);
+    handle_knockouts(state, attacking_ref, is_from_active_attack);
 }
 
 // ===== Other Helper Functions

--- a/src/actions/mutations.rs
+++ b/src/actions/mutations.rs
@@ -38,6 +38,12 @@ where
     Outcomes::single(damage_effect_mutation(targets, additional_effect))
 }
 
+/// Like `damage_effect_doutcome` but targets include an explicit player index,
+/// allowing damage to be dealt to any player's Pokémon (e.g. self-damage, own bench).
+pub(crate) fn full_targets_damage_doutcome(targets: Vec<(u32, usize, usize)>) -> Outcomes {
+    Outcomes::single(full_targets_damage_mutation(targets))
+}
+
 // ===== Helper functions for building Mutations
 pub(crate) fn active_damage_mutation(damage: u32) -> Mutation {
     damage_effect_mutation(vec![(damage, 0)], |_, _, _| {})
@@ -109,6 +115,37 @@ where
                 Some(&attack_name),
             );
             additional_effect(rng, state, action);
+            handle_knockouts(state, attacking_ref, is_from_active_attack);
+        }
+    })
+}
+
+fn full_targets_damage_mutation(targets: Vec<(u32, usize, usize)>) -> Mutation {
+    Box::new({
+        move |_, state, action| {
+            let attack_name: String = match &action.action {
+                SimpleAction::Attack(attack_index) => state.in_play_pokemon[action.actor][0]
+                    .as_ref()
+                    .expect("Attacking Pokemon must be there if attacking")
+                    .card
+                    .get_attacks()
+                    .get(*attack_index)
+                    .unwrap_or_else(|| {
+                        panic!("Index must exist if attacking with {}", attack_index)
+                    })
+                    .title
+                    .clone(),
+                _ => panic!("This codepath should come from an attack."),
+            };
+            let attacking_ref = (action.actor, 0);
+            let is_from_active_attack = true;
+            handle_damage_only(
+                state,
+                attacking_ref,
+                &targets,
+                is_from_active_attack,
+                Some(&attack_name),
+            );
             handle_knockouts(state, attacking_ref, is_from_active_attack);
         }
     })


### PR DESCRIPTION
Adds new SelfAndBothBenchDamage mechanic for attacks that deal damage
to the opponent's active, self-damage, and splash damage to all Benched
Pokémon on both sides (e.g. Enormous Explosion: 100 to opponent active,
100 to self, 50 to all bench).

https://claude.ai/code/session_01RAhiydFgn4uTrNgCKE8PZL