### PR TITLE
Add support for ability-based damage bonus mechanic

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -532,6 +532,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfOpponentHpMoreThanSelf { extra_damage } => {
             extra_damage_if_opponent_hp_more_than_self(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::ExtraDamageIfOpponentActiveHasAbility { extra_damage } => {
+            extra_damage_if_opponent_active_has_ability(state, attack.fixed_damage, *extra_damage)
+        }
         Mechanic::CoinFlipShuffleRandomOpponentHandCardIntoDeck => {
             coin_flip_shuffle_random_opponent_hand_card_into_deck()
         }
@@ -1635,6 +1638,17 @@ fn extra_damage_if_opponent_hp_more_than_self(state: &State, base: u32, extra: u
     } else {
         active_damage_doutcome(base)
     }
+}
+
+fn extra_damage_if_opponent_active_has_ability(
+    state: &State,
+    base: u32,
+    extra: u32,
+) -> Outcomes {
+    let opponent = (state.current_player + 1) % 2;
+    let opponent_active = state.get_active(opponent);
+    let has_ability = opponent_active.card.get_ability().is_some();
+    active_damage_doutcome(if has_ability { base + extra } else { base })
 }
 
 fn extra_damage_if_hurt(state: &State, base: u32, extra: u32, opponent: bool) -> Outcomes {

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -1664,11 +1664,7 @@ fn extra_damage_if_opponent_hp_more_than_self(state: &State, base: u32, extra: u
     }
 }
 
-fn extra_damage_if_opponent_active_has_ability(
-    state: &State,
-    base: u32,
-    extra: u32,
-) -> Outcomes {
+fn extra_damage_if_opponent_active_has_ability(state: &State, base: u32, extra: u32) -> Outcomes {
     let opponent = (state.current_player + 1) % 2;
     let opponent_active = state.get_active(opponent);
     let has_ability = opponent_active.card.get_ability().is_some();

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -275,5 +275,8 @@ pub enum Mechanic {
     ExtraDamageIfOpponentHpMoreThanSelf {
         extra_damage: u32,
     },
+    ExtraDamageIfOpponentActiveHasAbility {
+        extra_damage: u32,
+    },
     CoinFlipShuffleRandomOpponentHandCardIntoDeck,
 }

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -792,7 +792,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::ExtraDamageIfSupportPlayedThisTurn { extra_damage: 50 },
     );
     // map.insert("If your opponent's Active Pokémon has a Pokémon Tool attached, this attack does 30 more damage.", todo_implementation);
-    // map.insert("If your opponent's Active Pokémon has an Ability, this attack does 40 more damage.", todo_implementation);
+    map.insert(
+        "If your opponent's Active Pokémon has an Ability, this attack does 40 more damage.",
+        Mechanic::ExtraDamageIfOpponentActiveHasAbility { extra_damage: 40 },
+    );
     map.insert(
         "If your opponent's Active Pokémon has damage on it, this attack does 30 more damage.",
         Mechanic::ExtraDamageIfHurt {


### PR DESCRIPTION
## Summary
Implement support for attack mechanics that deal extra damage when the opponent's Active Pokémon has an Ability.

## Key Changes
- Added new `ExtraDamageIfOpponentActiveHasAbility` variant to the `Mechanic` enum with configurable `extra_damage` parameter
- Implemented `extra_damage_if_opponent_active_has_ability()` function that:
  - Checks if the opponent's Active Pokémon has an Ability
  - Returns base damage + extra damage if ability is present, otherwise returns base damage only
- Added forecast effect handler in `forecast_effect_attack_by_mechanic()` to process this mechanic during attack resolution
- Mapped the game text "If your opponent's Active Pokémon has an Ability, this attack does 40 more damage." to the new mechanic in the effect mechanic map

## Implementation Details
The implementation follows the existing pattern used for similar conditional damage mechanics (e.g., `ExtraDamageIfOpponentHpMoreThanSelf`). The ability check uses the card's `get_ability()` method to determine if an Ability is present on the opponent's Active Pokémon.

https://claude.ai/code/session_01D9WZtbdn3onfUqkzmGS4H1