### PR TITLE
Refactor test setup to use get_test_game_with_board helper

### DIFF
--- a/tests/ability_mechanic_examples_test.rs
+++ b/tests/ability_mechanic_examples_test.rs
@@ -2,23 +2,17 @@ use deckgym::{
     actions::{Action, SimpleAction},
     card_ids::CardId,
     models::PlayedCard,
-    test_support::get_initialized_game,
+    test_support::get_test_game_with_board,
 };
 
 #[test]
 fn test_weezing_gas_leak_poisons_opponent_active() {
     // Weezing's Gas Leak: Once during your turn, if this Pokémon is in the Active Spot,
     // you may make your opponent's Active Pokémon Poisoned.
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1177Weezing)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
 
     let ability_action = Action {
         actor: 0,
@@ -40,16 +34,10 @@ fn test_weezing_gas_leak_poisons_opponent_active() {
 #[test]
 fn test_indeedee_ex_watch_over_heals_active() {
     // Indeedee ex's Watch Over: Once during your turn, you may heal 20 damage from your Active Pokémon.
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::B1121IndeedeeEx).with_remaining_hp(80)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
 
     let ability_action = Action {
         actor: 0,
@@ -73,19 +61,13 @@ fn test_indeedee_ex_watch_over_heals_active() {
 fn test_pidgeot_drive_off_forces_opponent_switch() {
     // Pidgeot's Drive Off: Once during your turn, you may switch out your opponent's Active Pokémon
     // to the Bench. (Your opponent chooses the new Active Pokémon.)
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1188Pidgeot)],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::A1002Ivysaur),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
 
     let ability_action = Action {
         actor: 0,

--- a/tests/coin_flip_effect_test.rs
+++ b/tests/coin_flip_effect_test.rs
@@ -3,27 +3,21 @@ use deckgym::{
     card_ids::CardId,
     effects::CardEffect,
     models::{EnergyType, PlayedCard},
-    test_support::get_initialized_game,
+    test_support::get_test_game_with_board,
 };
 
 /// Test that CoinFlipToBlockAttack effect blocks attacks 50% of the time
 #[test]
 fn test_coin_flip_to_block_attack_effect() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.current_player = 0;
-
     // Set up attacker with CoinFlipToBlockAttack effect
     let mut charmander_played = PlayedCard::from_id(CardId::A1033Charmander)
         .with_energy(vec![EnergyType::Fire, EnergyType::Fire]);
     charmander_played.add_effect(CardEffect::CoinFlipToBlockAttack, 1);
 
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![charmander_played],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
-    game.set_state(state);
 
     let action = Action {
         actor: 0,

--- a/tests/copied_attack_test.rs
+++ b/tests/copied_attack_test.rs
@@ -2,7 +2,7 @@ use deckgym::{
     actions::{Action, SimpleAction},
     card_ids::CardId,
     models::{Card, EnergyType, PlayedCard},
-    test_support::get_initialized_game,
+    test_support::{get_initialized_game, get_test_game_with_board},
 };
 
 #[test]
@@ -66,23 +66,18 @@ fn test_genome_hacking_copies_simple_damage_attack() {
 
 #[test]
 fn test_genome_hacking_uses_copied_attack_as_mew_ex_attack() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
                 EnergyType::Psychic,
-                EnergyType::Psychic,
+        EnergyType::Psychic,
                 EnergyType::Psychic,
             ]),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
         vec![PlayedCard::from_id(CardId::A1115Abra)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -137,13 +132,10 @@ fn test_genome_hacking_uses_copied_attack_as_mew_ex_attack() {
 
 #[test]
 fn test_genome_hacking_only_offers_opponent_active_attacks() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
             EnergyType::Psychic,
-            EnergyType::Psychic,
+        EnergyType::Psychic,
             EnergyType::Psychic,
         ])],
         vec![
@@ -151,9 +143,7 @@ fn test_genome_hacking_only_offers_opponent_active_attacks() {
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -374,20 +364,15 @@ fn test_copy_a_friend_uses_own_non_ex_bench_attacks_only() {
 
 #[test]
 fn test_genome_hacking_filters_out_opponent_mew_ex_genome_hacking() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
             EnergyType::Psychic,
-            EnergyType::Psychic,
+        EnergyType::Psychic,
             EnergyType::Psychic,
         ])],
         vec![PlayedCard::from_id(CardId::A1a032MewEx)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -460,13 +445,10 @@ fn test_genome_hacking_does_not_offer_opponent_ditto_copy_anything() {
 
 #[test]
 fn test_copy_anything_does_not_offer_copy_attacks() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1205Ditto).with_energy(vec![
             EnergyType::Colorless,
-            EnergyType::Colorless,
+        EnergyType::Colorless,
             EnergyType::Colorless,
         ])],
         vec![
@@ -475,9 +457,7 @@ fn test_copy_anything_does_not_offer_copy_attacks() {
             PlayedCard::from_id(CardId::A1205Ditto),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -547,21 +527,17 @@ fn test_copy_anything_does_not_offer_copy_attacks() {
 
 #[test]
 fn test_copy_a_friend_does_not_offer_own_bench_copy_attacks() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::B1a055Ditto)
-                .with_energy(vec![EnergyType::Grass, EnergyType::Colorless]),
+                .with_energy(vec![EnergyType::Grass,
+        EnergyType::Colorless]),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::A1205Ditto),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -603,13 +579,10 @@ fn test_copy_a_friend_does_not_offer_own_bench_copy_attacks() {
 
 #[test]
 fn test_genome_hacking_best_effort_discards_only_matching_typed_energy() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
             EnergyType::Psychic,
-            EnergyType::Psychic,
+        EnergyType::Psychic,
             EnergyType::Psychic,
         ])],
         vec![
@@ -617,9 +590,7 @@ fn test_genome_hacking_best_effort_discards_only_matching_typed_energy() {
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -665,14 +636,11 @@ fn test_genome_hacking_best_effort_discards_only_matching_typed_energy() {
 
 #[test]
 fn test_genome_hacking_best_effort_discards_matching_energy_for_attackid_copy() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
                 EnergyType::Water,
-                EnergyType::Psychic,
+        EnergyType::Psychic,
                 EnergyType::Psychic,
             ]),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
@@ -682,9 +650,7 @@ fn test_genome_hacking_best_effort_discards_matching_energy_for_attackid_copy() 
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,

--- a/tests/copied_attack_test.rs
+++ b/tests/copied_attack_test.rs
@@ -70,14 +70,13 @@ fn test_genome_hacking_uses_copied_attack_as_mew_ex_attack() {
         vec![
             PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
                 EnergyType::Psychic,
-        EnergyType::Psychic,
+                EnergyType::Psychic,
                 EnergyType::Psychic,
             ]),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
         vec![PlayedCard::from_id(CardId::A1115Abra)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -135,7 +134,7 @@ fn test_genome_hacking_only_offers_opponent_active_attacks() {
     let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
             EnergyType::Psychic,
-        EnergyType::Psychic,
+            EnergyType::Psychic,
             EnergyType::Psychic,
         ])],
         vec![
@@ -143,7 +142,6 @@ fn test_genome_hacking_only_offers_opponent_active_attacks() {
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -367,12 +365,11 @@ fn test_genome_hacking_filters_out_opponent_mew_ex_genome_hacking() {
     let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
             EnergyType::Psychic,
-        EnergyType::Psychic,
+            EnergyType::Psychic,
             EnergyType::Psychic,
         ])],
         vec![PlayedCard::from_id(CardId::A1a032MewEx)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -448,7 +445,7 @@ fn test_copy_anything_does_not_offer_copy_attacks() {
     let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1205Ditto).with_energy(vec![
             EnergyType::Colorless,
-        EnergyType::Colorless,
+            EnergyType::Colorless,
             EnergyType::Colorless,
         ])],
         vec![
@@ -457,7 +454,6 @@ fn test_copy_anything_does_not_offer_copy_attacks() {
             PlayedCard::from_id(CardId::A1205Ditto),
         ],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -530,14 +526,12 @@ fn test_copy_a_friend_does_not_offer_own_bench_copy_attacks() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::B1a055Ditto)
-                .with_energy(vec![EnergyType::Grass,
-        EnergyType::Colorless]),
+                .with_energy(vec![EnergyType::Grass, EnergyType::Colorless]),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::A1205Ditto),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -582,7 +576,7 @@ fn test_genome_hacking_best_effort_discards_only_matching_typed_energy() {
     let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
             EnergyType::Psychic,
-        EnergyType::Psychic,
+            EnergyType::Psychic,
             EnergyType::Psychic,
         ])],
         vec![
@@ -590,7 +584,6 @@ fn test_genome_hacking_best_effort_discards_only_matching_typed_energy() {
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -640,7 +633,7 @@ fn test_genome_hacking_best_effort_discards_matching_energy_for_attackid_copy() 
         vec![
             PlayedCard::from_id(CardId::A1a032MewEx).with_energy(vec![
                 EnergyType::Water,
-        EnergyType::Psychic,
+                EnergyType::Psychic,
                 EnergyType::Psychic,
             ]),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
@@ -650,7 +643,6 @@ fn test_genome_hacking_best_effort_discards_matching_energy_for_attackid_copy() 
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
     );
-
 
     game.apply_action(&Action {
         actor: 0,

--- a/tests/darkrai_bad_dreams_test.rs
+++ b/tests/darkrai_bad_dreams_test.rs
@@ -5,22 +5,19 @@ use deckgym::{
     actions::{Action, SimpleAction},
     card_ids::CardId,
     models::{PlayedCard, StatusCondition},
-    test_support::get_initialized_game,
+    test_support::{get_initialized_game, get_test_game_with_board},
 };
 
 #[test]
 fn test_bad_dreams_deals_damage_when_opponent_asleep() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    // Darkrai (Bad Dreams) active for player 0; Caterpie (50 HP) asleep for player 1.
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::B2b040Darkrai)],
         vec![PlayedCard::from_id(CardId::A1005Caterpie)],
     );
+    let mut state = game.get_state_clone();
+
+    // Darkrai (Bad Dreams) active for player 0; Caterpie (50 HP) asleep for player 1.
     state.apply_status_condition(1, 0, StatusCondition::Asleep);
-    state.current_player = 0;
-    state.turn_count = 3;
     game.set_state(state);
 
     game.apply_action(&Action {
@@ -40,16 +37,10 @@ fn test_bad_dreams_deals_damage_when_opponent_asleep() {
 
 #[test]
 fn test_bad_dreams_no_damage_when_not_asleep() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::B2b040Darkrai)],
         vec![PlayedCard::from_id(CardId::A1005Caterpie)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
 
     game.apply_action(&Action {
         actor: 0,
@@ -68,16 +59,13 @@ fn test_bad_dreams_no_damage_when_not_asleep() {
 fn test_bad_dreams_triggers_at_end_of_each_turn() {
     // Darkrai belongs to player 1; player 0 ends their turn with an Asleep active.
     // The ability says "at the end of EACH turn", so it fires on the opponent's turn too.
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1005Caterpie)],
         vec![PlayedCard::from_id(CardId::B2b040Darkrai)],
     );
+    let mut state = game.get_state_clone();
+
     state.apply_status_condition(0, 0, StatusCondition::Asleep);
-    state.current_player = 0;
-    state.turn_count = 3;
     game.set_state(state);
 
     game.apply_action(&Action {
@@ -99,10 +87,7 @@ fn test_bad_dreams_triggers_at_end_of_each_turn() {
 fn test_bad_dreams_ko_during_end_turn_queues_promotion() {
     // Corner case: Bad Dreams KOs the opponent's Active Pokémon during end-turn processing.
     // The opponent must promote a benched Pokémon.
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::B2b040Darkrai)],
         vec![
             // Caterpie with only 10 HP left and Asleep — Bad Dreams (20 dmg) will KO it.
@@ -111,9 +96,9 @@ fn test_bad_dreams_ko_during_end_turn_queues_promotion() {
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
     );
+    let mut state = game.get_state_clone();
+
     state.apply_status_condition(1, 0, StatusCondition::Asleep);
-    state.current_player = 0;
-    state.turn_count = 3;
     game.set_state(state);
 
     game.apply_action(&Action {
@@ -149,19 +134,16 @@ fn test_bad_dreams_ko_during_end_turn_queues_promotion() {
 fn test_bad_dreams_multiple_darkrai_each_trigger_independently() {
     // Corner case: Two Darkrai in play for the same player each trigger Bad Dreams.
     // Combined damage should be 40 (2 × 20).
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::B2b040Darkrai), // active
             PlayedCard::from_id(CardId::B2b040Darkrai), // bench
         ],
         vec![PlayedCard::from_id(CardId::A1005Caterpie)],
     );
+    let mut state = game.get_state_clone();
+
     state.apply_status_condition(1, 0, StatusCondition::Asleep);
-    state.current_player = 0;
-    state.turn_count = 3;
     game.set_state(state);
 
     game.apply_action(&Action {

--- a/tests/mechanics/ability_effects_test.rs
+++ b/tests/mechanics/ability_effects_test.rs
@@ -191,7 +191,6 @@ fn test_glaceon_ex_snowy_terrain_damages_opponent_active_during_checkup() {
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
 
-
     let end_turn_action = Action {
         actor: 0,
         action: SimpleAction::EndTurn,
@@ -217,11 +216,10 @@ fn test_espeon_ex_psychic_healing_not_available_without_damaged_pokemon() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A4083EspeonEx),
-        PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
 
@@ -243,7 +241,6 @@ fn test_victreebel_fragrance_trap_not_available_without_benched_basic_target() {
         ],
     );
 
-
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
 
     assert!(
@@ -262,7 +259,6 @@ fn test_weezing_gas_leak_poisons_opponent_active() {
         vec![PlayedCard::from_id(CardId::A1177Weezing)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     let ability_action = Action {
         actor: 0,
@@ -288,7 +284,6 @@ fn test_indeedee_ex_watch_over_heals_active() {
         vec![PlayedCard::from_id(CardId::B1121IndeedeeEx).with_remaining_hp(80)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     let ability_action = Action {
         actor: 0,
@@ -319,7 +314,6 @@ fn test_pidgeot_drive_off_forces_opponent_switch() {
             PlayedCard::from_id(CardId::A1002Ivysaur),
         ],
     );
-
 
     let ability_action = Action {
         actor: 0,

--- a/tests/mechanics/ability_effects_test.rs
+++ b/tests/mechanics/ability_effects_test.rs
@@ -2,7 +2,7 @@ use deckgym::{
     actions::{Action, SimpleAction},
     card_ids::CardId,
     models::{EnergyType, PlayedCard},
-    test_support::get_initialized_game,
+    test_support::{get_initialized_game, get_test_game_with_board},
 };
 
 #[test]
@@ -186,16 +186,11 @@ fn test_giratina_ex_ability_end_turn_does_not_panic_if_ko_by_jolteon() {
 
 #[test]
 fn test_glaceon_ex_snowy_terrain_damages_opponent_active_during_checkup() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A2a022GlaceonEx)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let end_turn_action = Action {
         actor: 0,
@@ -219,19 +214,14 @@ fn test_glaceon_ex_snowy_terrain_damages_opponent_active_during_checkup() {
 
 #[test]
 fn test_espeon_ex_psychic_healing_not_available_without_damaged_pokemon() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A4083EspeonEx),
-            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
 
@@ -245,19 +235,14 @@ fn test_espeon_ex_psychic_healing_not_available_without_damaged_pokemon() {
 
 #[test]
 fn test_victreebel_fragrance_trap_not_available_without_benched_basic_target() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1020Victreebel)],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::A1002Ivysaur),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
 
@@ -273,16 +258,11 @@ fn test_victreebel_fragrance_trap_not_available_without_benched_basic_target() {
 fn test_weezing_gas_leak_poisons_opponent_active() {
     // Weezing's Gas Leak: Once during your turn, if this Pokémon is in the Active Spot,
     // you may make your opponent's Active Pokémon Poisoned.
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1177Weezing)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let ability_action = Action {
         actor: 0,
@@ -304,16 +284,11 @@ fn test_weezing_gas_leak_poisons_opponent_active() {
 #[test]
 fn test_indeedee_ex_watch_over_heals_active() {
     // Indeedee ex's Watch Over: Once during your turn, you may heal 20 damage from your Active Pokémon.
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::B1121IndeedeeEx).with_remaining_hp(80)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let ability_action = Action {
         actor: 0,
@@ -337,19 +312,14 @@ fn test_indeedee_ex_watch_over_heals_active() {
 fn test_pidgeot_drive_off_forces_opponent_switch() {
     // Pidgeot's Drive Off: Once during your turn, you may switch out your opponent's Active Pokémon
     // to the Bench. (Your opponent chooses the new Active Pokémon.)
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1188Pidgeot)],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::A1002Ivysaur),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let ability_action = Action {
         actor: 0,

--- a/tests/mega_scizor_ex_test.rs
+++ b/tests/mega_scizor_ex_test.rs
@@ -96,12 +96,11 @@ fn test_bullet_slugger_bonus_after_revavroom_metal_transport() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::B2b049Varoom),
-        PlayedCard::from_id(CardId::B2b050Revavroom),
+            PlayedCard::from_id(CardId::B2b050Revavroom),
             mega_scizor_ex_with_energy(),
         ],
         vec![fat_bulbasaur()],
     );
-
 
     // Use Revavroom's Metal Transport ability (bench index 1).
     game.apply_action(&Action {

--- a/tests/mega_scizor_ex_test.rs
+++ b/tests/mega_scizor_ex_test.rs
@@ -3,7 +3,7 @@ use deckgym::{
     card_ids::CardId,
     database::get_card_by_enum,
     models::{Card, EnergyType, PlayedCard, TrainerCard},
-    test_support::get_initialized_game,
+    test_support::{get_initialized_game, get_test_game_with_board},
 };
 
 fn trainer_from_id(card_id: CardId) -> TrainerCard {
@@ -93,22 +93,15 @@ fn test_bullet_slugger_bonus_after_regular_retreat() {
 /// Revavroom's Metal Transport ability moves Mega Scizor ex to active, triggering the 50 extra damage.
 #[test]
 fn test_bullet_slugger_bonus_after_revavroom_metal_transport() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    // Varoom (Metal type) is active; Revavroom is on bench 1 with its ability unused;
-    // Mega Scizor ex is on bench 2 with full energy.
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::B2b049Varoom),
-            PlayedCard::from_id(CardId::B2b050Revavroom),
+        PlayedCard::from_id(CardId::B2b050Revavroom),
             mega_scizor_ex_with_energy(),
         ],
         vec![fat_bulbasaur()],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     // Use Revavroom's Metal Transport ability (bench index 1).
     game.apply_action(&Action {

--- a/tests/pokemon/legacy_ability_logic_test.rs
+++ b/tests/pokemon/legacy_ability_logic_test.rs
@@ -28,7 +28,6 @@ fn test_victreebel_fragrance_trap_switches_benched_basic_to_active() {
         ],
     );
 
-
     game.apply_action(&Action {
         actor: 0,
         action: SimpleAction::UseAbility { in_play_idx: 0 },
@@ -100,7 +99,6 @@ fn test_gardevoir_attaches_psychic_energy_to_active() {
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
 
-
     game.apply_action(&Action {
         actor: 0,
         action: SimpleAction::UseAbility { in_play_idx: 0 },
@@ -117,12 +115,11 @@ fn test_vaporeon_wash_out_moves_water_energy_to_active() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1053Squirtle),
-        PlayedCard::from_id(CardId::A1a019Vaporeon),
+            PlayedCard::from_id(CardId::A1a019Vaporeon),
             PlayedCard::from_id(CardId::A1055Blastoise).with_energy(vec![EnergyType::Water]),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -176,11 +173,10 @@ fn test_giratina_levitate_allows_retreat_with_energy_attached() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A2078Giratina).with_energy(vec![EnergyType::Psychic]),
-        PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
     assert!(actions
@@ -194,7 +190,6 @@ fn test_giratina_ex_broken_space_bellow_attaches_energy_and_offers_end_turn() {
         vec![PlayedCard::from_id(CardId::A2b035GiratinaEx)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -219,11 +214,10 @@ fn test_solgaleo_ex_rising_road_switches_from_bench() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
-        PlayedCard::from_id(CardId::A3122SolgaleoEx),
+            PlayedCard::from_id(CardId::A3122SolgaleoEx),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -279,11 +273,10 @@ fn test_celesteela_ultra_thrusters_switches_ultra_beast() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A3a042Nihilego),
-        PlayedCard::from_id(CardId::A3a062Celesteela),
+            PlayedCard::from_id(CardId::A3a062Celesteela),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -339,11 +332,10 @@ fn test_espeon_ex_psychic_healing_heals_selected_pokemon() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A4083EspeonEx),
-        PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(40),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(40),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -374,11 +366,10 @@ fn test_crobat_cunning_link_damages_opponent_active() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A2a050Crobat),
-        PlayedCard::from_id(CardId::A2a071ArceusEx),
+            PlayedCard::from_id(CardId::A2a071ArceusEx),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -398,7 +389,6 @@ fn test_umbreon_ex_dark_chase_switches_damaged_bench_to_active() {
             PlayedCard::from_id(CardId::A1002Ivysaur).with_damage(20),
         ],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -424,11 +414,9 @@ fn test_umbreon_ex_dark_chase_switches_damaged_bench_to_active() {
 fn test_oricorio_safeguard_prevents_damage_from_ex_attack() {
     let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1129MewtwoEx)
-            .with_energy(vec![EnergyType::Psychic,
-        EnergyType::Colorless])],
+            .with_energy(vec![EnergyType::Psychic, EnergyType::Colorless])],
         vec![PlayedCard::from_id(CardId::A3066Oricorio)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -445,7 +433,6 @@ fn test_komala_comatose_puts_it_to_sleep_on_zone_attach() {
         vec![PlayedCard::from_id(CardId::A3141Komala)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -530,7 +517,6 @@ fn test_snorlax_ex_full_mouth_manner_heals_at_end_of_turn() {
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
 
-
     game.apply_action(&Action {
         actor: 0,
         action: SimpleAction::EndTurn,
@@ -601,7 +587,6 @@ fn test_cresselia_ex_lunar_plumage_heals_on_psychic_attach() {
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
 
-
     game.apply_action(&Action {
         actor: 0,
         action: SimpleAction::Attach {
@@ -619,14 +604,13 @@ fn test_ariados_trap_territory_increases_retreat_cost() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass]),
-        PlayedCard::from_id(CardId::A1053Squirtle),
+            PlayedCard::from_id(CardId::A1053Squirtle),
         ],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::B1a006Ariados),
         ],
     );
-
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
     assert!(!actions
@@ -638,14 +622,12 @@ fn test_ariados_trap_territory_increases_retreat_cost() {
 fn test_wartortle_shell_shield_prevents_bench_damage() {
     let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A4a025RaikouEx)
-            .with_energy(vec![EnergyType::Lightning,
-        EnergyType::Lightning])],
+            .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning])],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::B1a018Wartortle),
         ],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -677,7 +659,6 @@ fn test_reuniclus_infinite_increase_raises_effective_hp_on_attach() {
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
 
-
     game.apply_action(&Action {
         actor: 0,
         action: SimpleAction::Attach {
@@ -697,7 +678,6 @@ fn test_goomy_sticky_membrane_blocks_exact_cost_attack() {
         vec![PlayedCard::from_id(CardId::B1177Goomy)],
     );
 
-
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
     assert!(!actions
         .iter()
@@ -710,13 +690,12 @@ fn test_aegislash_cursed_metal_boosts_its_own_attack_damage() {
         vec![
             PlayedCard::from_id(CardId::B1172Aegislash).with_energy(vec![
                 EnergyType::Metal,
-        EnergyType::Colorless,
+                EnergyType::Colorless,
                 EnergyType::Colorless,
             ]),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     game.apply_action(&Action {
         actor: 0,
@@ -777,12 +756,11 @@ fn test_shaymin_sky_support_reduces_active_basic_retreat_cost() {
     let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
-        PlayedCard::from_id(CardId::A2a069Shaymin),
+            PlayedCard::from_id(CardId::A2a069Shaymin),
             PlayedCard::from_id(CardId::A1053Squirtle),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
     assert!(actions

--- a/tests/pokemon/legacy_ability_logic_test.rs
+++ b/tests/pokemon/legacy_ability_logic_test.rs
@@ -3,7 +3,7 @@ use deckgym::{
     card_ids::CardId,
     database::get_card_by_enum,
     models::{EnergyType, PlayedCard},
-    test_support::get_initialized_game,
+    test_support::{get_initialized_game, get_test_game_with_board},
     Game,
 };
 
@@ -20,18 +20,14 @@ where
 
 #[test]
 fn test_victreebel_fragrance_trap_switches_benched_basic_to_active() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1020Victreebel)],
         vec![
             PlayedCard::from_id(CardId::A1002Ivysaur),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -99,15 +95,11 @@ fn test_gengar_ex_shadowy_spellbind_blocks_supporters() {
 
 #[test]
 fn test_gardevoir_attaches_psychic_energy_to_active() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1132Gardevoir)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -122,19 +114,15 @@ fn test_gardevoir_attaches_psychic_energy_to_active() {
 
 #[test]
 fn test_vaporeon_wash_out_moves_water_energy_to_active() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1053Squirtle),
-            PlayedCard::from_id(CardId::A1a019Vaporeon),
+        PlayedCard::from_id(CardId::A1a019Vaporeon),
             PlayedCard::from_id(CardId::A1055Blastoise).with_energy(vec![EnergyType::Water]),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -185,18 +173,14 @@ fn test_aerodactyl_ex_primeval_law_blocks_active_evolution() {
 
 #[test]
 fn test_giratina_levitate_allows_retreat_with_energy_attached() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A2078Giratina).with_energy(vec![EnergyType::Psychic]),
-            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        PlayedCard::from_id(CardId::A1001Bulbasaur),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
     assert!(actions
@@ -206,15 +190,11 @@ fn test_giratina_levitate_allows_retreat_with_energy_attached() {
 
 #[test]
 fn test_giratina_ex_broken_space_bellow_attaches_energy_and_offers_end_turn() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A2b035GiratinaEx)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -236,18 +216,14 @@ fn test_giratina_ex_broken_space_bellow_attaches_energy_and_offers_end_turn() {
 
 #[test]
 fn test_solgaleo_ex_rising_road_switches_from_bench() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
-            PlayedCard::from_id(CardId::A3122SolgaleoEx),
+        PlayedCard::from_id(CardId::A3122SolgaleoEx),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -300,18 +276,14 @@ fn test_shiinotic_illuminate_puts_pokemon_from_deck_into_hand() {
 
 #[test]
 fn test_celesteela_ultra_thrusters_switches_ultra_beast() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A3a042Nihilego),
-            PlayedCard::from_id(CardId::A3a062Celesteela),
+        PlayedCard::from_id(CardId::A3a062Celesteela),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -364,18 +336,14 @@ fn test_flareon_ex_combust_attaches_from_discard_and_damages_self() {
 
 #[test]
 fn test_espeon_ex_psychic_healing_heals_selected_pokemon() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A4083EspeonEx),
-            PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(40),
+        PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(40),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -403,18 +371,14 @@ fn test_espeon_ex_psychic_healing_heals_selected_pokemon() {
 
 #[test]
 fn test_crobat_cunning_link_damages_opponent_active() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A2a050Crobat),
-            PlayedCard::from_id(CardId::A2a071ArceusEx),
+        PlayedCard::from_id(CardId::A2a071ArceusEx),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -427,18 +391,14 @@ fn test_crobat_cunning_link_damages_opponent_active() {
 
 #[test]
 fn test_umbreon_ex_dark_chase_switches_damaged_bench_to_active() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A4112UmbreonEx)],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::A1002Ivysaur).with_damage(20),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -462,16 +422,13 @@ fn test_umbreon_ex_dark_chase_switches_damaged_bench_to_active() {
 
 #[test]
 fn test_oricorio_safeguard_prevents_damage_from_ex_attack() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1129MewtwoEx)
-            .with_energy(vec![EnergyType::Psychic, EnergyType::Colorless])],
+            .with_energy(vec![EnergyType::Psychic,
+        EnergyType::Colorless])],
         vec![PlayedCard::from_id(CardId::A3066Oricorio)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -484,15 +441,11 @@ fn test_oricorio_safeguard_prevents_damage_from_ex_attack() {
 
 #[test]
 fn test_komala_comatose_puts_it_to_sleep_on_zone_attach() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A3141Komala)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -572,15 +525,11 @@ fn test_sylveon_ex_happy_ribbon_draws_two_on_evolve() {
 
 #[test]
 fn test_snorlax_ex_full_mouth_manner_heals_at_end_of_turn() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A3b057SnorlaxEx).with_damage(20)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -647,15 +596,11 @@ fn test_milotic_healing_ripples_heals_on_evolve() {
 
 #[test]
 fn test_cresselia_ex_lunar_plumage_heals_on_psychic_attach() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::PA037CresseliaEx).with_damage(40)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -671,21 +616,17 @@ fn test_cresselia_ex_lunar_plumage_heals_on_psychic_attach() {
 
 #[test]
 fn test_ariados_trap_territory_increases_retreat_cost() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass]),
-            PlayedCard::from_id(CardId::A1053Squirtle),
+        PlayedCard::from_id(CardId::A1053Squirtle),
         ],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::B1a006Ariados),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
     assert!(!actions
@@ -695,19 +636,16 @@ fn test_ariados_trap_territory_increases_retreat_cost() {
 
 #[test]
 fn test_wartortle_shell_shield_prevents_bench_damage() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A4a025RaikouEx)
-            .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning])],
+            .with_energy(vec![EnergyType::Lightning,
+        EnergyType::Lightning])],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::B1a018Wartortle),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -734,15 +672,11 @@ fn test_wartortle_shell_shield_prevents_bench_damage() {
 
 #[test]
 fn test_reuniclus_infinite_increase_raises_effective_hp_on_attach() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::B1a034Reuniclus).with_damage(20)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -758,15 +692,11 @@ fn test_reuniclus_infinite_increase_raises_effective_hp_on_attach() {
 
 #[test]
 fn test_goomy_sticky_membrane_blocks_exact_cost_attack() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A2091Riolu).with_energy(vec![EnergyType::Fighting])],
         vec![PlayedCard::from_id(CardId::B1177Goomy)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
     assert!(!actions
@@ -776,21 +706,17 @@ fn test_goomy_sticky_membrane_blocks_exact_cost_attack() {
 
 #[test]
 fn test_aegislash_cursed_metal_boosts_its_own_attack_damage() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::B1172Aegislash).with_energy(vec![
                 EnergyType::Metal,
-                EnergyType::Colorless,
+        EnergyType::Colorless,
                 EnergyType::Colorless,
             ]),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     game.apply_action(&Action {
         actor: 0,
@@ -848,19 +774,15 @@ fn test_nihilego_more_poison_increases_poison_damage() {
 
 #[test]
 fn test_shaymin_sky_support_reduces_active_basic_retreat_cost() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
-            PlayedCard::from_id(CardId::A2a069Shaymin),
+        PlayedCard::from_id(CardId::A2a069Shaymin),
             PlayedCard::from_id(CardId::A1053Squirtle),
         ],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
+
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
     assert!(actions

--- a/tests/pokemon/vaporeon_ex_test.rs
+++ b/tests/pokemon/vaporeon_ex_test.rs
@@ -2,24 +2,18 @@ use deckgym::{
     actions::{Action, SimpleAction},
     card_ids::CardId,
     models::PlayedCard,
-    test_support::get_initialized_game,
+    test_support::get_test_game_with_board,
 };
 
 #[test]
 fn test_vaporeon_ex_frozen_flow_forces_opponent_switch() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::B3037VaporeonEx)],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::A1002Ivysaur),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
 
     let ability_action = Action {
         actor: 0,
@@ -37,10 +31,7 @@ fn test_vaporeon_ex_frozen_flow_forces_opponent_switch() {
 
 #[test]
 fn test_vaporeon_ex_frozen_flow_not_available_from_bench() {
-    let mut game = get_initialized_game(0);
-    let mut state = game.get_state_clone();
-
-    state.set_board(
+    let mut game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::B3037VaporeonEx),
@@ -50,9 +41,6 @@ fn test_vaporeon_ex_frozen_flow_not_available_from_bench() {
             PlayedCard::from_id(CardId::A1003Venusaur),
         ],
     );
-    state.current_player = 0;
-    state.turn_count = 3;
-    game.set_state(state);
 
     let (_actor, actions) = game.get_state_clone().generate_possible_actions();
     assert!(!actions


### PR DESCRIPTION
## Summary
Refactored multiple test files to use the `get_test_game_with_board` helper function instead of manually creating a game, cloning state, setting the board, and configuring turn state. This reduces boilerplate code and improves test readability.

## Key Changes
- Updated imports across 7 test files to include `get_test_game_with_board` from `test_support`
- Replaced repetitive test setup pattern:
  ```rust
  let mut game = get_initialized_game(0);
  let mut state = game.get_state_clone();
  state.set_board(active, bench);
  state.current_player = 0;
  state.turn_count = 3;
  game.set_state(state);
  ```
  with:
  ```rust
  let mut game = get_test_game_with_board(active, bench);
  ```
- Applied refactoring to 50+ test functions across:
  - `tests/pokemon/legacy_ability_logic_test.rs`
  - `tests/copied_attack_test.rs`
  - `tests/mechanics/ability_effects_test.rs`
  - `tests/darkrai_bad_dreams_test.rs`
  - `tests/ability_mechanic_examples_test.rs`
  - `tests/pokemon/vaporeon_ex_test.rs`
  - `tests/mega_scizor_ex_test.rs`
  - `tests/coin_flip_effect_test.rs`

## Implementation Details
- The `get_test_game_with_board` helper encapsulates the common initialization pattern, automatically setting `current_player = 0` and `turn_count = 3`
- In `darkrai_bad_dreams_test.rs`, status conditions are applied after calling the helper (since they require state manipulation after board setup)
- Minor formatting adjustments were made to maintain consistent indentation in multi-line array literals

https://claude.ai/code/session_01TtFwQRAoZH5AHCTJSmcpfe