### PR TITLE
Implement Arena of Antiquity, Fragrant Forest stadiums and Lucky Egg tool

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -14,7 +14,7 @@ use crate::{
     effects::TurnEffect,
     hooks::{get_retreat_cost, on_evolve, to_playable_card},
     models::{Card, EnergyType},
-    stadiums::is_mesagoza_active,
+    stadiums::{is_fragrant_forest_active, is_mesagoza_active},
     state::State,
     tools,
 };
@@ -739,13 +739,14 @@ fn apply_heal_all_eevee_evolutions(acting_player: usize, state: &mut State) {
     }
 }
 
-/// Forecasts the UseStadium action for activated stadiums like Mesagoza.
+/// Forecasts the UseStadium action for activated stadiums like Mesagoza and Fragrant Forest.
 fn forecast_use_stadium(state: &State, acting_player: usize) -> Outcomes {
-    // Currently only Mesagoza has an activated effect
     if is_mesagoza_active(state) {
         return forecast_mesagoza_effect(state, acting_player);
     }
-    // No other activated stadiums for now, just mark as used
+    if is_fragrant_forest_active(state) {
+        return forecast_fragrant_forest_effect(state, acting_player);
+    }
     Outcomes::single_fn(|_, _, _| {})
 }
 
@@ -774,6 +775,36 @@ fn forecast_mesagoza_effect(state: &State, acting_player: usize) -> Outcomes {
 
     // Not `binary_coin`: heads fans out into many weighted search outcomes, not one mutation.
     Outcomes::from_coin_branches(branches).expect("Mesagoza coin branches should be valid")
+}
+
+/// Fragrant Forest: Once during each player's turn, that player may put a random Basic [G] Pokémon from their deck into their hand.
+fn forecast_fragrant_forest_effect(state: &State, acting_player: usize) -> Outcomes {
+    let basic_grass: Vec<Card> = state.decks[acting_player]
+        .cards
+        .iter()
+        .filter(|card| {
+            matches!(card, Card::Pokemon(p) if p.stage == 0 && p.energy_type == EnergyType::Grass)
+        })
+        .cloned()
+        .collect();
+
+    if basic_grass.is_empty() {
+        return Outcomes::single_fn(|_, state, action| {
+            state.has_used_stadium[action.actor] = true;
+        });
+    }
+
+    let num = basic_grass.len();
+    let prob = 1.0 / num as f64;
+    let mut outcomes: Mutations = vec![];
+    for pokemon in basic_grass {
+        outcomes.push(Box::new(move |_, state, action| {
+            state.has_used_stadium[action.actor] = true;
+            state.transfer_card_from_deck_to_hand(action.actor, &pokemon);
+            debug!("Fragrant Forest: Moved {} to hand", pokemon.get_name());
+        }));
+    }
+    Outcomes::from_parts(vec![prob; num], outcomes)
 }
 
 // Test that when evolving a damanged pokemon, damage stays.

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -9,7 +9,7 @@ use crate::{
         abilities::AbilityMechanic,
         apply_abilities_action::forecast_ability,
         apply_action_helpers::{wrap_with_common_logic, Mutation},
-        shared_mutations::pokemon_search_outcomes,
+        shared_mutations::{pokemon_search_outcomes, pokemon_search_outcomes_by_type_for_player},
     },
     effects::TurnEffect,
     hooks::{get_retreat_cost, on_evolve, to_playable_card},
