### PR TITLE
Implement Lucario B3 card mechanics and vulnerability effects

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1809,7 +1809,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("During your next turn, attacks used by your [F] Pokémon do +30 damage to your opponent's Active Pokémon.", todo_implementation);
     // map.insert("During your next turn, this Pokémon's Psych Up attack does +30 damage.", todo_implementation);
     // map.insert("During your opponent's next turn, they can't play any Pokémon from their hand to evolve their Pokémon.", todo_implementation);
-    // map.insert("During your opponent's next turn, this Pokémon takes +20 damage from attacks.", todo_implementation);
+    map.insert(
+        "During your opponent's next turn, this Pokémon takes +20 damage from attacks.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::IncreasedVulnerability { amount: 20 },
+            duration: 1,
+            coin_flip: false,
+        },
+    );
     map.insert(
         "Flip 3 coins. For each heads, discard a [R] Energy from this Pokémon. This attack does 30 more damage for each [R] Energy you discarded in this way.",
         Mechanic::DiscardSelfEnergyPerHeadsExtraDamage {
@@ -1872,7 +1880,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("If any of your [D] Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 80 more damage.", todo_implementation);
     // map.insert("If this Pokémon evolved from Poliwhirl during this turn, this attack does 50 more damage.", todo_implementation);
     // map.insert("If this Pokémon has any [F] Energy attached, this attack does 60 more damage.", todo_implementation);
-    // map.insert("If this Pokémon has at least 1 extra [F] Energy attached, this attack does 50 more damage.", todo_implementation);
+    map.insert(
+        "If this Pokémon has at least 1 extra [F] Energy attached, this attack does 50 more damage.",
+        Mechanic::ExtraDamageIfExtraEnergy {
+            required_extra_energy: vec![EnergyType::Fighting],
+            extra_damage: 50,
+        },
+    );
     map.insert(
         "If this Pokémon has no damage on it, this attack does 30 more damage.",
         Mechanic::ExtraDamageIfUndamaged { extra_damage: 30 },

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -7,6 +7,7 @@ use crate::models::EnergyType;
 pub enum CardEffect {
     NoRetreat,
     ReducedDamage { amount: u32 },
+    IncreasedVulnerability { amount: u32 },
     IncreasedAttackCost { amount: u8 },
     CannotAttack,
     CannotUseAttack(String),

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -630,6 +630,26 @@ fn get_reduced_card_effect_modifiers(
         .sum::<u32>()
 }
 
+fn get_increased_vulnerability_modifiers(
+    state: &State,
+    is_active_to_active: bool,
+    target_player: usize,
+) -> u32 {
+    if !is_active_to_active {
+        return 0;
+    }
+    state
+        .get_active(target_player)
+        .get_active_effects()
+        .iter()
+        .filter(|effect| matches!(effect, CardEffect::IncreasedVulnerability { .. }))
+        .map(|effect| match effect {
+            CardEffect::IncreasedVulnerability { amount } => *amount,
+            _ => 0,
+        })
+        .sum::<u32>()
+}
+
 fn get_turn_effect_damage_reduction(
     state: &State,
     target_player: usize,
@@ -788,6 +808,8 @@ pub(crate) fn modify_damage(
     );
     let reduced_card_effect_modifiers =
         get_reduced_card_effect_modifiers(state, is_active_to_active, target_player);
+    let increased_vulnerability_modifiers =
+        get_increased_vulnerability_modifiers(state, is_active_to_active, target_player);
     let reduced_turn_effect_modifiers = get_turn_effect_damage_reduction(
         state,
         target_player,
@@ -816,11 +838,12 @@ pub(crate) fn modify_damage(
     };
 
     debug!(
-        "Attack: {:?}, Weakness: {}, IncreasedDamage: {}, IncreasedAttackSpecific: {}, ReducedDamage: {}, TurnEffectReduction: {}, HeavyHelmet: {}, MetalCoreBarrier: {}, SteelApron: {}, IntimidatingFang: {}, AbilityReduction: {}, AbilityIncrease: {}, TypeBoost: {}, StadiumBonus: {}",
+        "Attack: {:?}, Weakness: {}, IncreasedDamage: {}, IncreasedAttackSpecific: {}, IncreasedVulnerability: {}, ReducedDamage: {}, TurnEffectReduction: {}, HeavyHelmet: {}, MetalCoreBarrier: {}, SteelApron: {}, IntimidatingFang: {}, AbilityReduction: {}, AbilityIncrease: {}, TypeBoost: {}, StadiumBonus: {}",
         base_damage,
         weakness_modifier,
         increased_turn_effect_modifiers,
         increased_attack_specific_modifiers,
+        increased_vulnerability_modifiers,
         reduced_card_effect_modifiers,
         reduced_turn_effect_modifiers,
         heavy_helmet_reduction,
@@ -837,6 +860,7 @@ pub(crate) fn modify_damage(
         + ability_damage_increase
         + increased_turn_effect_modifiers
         + increased_attack_specific_modifiers
+        + increased_vulnerability_modifiers
         + type_boost_bonus
         + stadium_damage_bonus)
         .saturating_sub(

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -24,6 +24,8 @@ mod grovyle_slicing_snipe_test;
 mod jolteon_ex_test;
 #[path = "pokemon/legacy_ability_logic_test.rs"]
 mod legacy_ability_logic_test;
+#[path = "pokemon/lucario_b3_test.rs"]
+mod lucario_b3_test;
 #[path = "pokemon/lucario_fighting_coach_test.rs"]
 mod lucario_fighting_coach_test;
 #[path = "pokemon/magneton_test.rs"]

--- a/tests/pokemon/lucario_b3_test.rs
+++ b/tests/pokemon/lucario_b3_test.rs
@@ -1,0 +1,161 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn played_card_with_base_hp(card_id: CardId, base_hp: u32) -> PlayedCard {
+    let card = deckgym::database::get_card_by_enum(card_id);
+    PlayedCard::new(card, 0, base_hp, vec![], false, vec![])
+}
+
+/// Test Lucario B3 080's Close Combat deals 90 base damage
+#[test]
+fn test_lucario_b3_close_combat_base_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3080Lucario)
+            .with_energy(vec![EnergyType::Fighting, EnergyType::Fighting])],
+        vec![played_card_with_base_hp(CardId::A1001Bulbasaur, 150)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let attack_action = Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    };
+    game.apply_action(&attack_action);
+
+    let final_state = game.get_state_clone();
+    let opponent_hp = final_state.get_active(1).get_remaining_hp();
+
+    assert_eq!(
+        opponent_hp, 60,
+        "Close Combat should deal 90 base damage (150 - 90 = 60)"
+    );
+}
+
+/// Test Close Combat makes Lucario take +20 more damage from attacks during opponent's next turn
+#[test]
+fn test_lucario_b3_close_combat_vulnerability() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Player 0: Lucario B3 080 (100 HP) with 2F energy
+    // Player 1: Bulbasaur with 150 HP + Grass+Colorless energy (for Vine Whip = 40 damage)
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3080Lucario)
+            .with_energy(vec![EnergyType::Fighting, EnergyType::Fighting])],
+        vec![played_card_with_base_hp(CardId::A1001Bulbasaur, 150)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    // Player 0 uses Close Combat (90 damage to Bulbasaur, leaves vulnerability on Lucario)
+    let attack_action = Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    };
+    game.apply_action(&attack_action);
+
+    // Player 0 ends turn
+    let end_turn = Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    };
+    game.apply_action(&end_turn);
+
+    let state = game.get_state_clone();
+    let lucario_hp_before = state.get_active(0).get_remaining_hp();
+
+    // Player 1 uses Vine Whip (40 base damage)
+    // Lucario's Close Combat vulnerability adds +20 → 60 total damage taken
+    let vine_whip = Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    };
+    game.apply_action(&vine_whip);
+
+    let final_state = game.get_state_clone();
+    let lucario_hp_after = final_state.get_active(0).get_remaining_hp();
+    let damage_taken = lucario_hp_before - lucario_hp_after;
+
+    assert_eq!(
+        damage_taken, 60,
+        "Vine Whip (40) should deal 60 damage to Lucario due to Close Combat's +20 vulnerability"
+    );
+}
+
+/// Test Mega Lucario ex Fighting Pulse deals 90 base damage (no extra energy)
+#[test]
+fn test_mega_lucario_ex_fighting_pulse_base_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3081MegaLucarioEx)
+            .with_energy(vec![EnergyType::Fighting, EnergyType::Fighting])],
+        vec![played_card_with_base_hp(CardId::A1001Bulbasaur, 150)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let attack_action = Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    };
+    game.apply_action(&attack_action);
+
+    let final_state = game.get_state_clone();
+    let opponent_hp = final_state.get_active(1).get_remaining_hp();
+
+    assert_eq!(
+        opponent_hp, 60,
+        "Fighting Pulse should deal 90 base damage with no extra energy (150 - 90 = 60)"
+    );
+}
+
+/// Test Mega Lucario ex Fighting Pulse deals 140 damage with 1 extra Fighting energy
+#[test]
+fn test_mega_lucario_ex_fighting_pulse_boosted_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3081MegaLucarioEx).with_energy(vec![
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+            ]),
+        ],
+        vec![played_card_with_base_hp(CardId::A1001Bulbasaur, 200)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let attack_action = Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    };
+    game.apply_action(&attack_action);
+
+    let final_state = game.get_state_clone();
+    let opponent_hp = final_state.get_active(1).get_remaining_hp();
+
+    assert_eq!(
+        opponent_hp, 60,
+        "Fighting Pulse should deal 140 damage with 1 extra Fighting energy (200 - 140 = 60)"
+    );
+}


