### PR TITLE
Implement Tapu Lele's Energy Arrow attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -461,6 +461,9 @@ fn forecast_effect_attack_by_mechanic(
             opponent,
             damage_per_energy,
         } => damage_per_energy_all(state, *opponent, *damage_per_energy),
+        Mechanic::DamageToAnyOpponentPerTargetEnergy { damage_per_energy } => {
+            damage_to_any_opponent_per_target_energy(*damage_per_energy)
+        }
         Mechanic::DiscardHandCards { count } => {
             discard_hand_cards_required_attack(state, attack.fixed_damage, *count)
         }
@@ -2084,6 +2087,28 @@ fn damage_per_energy_all(state: &State, opponent: bool, damage_per_energy: u32) 
         .sum();
     let damage = total_energy * damage_per_energy;
     active_damage_doutcome(damage)
+}
+
+/// Choose 1 of the opponent's Pokémon; deal damage_per_energy × (energy on that Pokémon).
+fn damage_to_any_opponent_per_target_energy(damage_per_energy: u32) -> Outcomes {
+    active_damage_effect_doutcome(0, move |_, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        let choices: Vec<SimpleAction> = state
+            .enumerate_in_play_pokemon(opponent)
+            .map(|(in_play_idx, pokemon)| {
+                let energy_count = pokemon.attached_energy.len() as u32;
+                let damage = energy_count * damage_per_energy;
+                SimpleAction::ApplyDamage {
+                    attacking_ref: (action.actor, 0),
+                    targets: vec![(damage, opponent, in_play_idx)],
+                    is_from_active_attack: true,
+                }
+            })
+            .collect();
+        if !choices.is_empty() {
+            state.move_generation_stack.push((action.actor, choices));
+        }
+    })
 }
 
 /// Damage per specific energy type attached to self (e.g., Genesect's Metal Blast)

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -273,6 +273,10 @@ pub enum Mechanic {
         opponent: bool,
         damage_per_energy: u32,
     },
+    /// Choose 1 of the opponent's Pokémon; deal damage_per_energy × (energy on that Pokémon).
+    DamageToAnyOpponentPerTargetEnergy {
+        damage_per_energy: u32,
+    },
     DiscardHandCards {
         count: usize,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1278,7 +1278,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             bench_only: true,
         },
     );
-    // map.insert("This attack does 20 damage to 1 of your opponent's Pokémon for each Energy attached to that Pokémon.", todo_implementation);
+    map.insert(
+        "This attack does 20 damage to 1 of your opponent's Pokémon for each Energy attached to that Pokémon.",
+        Mechanic::DamageToAnyOpponentPerTargetEnergy { damage_per_energy: 20 },
+    );
     map.insert(
         "This attack does 20 damage to 1 of your opponent's Pokémon.",
         Mechanic::DirectDamage {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -70,6 +70,8 @@ mod shinx_hide_test;
 mod sunflora_quick_grow_beam_test;
 #[path = "pokemon/swift_shot_test.rs"]
 mod swift_shot_test;
+#[path = "pokemon/tapu_lele_energy_arrow_test.rs"]
+mod tapu_lele_energy_arrow_test;
 #[path = "pokemon/tepig_stoke_test.rs"]
 mod tepig_stoke_test;
 #[path = "pokemon/vaporeon_ex_test.rs"]

--- a/tests/pokemon/tapu_lele_energy_arrow_test.rs
+++ b/tests/pokemon/tapu_lele_energy_arrow_test.rs
@@ -1,0 +1,110 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Energy Arrow does 20 damage per energy attached to the chosen target.
+#[test]
+fn test_energy_arrow_damage_scales_with_target_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    // Tapu Lele with 1 Psychic energy; opponent active has 2 energy, benched has 1 energy.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A3084TapuLele).with_energy(vec![EnergyType::Psychic])],
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Grass]),
+            PlayedCard::from_id(CardId::A1033Charmander).with_energy(vec![EnergyType::Fire]),
+        ],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    // Should have 2 choices: active (2 energy → 40 dmg) and benched (1 energy → 20 dmg)
+    assert_eq!(choices.len(), 2);
+    assert!(choices
+        .iter()
+        .all(|c| matches!(c.action, SimpleAction::ApplyDamage { .. })));
+
+    // The choice targeting the active (in_play_idx 0, 2 energy) should deal 40 damage
+    let target_active = choices
+        .iter()
+        .find(|c| {
+            matches!(
+                &c.action,
+                SimpleAction::ApplyDamage { targets, .. } if targets == &vec![(40, 1, 0)]
+            )
+        })
+        .cloned()
+        .expect("Expected a choice dealing 40 damage to opponent's active");
+
+    game.apply_action(&target_active);
+    let state = game.get_state_clone();
+
+    // Bulbasaur HP 70, took 40 damage → 30 remaining
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        30,
+        "Bulbasaur should take 40 damage (2 energy × 20)"
+    );
+    // Charmander (bench) should be untouched
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        60,
+        "Charmander should be undamaged"
+    );
+}
+
+/// Energy Arrow deals 0 damage when the target has no energy.
+#[test]
+fn test_energy_arrow_deals_zero_when_target_has_no_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    // Opponent active has no energy attached.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A3084TapuLele).with_energy(vec![EnergyType::Psychic])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    // One choice targeting the active with 0 energy → 0 damage
+    assert_eq!(choices.len(), 1);
+
+    let target = choices[0].clone();
+    assert!(matches!(
+        &target.action,
+        SimpleAction::ApplyDamage { targets, .. } if targets == &vec![(0, 1, 0)]
+    ));
+
+    game.apply_action(&target);
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        70,
+        "Bulbasaur should take 0 damage (no energy)"
+    );
+}


### PR DESCRIPTION
Adds the DamageToAnyOpponentPerTargetEnergy mechanic that lets the
attacker choose 1 of the opponent's Pokémon and deal damage_per_energy ×
(energy attached to that target) damage, covering both A3 084 and A3 170.

https://claude.ai/code/session_01KpaBcxRQGx4KFJQrMnQyK1