@@ -779,32 +779,13 @@ fn forecast_mesagoza_effect(state: &State, acting_player: usize) -> Outcomes {
 
 /// Fragrant Forest: Once during each player's turn, that player may put a random Basic [G] Pokémon from their deck into their hand.
 fn forecast_fragrant_forest_effect(state: &State, acting_player: usize) -> Outcomes {
-    let basic_grass: Vec<Card> = state.decks[acting_player]
-        .cards
-        .iter()
-        .filter(|card| {
-            matches!(card, Card::Pokemon(p) if p.stage == 0 && p.energy_type == EnergyType::Grass)
+    pokemon_search_outcomes_by_type_for_player(acting_player, state, true, EnergyType::Grass)
+        .map_mutations(|mutation| {
+            Box::new(move |rng, state, action| {
+                state.has_used_stadium[action.actor] = true;
+                mutation(rng, state, action);
+            })
         })
-        .cloned()
-        .collect();
-
-    if basic_grass.is_empty() {
-        return Outcomes::single_fn(|_, state, action| {
-            state.has_used_stadium[action.actor] = true;
-        });
-    }
-
-    let num = basic_grass.len();
-    let prob = 1.0 / num as f64;
-    let mut outcomes: Mutations = vec![];
-    for pokemon in basic_grass {
-        outcomes.push(Box::new(move |_, state, action| {
-            state.has_used_stadium[action.actor] = true;
-            state.transfer_card_from_deck_to_hand(action.actor, &pokemon);
-            debug!("Fragrant Forest: Moved {} to hand", pokemon.get_name());
-        }));
-    }
-    Outcomes::from_parts(vec![prob; num], outcomes)
 }
 
 // Test that when evolving a damanged pokemon, damage stays.

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -527,7 +527,13 @@ pub(crate) fn handle_knockouts(
     // Handle knockouts: Discard cards and award points (to potentially short-circuit promotions)
     for (ko_receiver, ko_pokemon_idx) in knockouts.clone() {
         // Call knockout hook (e.g., for Electrical Cord)
-        on_knockout(state, ko_receiver, ko_pokemon_idx, is_from_active_attack);
+        on_knockout(
+            state,
+            ko_receiver,
+            ko_pokemon_idx,
+            attacking_ref,
+            is_from_active_attack,
+        );
         on_attack_knockout(state, attacking_ref, ko_receiver, is_from_active_attack);
 
         // Award points

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -11,7 +11,10 @@ use crate::{
     card_ids::CardId,
     effects::{CardEffect, TurnEffect},
     models::{Card, EnergyType, PlayedCard, TrainerCard, TrainerType, BASIC_STAGE},
-    stadiums::{get_training_area_damage_bonus, is_bounded_field_active, is_hiking_trail_active},
+    stadiums::{
+        get_arena_of_antiquity_damage_bonus, get_training_area_damage_bonus,
+        is_bounded_field_active, is_hiking_trail_active,
+    },
     tools::has_tool,
     State,
 };
@@ -851,7 +854,15 @@ pub(crate) fn modify_damage(
     // Stadium damage bonus (e.g., Training Area for Stage 1 Pokemon)
     // Only applies to attacks against the opponent's Active Pokemon
     let stadium_damage_bonus = if is_active_to_active {
-        get_training_area_damage_bonus(state, get_stage(attacking_pokemon))
+        let training_area = get_training_area_damage_bonus(state, get_stage(attacking_pokemon));
+        let arena_of_antiquity = get_arena_of_antiquity_damage_bonus(
+            state,
+            attacking_pokemon
+                .get_energy_type()
+                .unwrap_or(EnergyType::Colorless),
+            target_is_ex,
+        );
+        training_area + arena_of_antiquity
     } else {
         0
     };
@@ -1019,8 +1030,28 @@ pub(crate) fn on_knockout(
     state: &mut State,
     knocked_out_player: usize,
     knocked_out_idx: usize,
+    attacking_ref: (usize, usize),
     is_from_active_attack: bool,
 ) {
+    // Handle Lucky Egg: draw until hand has 5 when KO'd by opponent's active attack
+    let is_opponent_attack = is_from_active_attack && attacking_ref.0 != knocked_out_player;
+    let has_lucky_egg = {
+        let knocked_out_pokemon = state.in_play_pokemon[knocked_out_player][knocked_out_idx]
+            .as_ref()
+            .expect("Pokemon should be there if knocked out");
+        has_tool(knocked_out_pokemon, CardId::B3148LuckyEgg)
+    };
+    if has_lucky_egg && is_opponent_attack {
+        debug!("Lucky Egg: Drawing cards until hand has 5");
+        let draws_needed = 5usize.saturating_sub(state.hands[knocked_out_player].len());
+        for _ in 0..draws_needed {
+            if state.decks[knocked_out_player].cards.is_empty() {
+                break;
+            }
+            state.maybe_draw_card(knocked_out_player);
+        }
+    }
+
     let knocked_out_pokemon = state.in_play_pokemon[knocked_out_player][knocked_out_idx]
         .as_ref()
         .expect("Pokemon should be there if knocked out");

--- a/src/move_generation/mod.rs
+++ b/src/move_generation/mod.rs
@@ -5,7 +5,7 @@ mod move_generation_trainer;
 use crate::actions::{abilities::AbilityMechanic, get_ability_mechanic, Action, SimpleAction};
 use crate::hooks::{can_evolve_into, can_retreat, contains_energy, get_retreat_cost};
 use crate::models::Card;
-use crate::stadiums::can_use_mesagoza;
+use crate::stadiums::{can_use_fragrant_forest, can_use_mesagoza};
 use crate::state::State;
 
 use attacks::generate_attack_actions;
@@ -109,8 +109,8 @@ pub fn generate_possible_actions(state: &State) -> (usize, Vec<Action>) {
     let ability_actions = generate_ability_actions(state);
     actions.extend(ability_actions);
 
-    // Add actions given by active stadium (activated stadiums like Mesagoza)
-    if can_use_mesagoza(state, current_player) {
+    // Add actions given by active stadium (activated stadiums like Mesagoza, Fragrant Forest)
+    if can_use_mesagoza(state, current_player) || can_use_fragrant_forest(state, current_player) {
         actions.push(SimpleAction::UseStadium);
     }
 

--- a/src/stadiums.rs
+++ b/src/stadiums.rs
@@ -42,6 +42,10 @@ static HIKING_TRAIL_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B2b069HikingTrail));
 static BOUNDED_FIELD_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3155BoundedField));
+static ARENA_OF_ANTIQUITY_EFFECT: LazyLock<String> =
+    LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3154ArenaofAntiquity));
+static FRAGRANT_FOREST_EFFECT: LazyLock<String> =
+    LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3153FragrantForest));
 
 pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
     ensure_stadium_trainer(trainer_card);
@@ -54,6 +58,8 @@ pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == MESAGOZA_EFFECT.as_str()
             || e == HIKING_TRAIL_EFFECT.as_str()
             || e == BOUNDED_FIELD_EFFECT.as_str()
+            || e == ARENA_OF_ANTIQUITY_EFFECT.as_str()
+            || e == FRAGRANT_FOREST_EFFECT.as_str()
     )
 }
 
