### PR TITLE
[codex] Implement Galarian Cursola Perish Body

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -176,4 +176,5 @@ pub enum AbilityMechanic {
         energy_type: EnergyType,
     },
     ProtectSelfNextTurnAfterAttackKnockout,
+    PerishBody,
 }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -249,6 +249,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::ProtectSelfNextTurnAfterAttackKnockout => {
             panic!("ProtectSelfNextTurnAfterAttackKnockout is a passive ability")
         }
+        AbilityMechanic::PerishBody => {
+            panic!("PerishBody is a passive ability")
+        }
     }
 }
 

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -31,6 +31,7 @@ use super::{
 /// and then chooses one of them to apply. This is so that bot implementations can re-use the
 /// `forecast_action` function.
 pub fn apply_action(rng: &mut StdRng, state: &mut State, action: &Action) {
+    state.ensure_play_ids();
     let (probabilities, mut lazy_mutations) = forecast_action(state, action).into_branches();
     if probabilities.len() == 1 {
         lazy_mutations.remove(0)(rng, state, action);
@@ -119,11 +120,11 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
 
     // This is where we basically "apply" Will in a way that is forecasteable.
     // (The player should know if they have an upcoming Will).
-    if is_will_eligible_action(&action.action) && state.has_pending_will_first_heads() {
+    if is_will_eligible_action(&action.action) && state.has_pending_will_first_heads(action.actor) {
         outcomes = match outcomes.force_first_heads() {
             Ok(forced_outcomes) => forced_outcomes.map_mutations(|mutation| {
                 Box::new(move |rng, state, action| {
-                    state.consume_pending_will_first_heads();
+                    state.consume_pending_will_first_heads(action.actor);
                     mutation(rng, state, action);
                 })
             }),
@@ -334,6 +335,7 @@ pub(crate) fn apply_place_card(
 ) {
     let played_card = to_playable_card(card, true);
     state.in_play_pokemon[actor][index] = Some(played_card);
+    state.assign_new_play_id(actor, index);
     state.refresh_starting_plains_bonus_for_idx(actor, index);
     // SoothingWind (Ogerpon ex) / Flower Shield (Comfey): cure status conditions on entry.
     if let Some(AbilityMechanic::SoothingWind { energy_type }) = get_ability_mechanic(card) {
@@ -365,6 +367,7 @@ fn apply_return_pokemon_to_hand(acting_player: usize, state: &mut State, in_play
     let played_card = state.in_play_pokemon[acting_player][in_play_idx]
         .take()
         .expect("Pokemon should be there if returning to hand");
+    state.clear_play_id(acting_player, in_play_idx);
     let mut cards_to_collect = played_card.cards_behind.clone();
     cards_to_collect.push(played_card.card.clone());
     state.hands[acting_player].extend(cards_to_collect);
@@ -498,7 +501,7 @@ fn apply_retreat(player: usize, state: &mut State, bench_idx: usize, is_free: bo
         }
     }
 
-    state.in_play_pokemon[player].swap(0, bench_idx);
+    state.swap_in_play(player, 0, bench_idx);
 
     // Clear status and effects of the new bench Pokemon
     if let Some(pokemon) = state.in_play_pokemon[player][bench_idx].as_mut() {

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use log::debug;
-use rand::rngs::StdRng;
+use rand::{rngs::StdRng, Rng};
 
 use crate::{
     actions::{
@@ -9,7 +9,7 @@ use crate::{
         effect_ability_mechanic_map::get_ability_mechanic, shared_mutations, SimpleAction,
     },
     card_ids::CardId,
-    effects::TurnEffect,
+    effects::{CardEffect, TurnEffect},
     hooks::{
         get_counterattack_damage, modify_damage, on_attack_knockout, on_end_turn, on_knockout,
         should_poison_attacker,
@@ -105,6 +105,7 @@ fn forecast_pokemon_checkup(state: &State) -> (Probabilities, Mutations) {
             probabilities.push(base_probability * start_prob);
             outcomes.push(Box::new(move |rng, state, action| {
                 on_end_turn(action.actor, state);
+                resolve_pending_perish_body(rng, state);
                 let live_checkup_targets = collect_checkup_targets(state);
                 apply_pokemon_checkup(state, &live_checkup_targets, &outcome);
 
@@ -378,14 +379,38 @@ pub(crate) fn handle_damage(
     is_from_active_attack: bool,
     attack_name: Option<&str>,
 ) {
-    handle_damage_only(
+    handle_damage_internal(
         state,
         attacking_ref,
         targets,
         is_from_active_attack,
         attack_name,
+        None,
+        false,
     );
     handle_knockouts(state, attacking_ref, is_from_active_attack);
+}
+
+pub(crate) fn handle_attack_damage_from_source(
+    state: &mut State,
+    attacking_player: usize,
+    attacker_play_id: u64,
+    targets: &[(u32, usize, usize)],
+    allow_perish_will: bool,
+) {
+    let attacking_idx = state
+        .find_play_id(attacking_player, attacker_play_id)
+        .unwrap_or(0);
+    handle_damage_internal(
+        state,
+        (attacking_player, attacking_idx),
+        targets,
+        true,
+        None,
+        Some(attacker_play_id),
+        allow_perish_will,
+    );
+    handle_knockouts(state, (attacking_player, attacking_idx), true);
 }
 
 // This function handles Counter-Attacks and Attack Modifiers, but doesn't handle K.O.s or
@@ -397,6 +422,27 @@ pub(crate) fn handle_damage_only(
     is_from_active_attack: bool,
     attack_name: Option<&str>,
 ) {
+    handle_damage_internal(
+        state,
+        attacking_ref,
+        targets,
+        is_from_active_attack,
+        attack_name,
+        None,
+        false,
+    );
+}
+
+fn handle_damage_internal(
+    state: &mut State,
+    attacking_ref: (usize, usize), // (attacking_player, attacking_pokemon_idx)
+    targets: &[(u32, usize, usize)], // damage, target_player, in_play_idx
+    is_from_active_attack: bool,
+    attack_name: Option<&str>,
+    source_play_id_override: Option<u64>,
+    allow_perish_will: bool,
+) {
+    state.ensure_play_ids();
     let attacking_player = attacking_ref.0;
 
     // Reduce and sum damage for duplicate targets
@@ -437,10 +483,12 @@ pub(crate) fn handle_damage_only(
         }
 
         // Apply damage
+        let was_knocked_out;
         {
             let target_pokemon = state.in_play_pokemon[target_player][target_pokemon_idx]
                 .as_mut()
                 .expect("Pokemon should be there if taking damage");
+            was_knocked_out = target_pokemon.is_knocked_out();
             target_pokemon.apply_damage(damage); // Applies without surpassing 0 HP
             debug!(
                 "Dealt {} damage to opponent's {} Pokemon. Remaining HP: {}",
@@ -449,6 +497,17 @@ pub(crate) fn handle_damage_only(
                 target_pokemon.get_remaining_hp()
             );
         }
+        record_perish_body_if_needed(
+            state,
+            attacking_ref,
+            source_play_id_override,
+            target_player,
+            target_pokemon_idx,
+            damage,
+            was_knocked_out,
+            is_from_active_attack,
+            allow_perish_will,
+        );
 
         // Consider Counter-Attack (only if from Active Attack to Active)
         if !(is_from_active_attack && target_pokemon_idx == 0) {
@@ -465,6 +524,18 @@ pub(crate) fn handle_damage_only(
                 0
             }
         };
+        let reactive_attack_damages: Vec<(u32, usize, u64)> = target_pokemon
+            .get_effects()
+            .iter()
+            .filter_map(|(effect, _)| match effect {
+                CardEffect::ReactiveAttackDamageNextTurn {
+                    amount,
+                    source_player,
+                    source_play_id,
+                } => Some((*amount, *source_player, *source_play_id)),
+                _ => None,
+            })
+            .collect();
         let should_poison = should_poison_attacker(target_pokemon);
 
         // Apply counterattack damage and poison
@@ -479,12 +550,78 @@ pub(crate) fn handle_damage_only(
                 attacking_pokemon.get_remaining_hp()
             );
         }
+        for (reactive_damage, source_player, source_play_id) in reactive_attack_damages {
+            let Some(attacking_pokemon) = state.in_play_pokemon[attacking_player][0].as_mut()
+            else {
+                continue;
+            };
+            let was_knocked_out = attacking_pokemon.is_knocked_out();
+            attacking_pokemon.apply_damage(reactive_damage);
+            debug!(
+                "Dealt {} reactive attack damage to active Pokemon. Remaining HP: {}",
+                reactive_damage,
+                attacking_pokemon.get_remaining_hp()
+            );
+            record_perish_body_if_needed(
+                state,
+                (source_player, 0),
+                Some(source_play_id),
+                attacking_player,
+                0,
+                reactive_damage,
+                was_knocked_out,
+                true,
+                true,
+            );
+        }
 
         if should_poison {
             state.apply_status_condition(attacking_player, 0, StatusCondition::Poisoned);
             debug!("Poison Barb: Poisoned the attacking Pokemon");
         }
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_perish_body_if_needed(
+    state: &mut State,
+    attacking_ref: (usize, usize),
+    source_play_id_override: Option<u64>,
+    target_player: usize,
+    target_pokemon_idx: usize,
+    damage: u32,
+    was_knocked_out: bool,
+    is_from_active_attack: bool,
+    allow_will: bool,
+) {
+    if !is_from_active_attack
+        || target_pokemon_idx != 0
+        || damage == 0
+        || was_knocked_out
+        || attacking_ref.0 == target_player
+    {
+        return;
+    }
+
+    let Some(target_pokemon) = state.in_play_pokemon[target_player][target_pokemon_idx].as_ref()
+    else {
+        return;
+    };
+    if !target_pokemon.is_knocked_out()
+        || !matches!(
+            get_ability_mechanic(&target_pokemon.card),
+            Some(AbilityMechanic::PerishBody)
+        )
+    {
+        return;
+    }
+
+    let Some(attacker_play_id) =
+        source_play_id_override.or_else(|| state.play_id(attacking_ref.0, attacking_ref.1))
+    else {
+        return;
+    };
+    state.set_pending_perish_body(attacking_ref.0, attacker_play_id, target_player, allow_will);
 }
 
 fn is_iris_bonus_active(
@@ -614,6 +751,49 @@ pub(crate) fn handle_knockouts(
     }
 }
 
+fn resolve_deferred_attack_knockouts(state: &mut State) {
+    let Some(deferred) = state.deferred_attack_knockouts.take() else {
+        return;
+    };
+    let attacking_idx = state
+        .find_play_id(deferred.attacking_player, deferred.attacker_play_id)
+        .unwrap_or(0);
+    handle_knockouts(
+        state,
+        (deferred.attacking_player, attacking_idx),
+        deferred.is_from_active_attack,
+    );
+}
+
+fn resolve_pending_perish_body(rng: &mut StdRng, state: &mut State) {
+    let Some(trigger) = state.pending_perish_body.take() else {
+        return;
+    };
+
+    let heads =
+        if trigger.allow_will && state.consume_pending_will_first_heads(trigger.defender_player) {
+            true
+        } else {
+            rng.gen_bool(0.5)
+        };
+    if !heads {
+        return;
+    }
+
+    let Some(attacker_idx) = state.find_play_id(trigger.attacking_player, trigger.attacker_play_id)
+    else {
+        return;
+    };
+    let Some(attacker) = state.in_play_pokemon[trigger.attacking_player][attacker_idx].as_mut()
+    else {
+        return;
+    };
+
+    debug!("Perish Body: heads, knocking out the attacking Pokemon");
+    attacker.knock_out();
+    handle_knockouts(state, (trigger.attacking_player, attacker_idx), false);
+}
+
 fn get_knocked_out(state: &State) -> Vec<(usize, usize)> {
     let mut knockouts: Vec<(usize, usize)> = vec![];
     for (idx, card) in state.enumerate_in_play_pokemon(0) {
@@ -660,6 +840,11 @@ pub(crate) fn wrap_with_common_logic(mutation: Mutation) -> Mutation {
         }
 
         mutation(rng, state, action); // in the case of attacks, have this be damage + effect.
+
+        if action.is_stack {
+            resolve_deferred_attack_knockouts(state);
+        }
+        resolve_pending_perish_body(rng, state);
 
         if let SimpleAction::Attack(_) = &action.action {
             // We use a flag instead of .move_generation_stack to reduce

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -519,7 +519,16 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::OminousClaw => ominous_claw_attack(state.current_player, attack.fixed_damage),
         Mechanic::DarknessClaw => darkness_claw_attack(state.current_player, attack.fixed_damage),
         Mechanic::BlockBasicAttack => block_basic_attack(attack.fixed_damage),
-        Mechanic::SwitchSelfWithBench => switch_self_with_bench(state, attack.fixed_damage),
+        Mechanic::SwitchSelfWithBench => switch_self_with_bench(state, attack.fixed_damage, false),
+        Mechanic::MaySwitchSelfWithBench => {
+            switch_self_with_bench(state, attack.fixed_damage, true)
+        }
+        Mechanic::DelayedAttackDamage { amount } => {
+            delayed_attack_damage(attack.fixed_damage, *amount)
+        }
+        Mechanic::ReactiveAttackDamageNextTurn { amount } => {
+            reactive_attack_damage_next_turn(attack.fixed_damage, *amount)
+        }
         Mechanic::SelfHealIfStadiumInPlay { amount } => {
             self_heal_if_stadium_in_play(state, attack.fixed_damage, *amount)
         }
@@ -2694,30 +2703,72 @@ fn random_spread_damage(
     random_damage_outcomes_to_outcomes(outcomes)
 }
 
-fn switch_self_with_bench(state: &State, damage: u32) -> Outcomes {
-    let choices: Vec<_> = state
+fn switch_self_with_bench(state: &State, damage: u32, may_switch: bool) -> Outcomes {
+    let mut choices: Vec<_> = state
         .enumerate_bench_pokemon(state.current_player)
         .map(|(in_play_idx, _)| SimpleAction::Activate {
             player: state.current_player,
             in_play_idx,
         })
         .collect();
+    if may_switch && !choices.is_empty() {
+        choices.push(SimpleAction::Noop);
+    }
 
     Outcomes::single(Box::new(
         move |_: &mut StdRng, state: &mut State, action: &Action| {
             let opponent = (action.actor + 1) % 2;
             let attacking_ref = (action.actor, 0);
+            let attacker_play_id = state
+                .play_id(action.actor, 0)
+                .expect("Attacking Pokemon should have a play id");
 
             // Deal damage to opponent's active
-            handle_damage(state, attacking_ref, &[(damage, opponent, 0)], true, None);
+            handle_damage_only(state, attacking_ref, &[(damage, opponent, 0)], true, None);
 
-            // Push choices for switching if there are benched Pokemon and pokemon
-            // is still alive (after possible counterdamage)
+            // Switch effects resolve before final attack knockouts. Keep the original
+            // attacker id so counterattacks can still find hit-and-run attackers.
             if !choices.is_empty() && state.maybe_get_active(action.actor).is_some() {
+                state.defer_attack_knockouts(action.actor, attacker_play_id, true);
                 state.move_generation_stack.push((action.actor, choices));
+            } else {
+                handle_knockouts(state, attacking_ref, true);
             }
         },
     ))
+}
+
+fn delayed_attack_damage(base_damage: u32, delayed_damage: u32) -> Outcomes {
+    active_damage_effect_doutcome(base_damage, move |_, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        let source_play_id = state
+            .play_id(action.actor, 0)
+            .expect("Attacking Pokemon should have a play id");
+        state.get_active_mut(opponent).add_effect(
+            CardEffect::DelayedAttackDamage {
+                amount: delayed_damage,
+                source_player: action.actor,
+                source_play_id,
+            },
+            1,
+        );
+    })
+}
+
+fn reactive_attack_damage_next_turn(base_damage: u32, reactive_damage: u32) -> Outcomes {
+    active_damage_effect_doutcome(base_damage, move |_, state, action| {
+        let source_play_id = state
+            .play_id(action.actor, 0)
+            .expect("Attacking Pokemon should have a play id");
+        state.get_active_mut(action.actor).add_effect(
+            CardEffect::ReactiveAttackDamageNextTurn {
+                amount: reactive_damage,
+                source_player: action.actor,
+                source_play_id,
+            },
+            1,
+        );
+    })
 }
 
 /// Mega Steelix ex - Adamantine Rolling: Deals damage and applies multiple card effects

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -458,8 +458,8 @@ fn lucky_ice_pop_outcomes(_state: &State, _acting_player: usize) -> Outcomes {
     Outcomes::binary_coin(heads_mutation, tails_mutation)
 }
 
-fn will_effect(_: &mut StdRng, state: &mut State, _: &Action) {
-    state.set_pending_will_first_heads();
+fn will_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    state.set_pending_will_first_heads(action.actor);
 }
 
 fn electric_generator_outcomes() -> Outcomes {

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -197,6 +197,12 @@ pub enum Mechanic {
     DelayedSpotDamage {
         amount: u32,
     },
+    DelayedAttackDamage {
+        amount: u32,
+    },
+    ReactiveAttackDamageNextTurn {
+        amount: u32,
+    },
     // End Unique mechanics
     DamageAndCardEffect {
         opponent: bool,
@@ -309,6 +315,7 @@ pub enum Mechanic {
     DarknessClaw,
     BlockBasicAttack,
     SwitchSelfWithBench,
+    MaySwitchSelfWithBench,
     SelfHealIfStadiumInPlay {
         amount: u32,
     },

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -124,7 +124,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
         // map.insert("If this Pokémon has full HP, it takes -40 damage from attacks from your opponent's Pokémon.", todo_implementation);
         // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, do 10 damage to each of your opponent's Pokémon.", todo_implementation);
         // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, do 50 damage to the Attacking Pokémon.", todo_implementation);
-        // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, flip a coin. If heads, the Attacking Pokémon is Knocked Out.", todo_implementation);
+        map.insert(
+            "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, flip a coin. If heads, the Attacking Pokémon is Knocked Out.",
+            AbilityMechanic::PerishBody,
+        );
         // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all [F] Energy from this Pokémon to 1 of your Benched Pokémon.", todo_implementation);
         map.insert(
             "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon, do 20 damage to the Attacking Pokémon.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -47,12 +47,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     map.insert(
         "At the end of your opponent's next turn, do 90 damage to the Defending Pokémon.",
-        Mechanic::DamageAndCardEffect {
-            opponent: true,
-            effect: CardEffect::DelayedDamage { amount: 90 },
-            duration: 1,
-            coin_flip: false,
-        },
+        Mechanic::DelayedAttackDamage { amount: 90 },
     );
     map.insert(
         "Before doing damage, discard all Pokémon Tools from your opponent's Active Pokémon.",
@@ -351,7 +346,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("During your opponent's next turn, if they attach Energy from their Energy Zone to the Defending Pokémon, that Pokémon will be Asleep.", todo_implementation);
     // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 20 damage to the Attacking Pokémon.", todo_implementation);
     // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 30 damage to the Attacking Pokémon.", todo_implementation);
-    // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 40 damage to the Attacking Pokémon.", todo_implementation);
+    map.insert(
+        "During your opponent's next turn, if this Pokémon is damaged by an attack, do 40 damage to the Attacking Pokémon.",
+        Mechanic::ReactiveAttackDamageNextTurn { amount: 40 },
+    );
     // map.insert("During your opponent's next turn, prevent all damage done to this Pokémon by attacks if that damage is 40 or less.", todo_implementation);
     map.insert(
         "During your opponent's next turn, the Defending Pokémon can't attack.",
@@ -1438,7 +1436,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("Until this Pokémon leaves the Active Spot, this Pokémon's Rolling Frenzy attack does +30 damage. This effect stacks.", todo_implementation);
     // map.insert("You can use this attack only if you have Uxie and Azelf on your Bench. Discard all Energy from this Pokémon.", todo_implementation);
     // map.insert("You may discard any number of your Benched [W] Pokémon. This attack does 40 more damage for each Benched Pokémon you discarded in this way.", todo_implementation);
-    // map.insert("You may switch this Pokémon with 1 of your Benched Pokémon.", todo_implementation);
+    map.insert(
+        "You may switch this Pokémon with 1 of your Benched Pokémon.",
+        Mechanic::MaySwitchSelfWithBench,
+    );
     map.insert(
         "Your opponent can't use any Supporter cards from their hand during their next turn.",
         Mechanic::DamageAndTurnEffect {

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -17,6 +17,7 @@ pub(crate) use apply_action::apply_action;
 pub(crate) use apply_action::apply_evolve;
 pub(crate) use apply_action::apply_place_card;
 pub(crate) use apply_action::forecast_action;
+pub(crate) use apply_action_helpers::handle_attack_damage_from_source;
 pub(crate) use apply_action_helpers::handle_damage;
 pub(crate) use apply_action_helpers::handle_damage_only;
 pub(crate) use apply_action_helpers::handle_knockouts;

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -6,16 +6,37 @@ use crate::models::EnergyType;
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CardEffect {
     NoRetreat,
-    ReducedDamage { amount: u32 },
-    IncreasedVulnerability { amount: u32 },
-    IncreasedAttackCost { amount: u8 },
+    ReducedDamage {
+        amount: u32,
+    },
+    IncreasedVulnerability {
+        amount: u32,
+    },
+    IncreasedAttackCost {
+        amount: u8,
+    },
     CannotAttack,
     CannotUseAttack(String),
-    IncreasedDamageForAttack { attack_name: String, amount: u32 },
+    IncreasedDamageForAttack {
+        attack_name: String,
+        amount: u32,
+    },
     PreventAllDamageAndEffects,
     NoWeakness,
     CoinFlipToBlockAttack,
-    DelayedDamage { amount: u32 },
+    DelayedDamage {
+        amount: u32,
+    },
+    DelayedAttackDamage {
+        amount: u32,
+        source_player: usize,
+        source_play_id: u64,
+    },
+    ReactiveAttackDamageNextTurn {
+        amount: u32,
+        source_player: usize,
+        source_play_id: u64,
+    },
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
@@ -63,6 +84,8 @@ pub enum TurnEffect {
         target_in_play_idx: usize,
         amount: u32,
     },
-    ForceFirstHeads,
+    ForceFirstHeads {
+        player: usize,
+    },
     BonusPointForHaxorusActiveKO,
 }

--- a/src/game.rs
+++ b/src/game.rs
@@ -26,7 +26,8 @@ pub struct Game<'a> {
 }
 
 impl<'a> Game<'a> {
-    pub fn from_state(state: State, players: Vec<Box<dyn Player>>, seed: u64) -> Self {
+    pub fn from_state(mut state: State, players: Vec<Box<dyn Player>>, seed: u64) -> Self {
+        state.ensure_play_ids();
         let rng = StdRng::seed_from_u64(seed);
         Game {
             seed,
@@ -128,7 +129,8 @@ impl<'a> Game<'a> {
         apply_action(&mut self.rng, &mut self.state, action);
     }
 
-    pub fn set_state(&mut self, state: State) {
+    pub fn set_state(&mut self, mut state: State) {
+        state.ensure_play_ids();
         self.state = state;
     }
 

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -199,6 +199,38 @@ pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
         );
     }
 
+    let delayed_attack_damages: Vec<(u32, usize, u64)> = state
+        .maybe_get_active(player_ending_turn)
+        .map(|active| {
+            active
+                .get_effects()
+                .iter()
+                .filter_map(|(effect, _)| match effect {
+                    CardEffect::DelayedAttackDamage {
+                        amount,
+                        source_player,
+                        source_play_id,
+                    } => Some((*amount, *source_player, *source_play_id)),
+                    _ => None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    for (amount, source_player, source_play_id) in delayed_attack_damages {
+        debug!(
+            "Delayed attack damage: Applying {} damage to active Pokemon",
+            amount
+        );
+        crate::actions::handle_attack_damage_from_source(
+            state,
+            source_player,
+            source_play_id,
+            &[(amount, player_ending_turn, 0)],
+            true,
+        );
+    }
+
     // Process delayed spot damage effects from turn effects (e.g. Meowscarada ex's Flower Trick).
     // These target a board position, so they hit whichever Pokémon occupies the spot at trigger time.
     let triggered_spot_damages: Vec<(usize, usize, usize, u32)> = state

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -161,6 +161,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::EndTurnDrawCardIfActive { .. } => false,
         AbilityMechanic::EndTurnHealSelfIfActive { .. } => false,
         AbilityMechanic::ProtectSelfNextTurnAfterAttackKnockout => false,
+        AbilityMechanic::PerishBody => false,
     }
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -26,6 +26,21 @@ pub enum GameOutcome {
     Tie,
 }
 
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PendingPerishBody {
+    pub(crate) attacking_player: usize,
+    pub(crate) attacker_play_id: u64,
+    pub(crate) defender_player: usize,
+    pub(crate) allow_will: bool,
+}
+
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct DeferredAttackKnockouts {
+    pub(crate) attacking_player: usize,
+    pub(crate) attacker_play_id: u64,
+    pub(crate) is_from_active_attack: bool,
+}
+
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct State {
     // Turn State
@@ -46,6 +61,8 @@ pub struct State {
     pub discard_energies: [Vec<EnergyType>; 2],
     // 0 index is the active pokemon, 1..4 are the bench
     pub in_play_pokemon: [[Option<PlayedCard>; 4]; 2],
+    pub(crate) play_ids: [[Option<u64>; 4]; 2],
+    pub(crate) next_play_id: u64,
     // Stadium card currently in play (affects both players)
     pub active_stadium: Option<Card>,
 
@@ -55,6 +72,8 @@ pub struct State {
     pub has_used_stadium: [bool; 2], // Tracks if each player has used the stadium this turn
     pub(crate) knocked_out_by_opponent_attack_this_turn: bool,
     pub(crate) knocked_out_by_opponent_attack_last_turn: bool,
+    pub(crate) pending_perish_body: Option<PendingPerishBody>,
+    pub(crate) deferred_attack_knockouts: Option<DeferredAttackKnockouts>,
     // Maps turn to a vector of effects (cards) for that turn. Using BTreeMap to keep State hashable.
     turn_effects: BTreeMap<u8, Vec<TurnEffect>>,
 }
@@ -74,6 +93,8 @@ impl State {
             discard_piles: [Vec::new(), Vec::new()],
             discard_energies: [Vec::new(), Vec::new()],
             in_play_pokemon: [[None, None, None, None], [None, None, None, None]],
+            play_ids: [[None, None, None, None], [None, None, None, None]],
+            next_play_id: 1,
             active_stadium: None,
             has_played_support: false,
             has_retreated: false,
@@ -81,6 +102,8 @@ impl State {
 
             knocked_out_by_opponent_attack_this_turn: false,
             knocked_out_by_opponent_attack_last_turn: false,
+            pending_perish_body: None,
+            deferred_attack_knockouts: None,
             turn_effects: BTreeMap::new(),
         }
     }
@@ -269,27 +292,108 @@ impl State {
         }
     }
 
-    pub(crate) fn set_pending_will_first_heads(&mut self) {
-        self.add_turn_effect(TurnEffect::ForceFirstHeads, 0);
+    pub(crate) fn set_pending_will_first_heads(&mut self, player: usize) {
+        self.add_turn_effect(TurnEffect::ForceFirstHeads { player }, 0);
     }
 
-    pub(crate) fn has_pending_will_first_heads(&self) -> bool {
-        self.get_current_turn_effects()
-            .iter()
-            .any(|effect| matches!(effect, TurnEffect::ForceFirstHeads))
+    pub(crate) fn has_pending_will_first_heads(&self, player: usize) -> bool {
+        self.get_current_turn_effects().iter().any(
+            |effect| matches!(effect, TurnEffect::ForceFirstHeads { player: p } if *p == player),
+        )
     }
 
-    pub(crate) fn consume_pending_will_first_heads(&mut self) -> bool {
+    pub(crate) fn consume_pending_will_first_heads(&mut self, player: usize) -> bool {
         if let Some(turn_effects) = self.turn_effects.get_mut(&self.turn_count) {
             if let Some(pos) = turn_effects
                 .iter()
-                .position(|effect| matches!(effect, TurnEffect::ForceFirstHeads))
+                .position(|effect| matches!(effect, TurnEffect::ForceFirstHeads { player: p } if *p == player))
             {
                 turn_effects.remove(pos);
                 return true;
             }
         }
         false
+    }
+
+    pub(crate) fn set_pending_perish_body(
+        &mut self,
+        attacking_player: usize,
+        attacker_play_id: u64,
+        defender_player: usize,
+        allow_will: bool,
+    ) {
+        self.pending_perish_body = Some(PendingPerishBody {
+            attacking_player,
+            attacker_play_id,
+            defender_player,
+            allow_will,
+        });
+    }
+
+    fn allocate_play_id(&mut self) -> u64 {
+        if self.next_play_id == 0 {
+            self.next_play_id = 1;
+        }
+        let id = self.next_play_id;
+        self.next_play_id = self.next_play_id.saturating_add(1).max(1);
+        id
+    }
+
+    pub(crate) fn ensure_play_ids(&mut self) {
+        for player in 0..2 {
+            for idx in 0..4 {
+                if self.in_play_pokemon[player][idx].is_some() {
+                    if self.play_ids[player][idx].is_none() {
+                        let id = self.allocate_play_id();
+                        self.play_ids[player][idx] = Some(id);
+                    }
+                } else {
+                    self.play_ids[player][idx] = None;
+                }
+            }
+        }
+    }
+
+    pub(crate) fn assign_new_play_id(&mut self, player: usize, idx: usize) {
+        let id = self.allocate_play_id();
+        self.play_ids[player][idx] = Some(id);
+    }
+
+    pub(crate) fn clear_play_id(&mut self, player: usize, idx: usize) {
+        self.play_ids[player][idx] = None;
+    }
+
+    pub(crate) fn play_id(&self, player: usize, idx: usize) -> Option<u64> {
+        if self.in_play_pokemon[player][idx].is_some() {
+            self.play_ids[player][idx]
+        } else {
+            None
+        }
+    }
+
+    pub(crate) fn find_play_id(&self, player: usize, play_id: u64) -> Option<usize> {
+        (0..4).find(|idx| {
+            self.in_play_pokemon[player][*idx].is_some()
+                && self.play_ids[player][*idx] == Some(play_id)
+        })
+    }
+
+    pub(crate) fn swap_in_play(&mut self, player: usize, a: usize, b: usize) {
+        self.in_play_pokemon[player].swap(a, b);
+        self.play_ids[player].swap(a, b);
+    }
+
+    pub(crate) fn defer_attack_knockouts(
+        &mut self,
+        attacking_player: usize,
+        attacker_play_id: u64,
+        is_from_active_attack: bool,
+    ) {
+        self.deferred_attack_knockouts = Some(DeferredAttackKnockouts {
+            attacking_player,
+            attacker_play_id,
+            is_from_active_attack,
+        });
     }
 
     /// Adds an effect card that will remain active for a specified number of turns.
@@ -457,6 +561,7 @@ impl State {
         self.discard_piles[ko_receiver].extend(cards_to_discard);
         self.discard_energies[ko_receiver].extend(ko_pokemon.attached_energy.iter().cloned());
         self.in_play_pokemon[ko_receiver][ko_pokemon_idx] = None;
+        self.clear_play_id(ko_receiver, ko_pokemon_idx);
     }
 
     /// Removes the attached tool from a Pokémon and puts the tool card into the discard pile.
@@ -547,6 +652,7 @@ impl State {
         for (i, card) in player_1.into_iter().enumerate() {
             self.in_play_pokemon[1][i] = Some(card);
         }
+        self.ensure_play_ids();
     }
 
     /// Set the flag indicating a Pokemon was KO'd by opponent's attack last turn.

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -150,6 +150,10 @@ impl PlayedCard {
         self.damage_counters = self.damage_counters.saturating_add(damage);
     }
 
+    pub(crate) fn knock_out(&mut self) {
+        self.damage_counters = self.get_effective_total_hp();
+    }
+
     // Option because if playing an item card... (?)
     pub(crate) fn get_energy_type(&self) -> Option<EnergyType> {
         match &self.card {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -28,6 +28,8 @@ mod darkrai_ex_test;
 mod dusknoir_shadow_void_test;
 #[path = "pokemon/emboar_flare_storm_test.rs"]
 mod emboar_flare_storm_test;
+#[path = "pokemon/galarian_cursola_perish_body_test.rs"]
+mod galarian_cursola_perish_body_test;
 #[path = "pokemon/gallade_test.rs"]
 mod gallade_test;
 #[path = "pokemon/grovyle_slicing_snipe_test.rs"]

--- a/tests/pokemon/galarian_cursola_perish_body_test.rs
+++ b/tests/pokemon/galarian_cursola_perish_body_test.rs
@@ -1,0 +1,549 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard, StatusCondition, TrainerCard},
+    test_support::get_initialized_game,
+};
+
+fn trainer_from_id(card_id: CardId) -> TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+fn drain_stack(game: &mut deckgym::Game<'static>) {
+    while !game.get_state_clone().move_generation_stack.is_empty() {
+        let (_, actions) = game.get_state_clone().generate_possible_actions();
+        game.apply_action(&actions[0]);
+    }
+}
+
+fn setup_cursola_vs_parasect(seed: u64) -> deckgym::Game<'static> {
+    let mut game = get_initialized_game(seed);
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    state.turn_count = 3;
+    state.points = [0, 0];
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A4a035GalarianCursola),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1015Parasect).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Grass,
+                EnergyType::Colorless,
+            ]),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+    game.set_state(state);
+    game
+}
+
+fn parasect_attacks(game: &mut deckgym::Game<'static>) {
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+}
+
+fn assert_promotion_is_queued(state: &deckgym::State) {
+    let (actor, actions) = state.generate_possible_actions();
+    assert!(actor == 0 || actor == 1);
+    assert!(actions
+        .iter()
+        .all(|action| matches!(action.action, SimpleAction::Activate { .. })));
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_can_ko_attacker_on_heads() {
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let parasect = get_card_by_enum(CardId::A1015Parasect);
+    let mut saw_heads = false;
+    let mut saw_tails = false;
+
+    for seed in 0..100 {
+        let mut game = setup_cursola_vs_parasect(seed);
+        parasect_attacks(&mut game);
+        let state = game.get_state_clone();
+
+        assert!(state.discard_piles[0].contains(&cursola));
+        assert_eq!(
+            state.points[1], 1,
+            "Seed {seed}: Parasect should score Cursola"
+        );
+
+        if state.in_play_pokemon[1][0].is_none() {
+            saw_heads = true;
+            assert!(state.discard_piles[1].contains(&parasect));
+            assert_eq!(
+                state.points[0], 1,
+                "Seed {seed}: Cursola should score Parasect on heads"
+            );
+            assert_promotion_is_queued(&state);
+        } else {
+            saw_tails = true;
+            assert_eq!(
+                state.get_active(1).get_name(),
+                "Parasect",
+                "Seed {seed}: Parasect should survive on tails"
+            );
+            assert_eq!(state.points[0], 0);
+        }
+
+        if saw_heads && saw_tails {
+            break;
+        }
+    }
+
+    assert!(
+        saw_heads,
+        "Expected at least one seed where Perish Body hits heads"
+    );
+    assert!(
+        saw_tails,
+        "Expected at least one seed where Perish Body hits tails"
+    );
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_does_not_trigger_from_bench() {
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A4a035GalarianCursola),
+        ],
+        vec![PlayedCard::from_id(CardId::A1015Parasect)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (1, 0),
+            targets: vec![(100, 0, 1)],
+            is_from_active_attack: true,
+        },
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(state.discard_piles[0].contains(&cursola));
+    assert_eq!(state.points, [0, 1]);
+    assert_eq!(state.get_active(1).get_name(), "Parasect");
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_does_not_trigger_from_non_attack_damage() {
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let mut game = setup_cursola_vs_parasect(0);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (1, 0),
+            targets: vec![(100, 0, 0)],
+            is_from_active_attack: false,
+        },
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(state.discard_piles[0].contains(&cursola));
+    assert_eq!(state.points, [0, 1]);
+    assert_eq!(state.get_active(1).get_name(), "Parasect");
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_does_not_trigger_from_poison_checkup() {
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let mut game = setup_cursola_vs_parasect(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.in_play_pokemon[0][0] =
+        Some(PlayedCard::from_id(CardId::A4a035GalarianCursola).with_remaining_hp(10));
+    state.apply_status_condition(0, 0, StatusCondition::Poisoned);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(state.discard_piles[0].contains(&cursola));
+    assert_eq!(state.points, [0, 1]);
+    assert_eq!(state.get_active(1).get_name(), "Parasect");
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_is_not_forced_by_will_from_previous_turn() {
+    let will = trainer_from_id(CardId::A4156Will);
+    let will_card = Card::Trainer(will.clone());
+    let mut saw_heads = false;
+    let mut saw_tails = false;
+
+    for seed in 0..100 {
+        let mut game = setup_cursola_vs_parasect(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 3;
+        state.hands[0] = vec![will_card.clone()];
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::Play {
+                trainer_card: will.clone(),
+            },
+            is_stack: false,
+        });
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::EndTurn,
+            is_stack: false,
+        });
+        parasect_attacks(&mut game);
+
+        let state = game.get_state_clone();
+        if state.in_play_pokemon[1][0].is_none() {
+            saw_heads = true;
+        } else {
+            saw_tails = true;
+        }
+
+        if saw_heads && saw_tails {
+            break;
+        }
+    }
+
+    assert!(
+        saw_heads,
+        "Will should not prevent Perish Body from hitting heads"
+    );
+    assert!(saw_tails, "Will should not force Perish Body to heads");
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_does_not_trigger_from_rocky_helmet() {
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let rocky_helmet = get_card_by_enum(CardId::A2148RockyHelmet);
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A4a035GalarianCursola)
+                .with_energy(vec![EnergyType::Psychic, EnergyType::Psychic])
+                .with_remaining_hp(20),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1003Venusaur).with_tool(rocky_helmet),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(state.discard_piles[0].contains(&cursola));
+    assert_eq!(state.points, [0, 1]);
+    assert_eq!(state.get_active(1).get_name(), "Venusaur");
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_can_be_forced_by_will_with_spike_armor() {
+    let will = trainer_from_id(CardId::A4156Will);
+    let will_card = Card::Trainer(will.clone());
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let sandslash = get_card_by_enum(CardId::A3039AlolanSandslash);
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    state.turn_count = 3;
+    state.hands[0] = vec![will_card];
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A4a035GalarianCursola)
+                .with_energy(vec![EnergyType::Psychic, EnergyType::Psychic])
+                .with_remaining_hp(60),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A3039AlolanSandslash).with_energy(vec![EnergyType::Water]),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    drain_stack(&mut game);
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card: will },
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(state.discard_piles[0].contains(&cursola));
+    assert!(state.discard_piles[1].contains(&sandslash));
+    assert_eq!(state.points, [1, 1]);
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_can_be_forced_by_will_with_cursed_prose() {
+    let will = trainer_from_id(CardId::A4156Will);
+    let will_card = Card::Trainer(will.clone());
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let mismagius = get_card_by_enum(CardId::A4a033Mismagius);
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    state.turn_count = 3;
+    state.hands[0] = vec![will_card];
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A4a035GalarianCursola),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A4a033Mismagius).with_energy(vec![EnergyType::Psychic]),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    drain_stack(&mut game);
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card: will },
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(state.discard_piles[0].contains(&cursola));
+    assert!(state.discard_piles[1].contains(&mismagius));
+    assert_eq!(state.points, [1, 1]);
+}
+
+#[test]
+fn test_mismagius_cursed_prose_does_not_damage_if_target_moves_to_bench() {
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    state.turn_count = 3;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A4a035GalarianCursola),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A4a033Mismagius).with_energy(vec![EnergyType::Psychic]),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    drain_stack(&mut game);
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Activate {
+            player: 0,
+            in_play_idx: 1,
+        },
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(!state.discard_piles[0].contains(&cursola));
+    assert_eq!(state.points, [0, 0]);
+    assert_eq!(
+        state.in_play_pokemon[0][1].as_ref().unwrap().get_name(),
+        "Galarian Cursola"
+    );
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_tracks_jumpluff_after_breeze_by_switch() {
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let jumpluff = get_card_by_enum(CardId::A4a003JumpluffEx);
+    let mut saw_heads = false;
+    let mut saw_tails = false;
+
+    for seed in 0..100 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 1;
+        state.turn_count = 3;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::A4a035GalarianCursola).with_remaining_hp(70),
+                PlayedCard::from_id(CardId::A1001Bulbasaur),
+            ],
+            vec![
+                PlayedCard::from_id(CardId::A4a003JumpluffEx).with_energy(vec![EnergyType::Grass]),
+                PlayedCard::from_id(CardId::A1033Charmander),
+            ],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 1,
+            action: SimpleAction::Attack(0),
+            is_stack: false,
+        });
+        game.apply_action(&Action {
+            actor: 1,
+            action: SimpleAction::Activate {
+                player: 1,
+                in_play_idx: 1,
+            },
+            is_stack: true,
+        });
+
+        let state = game.get_state_clone();
+        assert!(state.discard_piles[0].contains(&cursola));
+        assert_eq!(state.points[1], 1);
+        assert_eq!(state.get_active(1).get_name(), "Charmander");
+
+        if state.discard_piles[1].contains(&jumpluff) {
+            saw_heads = true;
+            assert_eq!(state.points[0], 2);
+        } else {
+            saw_tails = true;
+            assert_eq!(
+                state.in_play_pokemon[1][1].as_ref().unwrap().get_name(),
+                "Jumpluff ex"
+            );
+            assert_eq!(state.points[0], 0);
+        }
+
+        if saw_heads && saw_tails {
+            break;
+        }
+    }
+
+    assert!(
+        saw_heads,
+        "Expected Perish Body heads against benched Jumpluff ex"
+    );
+    assert!(
+        saw_tails,
+        "Expected Perish Body tails against benched Jumpluff ex"
+    );
+}
+
+#[test]
+fn test_galarian_cursola_perish_body_triggers_from_scizor_gale_thrust_extra_damage() {
+    let cursola = get_card_by_enum(CardId::A4a035GalarianCursola);
+    let scizor = get_card_by_enum(CardId::A4123Scizor);
+    let mut saw_heads = false;
+    let mut saw_tails = false;
+
+    for seed in 0..100 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        let mut active_scizor = PlayedCard::from_id(CardId::A4123Scizor)
+            .with_energy(vec![EnergyType::Metal, EnergyType::Metal]);
+        active_scizor.moved_to_active_this_turn = true;
+        state.current_player = 1;
+        state.turn_count = 3;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::A4a035GalarianCursola),
+                PlayedCard::from_id(CardId::A1001Bulbasaur),
+            ],
+            vec![active_scizor, PlayedCard::from_id(CardId::A1033Charmander)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 1,
+            action: SimpleAction::Attack(0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        assert!(state.discard_piles[0].contains(&cursola));
+        assert_eq!(state.points[1], 1);
+
+        if state.discard_piles[1].contains(&scizor) {
+            saw_heads = true;
+            assert_eq!(state.points[0], 1);
+        } else {
+            saw_tails = true;
+            assert_eq!(state.get_active(1).get_name(), "Scizor");
+            assert_eq!(state.points[0], 0);
+        }
+
+        if saw_heads && saw_tails {
+            break;
+        }
+    }
+
+    assert!(saw_heads, "Expected Perish Body heads against Scizor");
+    assert!(saw_tails, "Expected Perish Body tails against Scizor");
+}


### PR DESCRIPTION
## Summary

Implements `Galarian Cursola [A4a 035]` Perish Body as a passive KO trigger based on attack-damage source tracking rather than only the current Active slot.

This needed core engine support because Perish Body depends on the identity of the Pokemon that produced the attack damage, not just its current board position. For example, Jumpluff ex can deal lethal damage with Breeze-By Attack and then move to the Bench before KO resolution; on heads, Perish Body should KO that Jumpluff instance on the Bench, not the newly promoted Active Pokemon. The same identity tracking is needed for delayed or reactive attack damage such as Mismagius's Cursed Prose and Alolan Sandslash's Spike Armor.

## What changed

- Added passive `AbilityMechanic::PerishBody` mapping and kept it out of `UseAbility` generation.
- Added internal in-play Pokemon instance IDs so damage-origin tracking survives switches, retreats, and evolution, and is cleared when a Pokemon leaves play.
- Added attack-damage context for normal, delayed, and reactive attack damage so Perish Body can distinguish attack damage from Tool, Ability, and checkup/status damage.
- Deferred attack KO resolution for hit-and-run attacks so movement effects can resolve before Perish Body targets the original attacker instance.
- Adjusted Will ownership handling so prior-turn defensive Perish Body flips are not forced, while same-turn Spike Armor/Cursed Prose edge cases can consume the Cursola owner's pending Will.
- Added focused tests for direct attacks, bench/no-trigger cases, non-attack damage bypasses, Rocky Helmet, Will timing, Spike Armor, Cursed Prose, Jumpluff ex hit-and-run tracking, and Scizor/Gale Thrust-style extra attack damage.

## Validation

- `cargo +stable-x86_64-pc-windows-gnu test --features test-utils --test pokemon galarian_cursola_perish_body`
- `cargo +stable-x86_64-pc-windows-gnu test --features test-utils`
- `cargo +stable-x86_64-pc-windows-gnu clippy --lib --features test-utils -- -D warnings`

Benchmarks were checked separately before this commit; `play random game` showed no relevant regression versus `origin/main`.