### PR TITLE
Implement Brambleghast's Accept Pain ability (B3 073, B3 167)

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -177,4 +177,7 @@ pub enum AbilityMechanic {
         energy_type: EnergyType,
     },
     ProtectSelfNextTurnAfterAttackKnockout,
+    MoveFixedDamageFromActiveToThisBenched {
+        amount: u32,
+    },
 }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -250,6 +250,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::ProtectSelfNextTurnAfterAttackKnockout => {
             panic!("ProtectSelfNextTurnAfterAttackKnockout is a passive ability")
         }
+        AbilityMechanic::MoveFixedDamageFromActiveToThisBenched { amount } => {
+            move_fixed_damage_from_active_to_this_benched(in_play_idx, *amount)
+        }
     }
 }
 
@@ -522,6 +525,14 @@ fn heal_active_your_pokemon(amount: u32) -> Outcomes {
     Outcomes::single_fn(move |_rng, state, action| {
         let active = state.get_active_mut(action.actor);
         active.heal(amount);
+    })
+}
+
+fn move_fixed_damage_from_active_to_this_benched(self_idx: usize, amount: u32) -> Outcomes {
+    Outcomes::single_fn(move |_rng, state, action| {
+        state.get_active_mut(action.actor).heal(amount);
+        let targets = vec![(amount, action.actor, self_idx)];
+        handle_damage(state, (action.actor, 0), &targets, false, None);
     })
 }
 

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -421,7 +421,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
         // map.insert("Once during your turn, after you flip any coins for an attack of 1 of your [R] Pokémon, you may ignore all results of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.", todo_implementation);
         // map.insert("Once during your turn, if this Pokémon is in the Active Spot, you may make your opponent's Active Pokémon Confused.", todo_implementation);
         // map.insert("Once during your turn, if this Pokémon is in the Active Spot, you may switch out your opponent's Active Pokémon to the Bench. (Your opponent chooses the new Active Pokémon.)", todo_implementation);
-        // map.insert("Once during your turn, if this Pokémon is on your Bench, you may move 30 damage that your Active Pokémon has on it to this Pokémon.", todo_implementation);
+        map.insert(
+            "Once during your turn, if this Pokémon is on your Bench, you may move 30 damage that your Active Pokémon has on it to this Pokémon.",
+            AbilityMechanic::MoveFixedDamageFromActiveToThisBenched { amount: 30 },
+        );
         map.insert(
             "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may do 20 damage to your opponent's Active Pokémon.",
             AbilityMechanic::DamageOpponentActiveOnEvolve { amount: 20 },

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -164,7 +164,23 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::EndTurnDrawCardIfActive { .. } => false,
         AbilityMechanic::EndTurnHealSelfIfActive { .. } => false,
         AbilityMechanic::ProtectSelfNextTurnAfterAttackKnockout => false,
+        AbilityMechanic::MoveFixedDamageFromActiveToThisBenched { amount } => {
+            can_use_accept_pain(state, _in_play_index, card, *amount)
+        }
     }
+}
+
+fn can_use_accept_pain(
+    state: &State,
+    in_play_index: usize,
+    card: &PlayedCard,
+    amount: u32,
+) -> bool {
+    in_play_index != 0
+        && !card.ability_used
+        && state
+            .maybe_get_active(state.current_player)
+            .is_some_and(|active| active.get_damage_counters() >= amount)
 }
 
 fn can_use_celesteela_ultra_thrusters(state: &State, card: &PlayedCard) -> bool {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -10,6 +10,8 @@ mod blastoise_double_splash_test;
 mod bombirdier_test;
 #[path = "pokemon/bonsly_teary_attack_test.rs"]
 mod bonsly_teary_attack_test;
+#[path = "pokemon/brambleghast_accept_pain_test.rs"]
+mod brambleghast_accept_pain_test;
 #[path = "pokemon/camerupt_eruption_test.rs"]
 mod camerupt_eruption_test;
 #[path = "pokemon/castform_test.rs"]

--- a/tests/pokemon/brambleghast_accept_pain_test.rs
+++ b/tests/pokemon/brambleghast_accept_pain_test.rs
@@ -1,0 +1,79 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::PlayedCard,
+    test_support::get_initialized_game,
+};
+
+/// Test Brambleghast's Accept Pain ability moves 30 damage from Active to itself
+#[test]
+fn test_brambleghast_accept_pain_moves_30_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Active has 40 damage; Brambleghast on bench should absorb 30 of it
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(40),
+            PlayedCard::from_id(CardId::B3073Brambleghast),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let ability_action = Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 1 },
+        is_stack: false,
+    };
+    game.apply_action(&ability_action);
+
+    let final_state = game.get_state_clone();
+
+    // Bulbasaur (70 HP) had 40 damage; after moving 30 it has 10 damage left => 60 HP remaining
+    let active_hp = final_state.get_active(0).get_remaining_hp();
+    assert_eq!(
+        active_hp, 60,
+        "Active Bulbasaur should have 60 HP remaining after Accept Pain"
+    );
+
+    // Brambleghast (90 HP) should have taken 30 damage => 60 HP remaining
+    let brambleghast_hp = final_state
+        .enumerate_bench_pokemon(0)
+        .next()
+        .unwrap()
+        .1
+        .get_remaining_hp();
+    assert_eq!(
+        brambleghast_hp, 60,
+        "Brambleghast should have 60 HP after absorbing 30 damage"
+    );
+}
+
+/// Test Accept Pain cannot be used when the Active Pokémon has less than 30 damage
+#[test]
+fn test_brambleghast_accept_pain_not_available_without_enough_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Active has only 20 damage — not enough to move 30
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(20),
+            PlayedCard::from_id(CardId::B3073Brambleghast),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    let can_use_ability = actions
+        .iter()
+        .any(|a| matches!(a.action, SimpleAction::UseAbility { in_play_idx: 1 }));
+    assert!(
+        !can_use_ability,
+        "Accept Pain should not be available when Active has fewer than 30 damage"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds new `AbilityMechanic::MoveFixedDamageFromActiveToThisBenched { amount: u32 }` for Brambleghast's "Accept Pain" ability
- Implements move generation: usable once per turn, only when benched, only when Active has ≥30 damage
- Implements effect: heals 30 from the Active Pokémon and applies 30 damage to Brambleghast (with KO handling)
- Covers both B3 073 and B3 167 (full art) variants

## Test plan

- [x] `test_brambleghast_accept_pain_moves_30_damage` — verifies 30 damage moves from Active to Brambleghast
- [x] `test_brambleghast_accept_pain_not_available_without_enough_damage` — verifies ability is not offered when Active has < 30 damage
- [x] `cargo run --bin card_test -- "B3 073"` — 10,000 random games complete without errors
- [x] `cargo run --bin card_test -- "B3 167"` — 10,000 random games complete without errors
- [x] Full pokemon test suite (150 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)