@@ -116,4 +122,43 @@ pub fn get_training_area_damage_bonus(state: &State, attacker_stage: u8) -> u32 
     } else {
         0
     }
+}
+
+pub fn is_arena_of_antiquity_active(state: &State) -> bool {
+    has_stadium(state, CardId::B3154ArenaofAntiquity)
+}
+
+/// Returns the damage bonus for Arena of Antiquity.
+/// Arena of Antiquity: "Attacks used by each [F] Pokémon in play (both yours and your opponent's) do +20 damage to the opponent's Active Pokémon ex."
+pub fn get_arena_of_antiquity_damage_bonus(
+    state: &State,
+    attacker_energy_type: EnergyType,
+    target_is_ex: bool,
+) -> u32 {
+    if attacker_energy_type == EnergyType::Fighting
+        && target_is_ex
+        && is_arena_of_antiquity_active(state)
+    {
+        20
+    } else {
+        0
+    }
+}
+
+pub fn is_fragrant_forest_active(state: &State) -> bool {
+    has_stadium(state, CardId::B3153FragrantForest)
+}
+
+/// Returns true if the player can use Fragrant Forest's effect (stadium is active, not used this turn, deck has Basic Grass Pokemon)
+pub fn can_use_fragrant_forest(state: &State, player: usize) -> bool {
+    if !is_fragrant_forest_active(state) {
+        return false;
+    }
+    if state.has_used_stadium[player] {
+        return false;
+    }
+    state.decks[player]
+        .cards
+        .iter()
+        .any(|card| matches!(card, Card::Pokemon(p) if p.stage == 0 && p.energy_type == EnergyType::Grass))
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -52,6 +52,8 @@ static METAL_CORE_BARRIER_EFFECT: LazyLock<String> =
     LazyLock::new(|| tool_effect_text_from_card_id(CardId::B2148MetalCoreBarrier));
 static BIG_AIR_BALLOON_EFFECT: LazyLock<String> =
     LazyLock::new(|| tool_effect_text_from_card_id(CardId::B2a087BigAirBalloon));
+static LUCKY_EGG_EFFECT: LazyLock<String> =
+    LazyLock::new(|| tool_effect_text_from_card_id(CardId::B3148LuckyEgg));
 
 pub fn tool_effects_equal(trainer_card: &TrainerCard, reference_tool_id: CardId) -> bool {
     ensure_tool_trainer(trainer_card);
@@ -120,5 +122,6 @@ pub fn is_tool_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == PROTECTIVE_PONCHO_EFFECT.as_str()
             || e == METAL_CORE_BARRIER_EFFECT.as_str()
             || e == BIG_AIR_BALLOON_EFFECT.as_str()
+            || e == LUCKY_EGG_EFFECT.as_str()
     )
 }

