### PR TITLE
Fix Bounded Field: apply weakness x2 to all modifiers, not just base damage

### DIFF
--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -686,26 +686,30 @@ fn get_turn_effect_damage_reduction(
         .sum::<u32>()
 }
 
-fn get_weakness_modifier(
+enum WeaknessApplication {
+    None,
+    Flat(u32),
+    Double,
+}
+
+fn get_weakness_application(
     state: &State,
     is_active_to_active: bool,
     target_player: usize,
     attacking_pokemon: &crate::models::PlayedCard,
-    base_damage: u32,
-) -> u32 {
+) -> WeaknessApplication {
     if !is_active_to_active {
-        return 0;
+        return WeaknessApplication::None;
     }
     let receiving = state.get_active(target_player);
 
-    // Check if defender has NoWeakness effect active
     if receiving
         .get_active_effects()
         .iter()
         .any(|effect| matches!(effect, CardEffect::NoWeakness))
     {
         debug!("NoWeakness: Ignoring weakness damage");
-        return 0;
+        return WeaknessApplication::None;
     }
 
     if let Card::Pokemon(pokemon_card) = &receiving.card {
@@ -715,17 +719,17 @@ fn get_weakness_modifier(
                 pokemon_card,
                 attacking_pokemon.card.get_type()
             );
-            // Bounded Field: apply weakness as ×2 for non-Mega-Evolution-ex attackers
+            // Bounded Field: ×2 all damage (including other modifiers) for non-Mega-ex attackers
             if is_bounded_field_active(state)
                 && !(attacking_pokemon.card.is_mega() && attacking_pokemon.card.is_ex())
             {
-                debug!("Bounded Field: Applying weakness as ×2");
-                return base_damage;
+                debug!("Bounded Field: Applying weakness as ×2 of total damage");
+                return WeaknessApplication::Double;
             }
-            return 20;
+            return WeaknessApplication::Flat(20);
         }
     }
-    0
+    WeaknessApplication::None
 }
 
 // TODO: Confirm is_from_attack and goes to enemy active
@@ -834,13 +838,8 @@ pub(crate) fn modify_damage(
         attacking_player,
         is_from_active_attack,
     );
-    let weakness_modifier = get_weakness_modifier(
-        state,
-        is_active_to_active,
-        target_player,
-        attacking_pokemon,
-        base_damage,
-    );
+    let weakness_application =
+        get_weakness_application(state, is_active_to_active, target_player, attacking_pokemon);
 
     // Type-specific damage boost abilities (e.g., Lucario's Fighting Coach, Aegislash's Royal Command)
     // These check if certain ability-holders are in play and boost damage for specific energy types
@@ -868,9 +867,8 @@ pub(crate) fn modify_damage(
     };
 
     debug!(
-        "Attack: {:?}, Weakness: {}, IncreasedDamage: {}, IncreasedAttackSpecific: {}, IncreasedVulnerability: {}, ReducedDamage: {}, TurnEffectReduction: {}, HeavyHelmet: {}, MetalCoreBarrier: {}, SteelApron: {}, IntimidatingFang: {}, AbilityReduction: {}, AbilityIncrease: {}, TypeBoost: {}, StadiumBonus: {}",
+        "Attack: {:?}, IncreasedDamage: {}, IncreasedAttackSpecific: {}, IncreasedVulnerability: {}, ReducedDamage: {}, TurnEffectReduction: {}, HeavyHelmet: {}, MetalCoreBarrier: {}, SteelApron: {}, IntimidatingFang: {}, AbilityReduction: {}, AbilityIncrease: {}, TypeBoost: {}, StadiumBonus: {}",
         base_damage,
-        weakness_modifier,
         increased_turn_effect_modifiers,
         increased_attack_specific_modifiers,
         increased_vulnerability_modifiers,
@@ -885,8 +883,7 @@ pub(crate) fn modify_damage(
         type_boost_bonus,
         stadium_damage_bonus
     );
-    (base_damage
-        + weakness_modifier
+    let pre_weakness = (base_damage
         + ability_damage_increase
         + increased_turn_effect_modifiers
         + increased_attack_specific_modifiers
@@ -901,7 +898,12 @@ pub(crate) fn modify_damage(
                 + steel_apron_reduction
                 + intimidating_fang_reduction
                 + ability_damage_reduction,
-        )
+        );
+    match weakness_application {
+        WeaknessApplication::None => pre_weakness,
+        WeaknessApplication::Flat(amount) => pre_weakness + amount,
+        WeaknessApplication::Double => pre_weakness * 2,
+    }
 }
 
 /// Calculate type-specific damage boost from abilities like Lucario's Fighting Coach or Aegislash's Royal Command

--- a/tests/stadiums/stadium_test.rs
+++ b/tests/stadiums/stadium_test.rs
@@ -901,3 +901,45 @@ fn test_bounded_field_does_not_affect_no_weakness_attacks() {
         "Bounded Field should not affect attacks where no weakness applies (60 - 30 = 30 HP)"
     );
 }
+
+#[test]
+fn test_bounded_field_doubles_all_modifiers_including_red() {
+    // Ponyta (Fire, 20 base damage) attacks Venusaur ex (Grass, weak to Fire, 190 HP).
+    // Red is played: +20 damage against ex → total before weakness = 40.
+    // Bounded Field is active: weakness multiplies everything x2 → 40 × 2 = 80 damage.
+    // Venusaur ex should have 190 - 80 = 110 HP remaining.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1042Ponyta).with_energy(vec![EnergyType::Fire])],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.active_stadium = Some(get_card_by_enum(CardId::B3155BoundedField));
+    state.hands[0] = vec![get_card_by_enum(CardId::A2b071Red)];
+    game.set_state(state);
+
+    let red_trainer = trainer_from_id(CardId::A2b071Red);
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: red_trainer,
+        },
+        is_stack: false,
+    });
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let defender_hp = state.get_active(1).get_remaining_hp();
+    assert_eq!(
+        defender_hp, 110,
+        "Bounded Field x2 should apply to all modifiers: (20 base + 20 Red) × 2 = 80 damage, leaving 110 HP"
+    );
+}


### PR DESCRIPTION
Weakness was computed as a flat additive modifier before other effects like
Red's +20 against ex. Bounded Field's x2 should multiply the total damage
after all additive and reductive modifiers are applied.

Refactors get_weakness_modifier into get_weakness_application returning a
WeaknessApplication enum (None / Flat / Double) so modify_damage can apply
weakness last — either +20 or x2 of the pre-weakness total.

Adds a regression test: Ponyta (20 dmg) + Red (+20 vs ex) + Bounded Field
into Venusaur ex (weak to Fire) → (20+20)×2 = 80 damage.

https://claude.ai/code/session_01Y6Zh8XgSguq3zWYn4BLnYz