### PR TITLE
Add Bonsly Teary Attack implementation and -30 damage effect

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -322,13 +322,21 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     map.insert(
         "During your opponent's next turn, attacks used by the Defending Pokémon do -20 damage.",
         Mechanic::DamageAndCardEffect {
-            opponent: true,
+            opponent: false,
             effect: CardEffect::ReducedDamage { amount: 20 },
             duration: 1,
             coin_flip: false,
         },
     );
-    // map.insert("During your opponent's next turn, attacks used by the Defending Pokémon do -30 damage.", todo_implementation);
+    map.insert(
+        "During your opponent's next turn, attacks used by the Defending Pokémon do -30 damage.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::ReducedDamage { amount: 30 },
+            duration: 1,
+            coin_flip: false,
+        },
+    );
     // map.insert("During your opponent's next turn, if the Defending Pokémon tries to use an attack, your opponent flips a coin. If tails, that attack doesn't happen.", todo_implementation);
     // map.insert("During your opponent's next turn, if they attach Energy from their Energy Zone to the Defending Pokémon, that Pokémon will be Asleep.", todo_implementation);
     // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 20 damage to the Attacking Pokémon.", todo_implementation);

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -4,6 +4,8 @@ mod additional_ability_logic_test;
 mod arceus_ex_test;
 #[path = "pokemon/blastoise_double_splash_test.rs"]
 mod blastoise_double_splash_test;
+#[path = "pokemon/bonsly_teary_attack_test.rs"]
+mod bonsly_teary_attack_test;
 #[path = "pokemon/camerupt_eruption_test.rs"]
 mod camerupt_eruption_test;
 #[path = "pokemon/castform_test.rs"]

--- a/tests/pokemon/bonsly_teary_attack_test.rs
+++ b/tests/pokemon/bonsly_teary_attack_test.rs
@@ -1,0 +1,79 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Test Bonsly's Teary Attack deals 10 damage to the opponent
+#[test]
+fn test_bonsly_teary_attack_deals_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3078Bonsly)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let bulbasaur_hp = state.get_active(1).get_remaining_hp();
+    assert_eq!(
+        bulbasaur_hp, 60,
+        "Bulbasaur should take 10 damage from Teary Attack (70 - 10 = 60)"
+    );
+}
+
+/// Test Bonsly's Teary Attack reduces opponent's next attack by 30
+#[test]
+fn test_bonsly_teary_attack_reduces_opponent_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Bonsly (30 HP) vs Bulbasaur (70 HP, Vine Whip = 40 damage)
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3078Bonsly)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    // Bonsly uses Teary Attack (no energy required): 10 damage + -30 effect on opponent
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    // End Bonsly's turn
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    // Bulbasaur attacks with Vine Whip (normally 40 damage, should be 40-30=10 with effect)
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let bonsly_hp = state.get_active(0).get_remaining_hp();
+    // Bonsly has 30 HP, should take only 10 damage (40 - 30) = 20 HP remaining
+    assert_eq!(
+        bonsly_hp, 20,
+        "Bonsly should take only 10 damage (40 - 30 reduction) and have 20 HP remaining"
+    );
+}


### PR DESCRIPTION
## Summary
This PR implements support for Bonsly's Teary Attack and adds the missing "-30 damage" effect mechanic to the game engine.

## Key Changes
- **Added Bonsly Teary Attack tests** (`tests/pokemon/bonsly_teary_attack_test.rs`):
  - Test verifying Teary Attack deals 10 damage to opponent's active Pokémon
  - Test verifying the attack applies a -30 damage reduction effect to opponent's next attack
  
- **Implemented -30 damage effect mechanic** (`src/actions/effect_mechanic_map.rs`):
  - Added mapping for "During your opponent's next turn, attacks used by the Defending Pokémon do -30 damage."
  - Uses `CardEffect::ReducedDamage { amount: 30 }` with 1-turn duration
  - Fixed related -20 damage effect by correcting `opponent` flag from `true` to `false`

- **Updated test module registration** (`tests/pokemon.rs`):
  - Registered new Bonsly test module in the pokemon test suite

## Implementation Details
The -30 damage effect follows the same pattern as the existing -20 damage mechanic, applying a temporary damage reduction to the opponent's Pokémon for one turn. The `opponent: false` flag indicates the effect applies to the defending Pokémon (the one being attacked), which is the correct behavior for these attack effects.

https://claude.ai/code/session_01QiQ42UMdaE5wt77TyEC9pT