--- a/tests/mechanics/ability_effects_test.rs
+++ b/tests/mechanics/ability_effects_test.rs
@@ -213,7 +213,7 @@ fn test_glaceon_ex_snowy_terrain_damages_opponent_active_during_checkup() {
 
 #[test]
 fn test_espeon_ex_psychic_healing_not_available_without_damaged_pokemon() {
-    let mut game = get_test_game_with_board(
+    let game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A4083EspeonEx),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
@@ -233,7 +233,7 @@ fn test_espeon_ex_psychic_healing_not_available_without_damaged_pokemon() {
 
 #[test]
 fn test_victreebel_fragrance_trap_not_available_without_benched_basic_target() {
-    let mut game = get_test_game_with_board(
+    let game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A1020Victreebel)],
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),

--- a/tests/pokemon/legacy_ability_logic_test.rs
+++ b/tests/pokemon/legacy_ability_logic_test.rs
@@ -170,7 +170,7 @@ fn test_aerodactyl_ex_primeval_law_blocks_active_evolution() {
 
 #[test]
 fn test_giratina_levitate_allows_retreat_with_energy_attached() {
-    let mut game = get_test_game_with_board(
+    let game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A2078Giratina).with_energy(vec![EnergyType::Psychic]),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
@@ -601,7 +601,7 @@ fn test_cresselia_ex_lunar_plumage_heals_on_psychic_attach() {
 
 #[test]
 fn test_ariados_trap_territory_increases_retreat_cost() {
-    let mut game = get_test_game_with_board(
+    let game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass]),
             PlayedCard::from_id(CardId::A1053Squirtle),
@@ -673,7 +673,7 @@ fn test_reuniclus_infinite_increase_raises_effective_hp_on_attach() {
 
 #[test]
 fn test_goomy_sticky_membrane_blocks_exact_cost_attack() {
-    let mut game = get_test_game_with_board(
+    let game = get_test_game_with_board(
         vec![PlayedCard::from_id(CardId::A2091Riolu).with_energy(vec![EnergyType::Fighting])],
         vec![PlayedCard::from_id(CardId::B1177Goomy)],
     );
@@ -753,7 +753,7 @@ fn test_nihilego_more_poison_increases_poison_damage() {
 
 #[test]
 fn test_shaymin_sky_support_reduces_active_basic_retreat_cost() {
-    let mut game = get_test_game_with_board(
+    let game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::A2a069Shaymin),

--- a/tests/pokemon/vaporeon_ex_test.rs
+++ b/tests/pokemon/vaporeon_ex_test.rs
@@ -31,7 +31,7 @@ fn test_vaporeon_ex_frozen_flow_forces_opponent_switch() {
 
 #[test]
 fn test_vaporeon_ex_frozen_flow_not_available_from_bench() {
-    let mut game = get_test_game_with_board(
+    let game = get_test_game_with_board(
         vec![
             PlayedCard::from_id(CardId::A1001Bulbasaur),
             PlayedCard::from_id(CardId::B3037VaporeonEx),

--- a/tests/stadiums.rs
+++ b/tests/stadiums.rs
@@ -1,2 +1,6 @@
+#[path = "stadiums/arena_of_antiquity_test.rs"]
+mod arena_of_antiquity_test;
+#[path = "stadiums/fragrant_forest_test.rs"]
+mod fragrant_forest_test;
 #[path = "stadiums/stadium_test.rs"]
 mod stadium_test;

--- a/tests/stadiums/arena_of_antiquity_test.rs
+++ b/tests/stadiums/arena_of_antiquity_test.rs
@@ -1,0 +1,169 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn trainer_from_id(card_id: CardId) -> deckgym::models::TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+/// Sets up a game with Machop (player 0) vs Machamp ex (player 1),
+/// optionally with Arena of Antiquity active.
+fn setup_game_with_fighting_vs_ex(with_stadium: bool) -> deckgym::Game<'static> {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1143Machop).with_energy(vec![EnergyType::Fighting])],
+        vec![PlayedCard::from_id(CardId::A1146MachampEx)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+
+    if with_stadium {
+        state.hands[0] = vec![get_card_by_enum(CardId::B3154ArenaofAntiquity)];
+    }
+
+    game.set_state(state);
+
+    if with_stadium {
+        let trainer_card = trainer_from_id(CardId::B3154ArenaofAntiquity);
+        let play_action = Action {
+            actor: 0,
+            action: SimpleAction::Play { trainer_card },
+            is_stack: false,
+        };
+        game.apply_action(&play_action);
+    }
+
+    game
+}
+
+fn get_remaining_hp_after_damage(game: &mut deckgym::Game<'static>, damage: u32) -> u32 {
+    let action = Action {
+        actor: 0,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (0, 0),
+            targets: vec![(damage, 1, 0)],
+            is_from_active_attack: true,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&action);
+    game.get_state_clone().in_play_pokemon[1][0]
+        .as_ref()
+        .map(|p| p.get_remaining_hp())
+        .unwrap_or(0)
+}
+
+#[test]
+fn test_arena_of_antiquity_boosts_fighting_vs_ex() {
+    let machamp_ex_hp = match get_card_by_enum(CardId::A1146MachampEx) {
+        Card::Pokemon(p) => p.hp,
+        _ => panic!("Expected Pokemon"),
+    };
+
+    // Without stadium: deal 20 damage, measure remaining HP
+    let mut game_no_stadium = setup_game_with_fighting_vs_ex(false);
+    let remaining_no_stadium = get_remaining_hp_after_damage(&mut game_no_stadium, 20);
+
+    // With stadium: deal 20 damage, measure remaining HP (should be 20 less)
+    let mut game_with_stadium = setup_game_with_fighting_vs_ex(true);
+    let remaining_with_stadium = get_remaining_hp_after_damage(&mut game_with_stadium, 20);
+
+    let damage_without = machamp_ex_hp - remaining_no_stadium;
+    let damage_with = machamp_ex_hp - remaining_with_stadium;
+
+    assert_eq!(
+        damage_with.saturating_sub(damage_without),
+        20,
+        "Arena of Antiquity should add +20 damage for Fighting vs ex (without={damage_without}, with={damage_with})"
+    );
+}
+
+#[test]
+fn test_arena_of_antiquity_no_boost_vs_non_ex() {
+    // Arena of Antiquity does NOT boost Fighting vs non-ex pokemon
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1143Machop).with_energy(vec![EnergyType::Fighting])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)], // non-ex
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+    state.hands[0] = vec![get_card_by_enum(CardId::B3154ArenaofAntiquity)];
+    game.set_state(state);
+
+    let bulbasaur_hp = match get_card_by_enum(CardId::A1001Bulbasaur) {
+        Card::Pokemon(p) => p.hp,
+        _ => panic!("Expected Pokemon"),
+    };
+
+    // Play Arena of Antiquity
+    let trainer_card = trainer_from_id(CardId::B3154ArenaofAntiquity);
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    // Apply 20 damage
+    let remaining = get_remaining_hp_after_damage(&mut game, 20);
+
+    let damage = bulbasaur_hp - remaining;
+    // Damage should be exactly 20 (no +20 bonus since target is not ex)
+    assert_eq!(
+        damage, 20,
+        "Arena of Antiquity should NOT boost damage vs non-ex (expected 20, got {damage})"
+    );
+}
+
+#[test]
+fn test_arena_of_antiquity_no_boost_for_non_fighting() {
+    // Arena of Antiquity does NOT boost non-Fighting pokemon vs ex
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Bulbasaur (Grass type) vs Machamp ex
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1146MachampEx)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+    state.hands[0] = vec![get_card_by_enum(CardId::B3154ArenaofAntiquity)];
+    game.set_state(state);
+
+    let ex_hp = match get_card_by_enum(CardId::A1146MachampEx) {
+        Card::Pokemon(p) => p.hp,
+        _ => panic!("Expected Pokemon"),
+    };
+
+    // Play Arena of Antiquity
+    let trainer_card = trainer_from_id(CardId::B3154ArenaofAntiquity);
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    // Apply 20 damage
+    let remaining = get_remaining_hp_after_damage(&mut game, 20);
+
+    let damage = ex_hp - remaining;
+    // Should be 20 (no bonus for non-Fighting type)
+    assert_eq!(
+        damage, 20,
+        "Arena of Antiquity should NOT boost non-Fighting attacks vs ex (expected 20, got {damage})"
+    );
+}

--- a/tests/stadiums/fragrant_forest_test.rs
+++ b/tests/stadiums/fragrant_forest_test.rs
@@ -1,0 +1,203 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn trainer_from_id(card_id: CardId) -> deckgym::models::TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+#[test]
+fn test_fragrant_forest_use_stadium_available_with_basic_grass_in_deck() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+    state.hands[0] = vec![get_card_by_enum(CardId::B3153FragrantForest)];
+    // Put a Basic Grass pokemon in the deck
+    state.decks[0].cards = vec![get_card_by_enum(CardId::A4008Chikorita)];
+    game.set_state(state);
+
+    // Play Fragrant Forest stadium
+    let trainer_card = trainer_from_id(CardId::B3153FragrantForest);
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    assert!(
+        state.active_stadium.is_some(),
+        "Fragrant Forest should be active"
+    );
+
+    let (_actor, actions) = state.generate_possible_actions();
+    let has_use_stadium = actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium));
+
+    assert!(
+        has_use_stadium,
+        "UseStadium action should be available when Fragrant Forest is active and deck has Basic Grass Pokemon"
+    );
+}
+
+#[test]
+fn test_fragrant_forest_draws_basic_grass_to_hand() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+    state.hands[0] = vec![get_card_by_enum(CardId::B3153FragrantForest)];
+    let chikorita = get_card_by_enum(CardId::A4008Chikorita);
+    state.decks[0].cards = vec![chikorita.clone()];
+    game.set_state(state);
+
+    // Play Fragrant Forest
+    let trainer_card = trainer_from_id(CardId::B3153FragrantForest);
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    // Use the stadium effect
+    let use_stadium_action = Action {
+        actor: 0,
+        action: SimpleAction::UseStadium,
+        is_stack: false,
+    };
+    game.apply_action(&use_stadium_action);
+
+    let state = game.get_state_clone();
+
+    // Chikorita should now be in player 0's hand
+    let has_chikorita_in_hand = state.hands[0].contains(&chikorita);
+    assert!(
+        has_chikorita_in_hand,
+        "Fragrant Forest should have moved Chikorita (Basic Grass) from deck to hand"
+    );
+
+    // Deck should now be empty
+    assert!(
+        state.decks[0].cards.is_empty(),
+        "Deck should be empty after Fragrant Forest moved the only card"
+    );
+
+    // has_used_stadium should be true for player 0
+    assert!(
+        state.has_used_stadium[0],
+        "has_used_stadium[0] should be true after using Fragrant Forest"
+    );
+}
+
+#[test]
+fn test_fragrant_forest_use_stadium_not_available_without_basic_grass() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+    state.hands[0] = vec![get_card_by_enum(CardId::B3153FragrantForest)];
+    // Deck has no Basic Grass pokemon (only a Trainer card)
+    state.decks[0].cards = vec![get_card_by_enum(CardId::PA001Potion)];
+    game.set_state(state);
+
+    let trainer_card = trainer_from_id(CardId::B3153FragrantForest);
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    let has_use_stadium = actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium));
+
+    assert!(
+        !has_use_stadium,
+        "UseStadium should NOT be available when deck has no Basic Grass Pokemon"
+    );
+}
+
+#[test]
+fn test_fragrant_forest_each_player_can_use_once_per_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    let chikorita = get_card_by_enum(CardId::A4008Chikorita);
+    let bulbasaur = get_card_by_enum(CardId::A1001Bulbasaur);
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1033Charmander).with_energy(vec![EnergyType::Fire])],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+    state.hands[0] = vec![get_card_by_enum(CardId::B3153FragrantForest)];
+    state.decks[0].cards = vec![chikorita.clone()];
+    state.decks[1].cards = vec![bulbasaur.clone()];
+    game.set_state(state);
+
+    // Player 0 plays Fragrant Forest
+    let trainer_card = trainer_from_id(CardId::B3153FragrantForest);
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    // Player 0 uses it
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseStadium,
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(
+        state.has_used_stadium[0],
+        "Player 0 should have used stadium"
+    );
+    assert!(
+        !state.has_used_stadium[1],
+        "Player 1 should NOT have used stadium yet"
+    );
+
+    // Player 0 should no longer have UseStadium as an option this turn
+    let (_actor, actions) = state.generate_possible_actions();
+    let has_use_stadium = actions
+        .iter()
+        .any(|a| matches!(a.action, SimpleAction::UseStadium));
+    assert!(
+        !has_use_stadium,
+        "Player 0 should not be able to use Fragrant Forest a second time this turn"
+    );
+}

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -1,3 +1,5 @@
+#[path = "tools/lucky_egg_test.rs"]
+mod lucky_egg_test;
 #[path = "tools/lucky_ice_pop_test.rs"]
 mod lucky_ice_pop_test;
 #[path = "tools/protective_poncho_test.rs"]

--- a/tests/tools/lucky_egg_test.rs
+++ b/tests/tools/lucky_egg_test.rs
@@ -1,0 +1,159 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn play_lucky_egg_on_active(game: &mut deckgym::Game<'static>) {
+    let lucky_egg = get_card_by_enum(CardId::B3148LuckyEgg);
+    let trainer_card = match lucky_egg {
+        Card::Trainer(tc) => tc,
+        _ => panic!("Expected trainer card"),
+    };
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    let (_actor, choices) = state.generate_possible_actions();
+    let attach_action = choices
+        .iter()
+        .find(|action| {
+            matches!(
+                action.action,
+                SimpleAction::AttachTool { in_play_idx: 0, .. }
+            )
+        })
+        .cloned()
+        .expect("Expected attach tool choice for active slot 0");
+    game.apply_action(&attach_action);
+}
+
+#[test]
+fn test_lucky_egg_draws_to_five_on_opponent_attack_ko() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1033Charmander), // bench so game doesn't immediately end
+        ],
+        vec![PlayedCard::from_id(CardId::A1143Machop)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+
+    // Give player 0 only 2 cards in hand (below 5)
+    state.hands[0] = vec![
+        get_card_by_enum(CardId::B3148LuckyEgg),
+        get_card_by_enum(CardId::A1001Bulbasaur),
+    ];
+    // Fill deck so there are cards to draw
+    state.decks[0].cards = vec![
+        get_card_by_enum(CardId::PA001Potion),
+        get_card_by_enum(CardId::PA001Potion),
+        get_card_by_enum(CardId::PA001Potion),
+        get_card_by_enum(CardId::PA001Potion),
+        get_card_by_enum(CardId::PA001Potion),
+    ];
+    state.in_play_pokemon[0][0]
+        .as_mut()
+        .unwrap()
+        .attached_energy = vec![EnergyType::Grass];
+
+    game.set_state(state);
+
+    // Attach Lucky Egg to player 0's active
+    play_lucky_egg_on_active(&mut game);
+
+    // Player 1 delivers a lethal attack to player 0's active Bulbasaur
+    let ko_action = Action {
+        actor: 1,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (1, 0),
+            targets: vec![(100, 0, 0)],
+            is_from_active_attack: true,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&ko_action);
+
+    let state = game.get_state_clone();
+    // Player 0's Bulbasaur is KO'd - Lucky Egg should have drawn to 5
+    assert!(
+        state.in_play_pokemon[0][0].is_none(),
+        "Player 0's active should be KO'd"
+    );
+    assert_eq!(
+        state.hands[0].len(),
+        5,
+        "Lucky Egg should draw hand to 5 cards, got {}",
+        state.hands[0].len()
+    );
+}
+
+#[test]
+fn test_lucky_egg_does_not_draw_without_opponent_attack() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1143Machop)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+
+    state.hands[0] = vec![
+        get_card_by_enum(CardId::B3148LuckyEgg),
+        get_card_by_enum(CardId::A1001Bulbasaur),
+    ];
+    state.decks[0].cards = vec![
+        get_card_by_enum(CardId::PA001Potion),
+        get_card_by_enum(CardId::PA001Potion),
+        get_card_by_enum(CardId::PA001Potion),
+    ];
+    state.in_play_pokemon[0][0]
+        .as_mut()
+        .unwrap()
+        .attached_energy = vec![EnergyType::Grass];
+
+    game.set_state(state);
+
+    play_lucky_egg_on_active(&mut game);
+
+    // Use is_from_active_attack = false (not a direct opponent attack)
+    let ko_action = Action {
+        actor: 1,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (1, 0),
+            targets: vec![(100, 0, 0)],
+            is_from_active_attack: false,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&ko_action);
+
+    let state = game.get_state_clone();
+    assert!(
+        state.in_play_pokemon[0][0].is_none(),
+        "Player 0's active should be KO'd"
+    );
+    // Hand should still be 2 (1 card was the Lucky Egg but it was attached, so 1 remaining + the Bulbasaur)
+    // The Lucky Egg card goes to discard with the Pokemon, so hand stays at 1 (the Bulbasaur)
+    assert!(
+        state.hands[0].len() < 5,
+        "Lucky Egg should NOT draw when KO is not from opponent's active attack, hand={}",
+        state.hands[0].len()
+    );
+}