### PR DESCRIPTION
## Summary
This PR adds support for Lucario B3 080 and Mega Lucario ex B3 081 card mechanics, including their attacks and effects. It introduces a new `IncreasedVulnerability` card effect that increases damage taken by a Pokémon during the opponent's next turn.

## Key Changes

- **New Card Effect**: Added `IncreasedVulnerability` to the `CardEffect` enum to track when a Pokémon takes increased damage from attacks
- **Damage Calculation**: Updated `modify_damage()` in `core.rs` to apply vulnerability modifiers when calculating attack damage
- **Attack Mechanics**:
  - Implemented "During your opponent's next turn, this Pokémon takes +20 damage from attacks" effect mapping
  - Implemented "If this Pokémon has at least 1 extra [F] Energy attached, this attack does 50 more damage" mechanic for variable damage scaling
- **Comprehensive Tests**: Added three test cases covering:
  - Lucario B3's Close Combat base damage (90)
  - Close Combat vulnerability effect (+20 damage taken next turn)
  - Mega Lucario ex's Fighting Pulse base damage (90) and boosted damage with extra energy (140)

## Implementation Details

- Vulnerability modifiers are only applied to active-to-active attacks
- The `get_increased_vulnerability_modifiers()` function sums all `IncreasedVulnerability` effects on the target's active Pokémon
- Vulnerability is added to the damage calculation alongside other modifiers (weakness, ability increases, etc.)
- Debug logging updated to include vulnerability modifier tracking

https://claude.ai/code/session_017SoDNNTNS8v2fAkZCHuc8N