### PR DESCRIPTION
## Summary
This PR adds implementations for three card effects: two stadium cards (Arena of Antiquity and Fragrant Forest) and one tool card (Lucky Egg), along with comprehensive test coverage for each.

## Key Changes

### Stadium Effects
- **Arena of Antiquity**: Adds +20 damage bonus when Fighting-type Pokémon attack the opponent's Active Pokémon ex. Implemented in `stadiums.rs` with damage calculation integrated into the core damage modification logic in `hooks/core.rs`.
- **Fragrant Forest**: Allows each player to put a random Basic Grass Pokémon from their deck into their hand once per turn. Implemented with proper action forecasting and probability handling for multiple Basic Grass Pokémon in deck.

### Tool Effect
- **Lucky Egg**: When a Pokémon with Lucky Egg attached is knocked out by an opponent's active attack, the player draws cards until their hand has 5 cards. Integrated into the knockout handler in `hooks/core.rs` with proper opponent attack detection.

### Implementation Details
- Stadium effects are registered in `is_stadium_effect_implemented()` for validation
- Fragrant Forest uses the existing `forecast_use_stadium()` mechanism with probability-based outcomes for random selection
- Lucky Egg leverages the existing `on_knockout()` hook, requiring the `attacking_ref` parameter to distinguish opponent attacks from other damage sources
- All three cards include proper action generation checks to prevent invalid moves (e.g., UseStadium when no Basic Grass Pokémon available)

### Testing
- Added 4 comprehensive tests for Fragrant Forest covering availability, card drawing, and per-turn usage limits
- Added 3 tests for Arena of Antiquity covering Fighting vs ex bonus, non-ex immunity, and non-Fighting immunity
- Added 2 tests for Lucky Egg covering KO draw trigger and non-attack damage immunity
- Updated test module registrations in `tests/stadiums.rs` and `tests/tools.rs`

### Minor Fixes
- Removed unnecessary `mut` qualifiers in several test functions for cleaner code

https://claude.ai/code/session_0166D44Pws5WCDu5xnTDD7h2