### PR TITLE
Implement Flygon ex (B3 126/188/201): Dragon Pulse and Sand Slammer

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -90,6 +90,9 @@ pub enum AbilityMechanic {
     CheckupDamageToOpponentActive {
         amount: u32,
     },
+    CheckupDamageToAllOpponentPokemon {
+        amount: u32,
+    },
     DiscardEnergyToIncreaseTypeDamage {
         discard_energy: EnergyType,
         attack_type: EnergyType,

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -150,6 +150,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::CheckupDamageToOpponentActive { .. } => {
             panic!("CheckupDamageToOpponentActive is a passive ability")
         }
+        AbilityMechanic::CheckupDamageToAllOpponentPokemon { .. } => {
+            panic!("CheckupDamageToAllOpponentPokemon is a passive ability")
+        }
         AbilityMechanic::BadDreamsEndOfTurn { .. } => {
             panic!("BadDreamsEndOfTurn is a passive ability")
         }

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -292,33 +292,33 @@ fn apply_pokemon_checkup(
 }
 
 fn apply_snowy_terrain_checkup_damage(state: &mut State) {
-    let mut source_players_with_damage: Vec<(usize, u32)> = vec![];
+    let mut active_only_damage: Vec<(usize, u32)> = vec![];
+    let mut all_opponent_damage: Vec<(usize, u32)> = vec![];
 
     for player in 0..2 {
         let Some(active) = state.in_play_pokemon[player][0].as_ref() else {
             continue;
         };
-
-        let checkup_damage = get_ability_mechanic(&active.card)
-            .and_then(|m| match m {
-                AbilityMechanic::CheckupDamageToOpponentActive { amount } => Some(*amount),
-                _ => None,
-            })
-            .unwrap_or(0);
-
-        if checkup_damage > 0 && !active.is_knocked_out() {
-            source_players_with_damage.push((player, checkup_damage));
+        if active.is_knocked_out() {
+            continue;
+        }
+        match get_ability_mechanic(&active.card) {
+            Some(AbilityMechanic::CheckupDamageToOpponentActive { amount }) => {
+                active_only_damage.push((player, *amount));
+            }
+            Some(AbilityMechanic::CheckupDamageToAllOpponentPokemon { amount }) => {
+                all_opponent_damage.push((player, *amount));
+            }
+            _ => {}
         }
     }
 
-    for (source_player, checkup_damage) in source_players_with_damage {
+    for (source_player, checkup_damage) in active_only_damage {
         let target_player = (source_player + 1) % 2;
-
         if state.in_play_pokemon[target_player][0].is_some() {
             debug!(
                 "Snowy Terrain: Player {} active Pokémon deals {} checkup damage to opponent active",
-                source_player,
-                checkup_damage
+                source_player, checkup_damage
             );
             handle_damage(
                 state,
@@ -327,6 +327,21 @@ fn apply_snowy_terrain_checkup_damage(state: &mut State) {
                 false,
                 None,
             );
+        }
+    }
+
+    for (source_player, checkup_damage) in all_opponent_damage {
+        let target_player = (source_player + 1) % 2;
+        let targets: Vec<(u32, usize, usize)> = state
+            .enumerate_in_play_pokemon(target_player)
+            .map(|(idx, _)| (checkup_damage, target_player, idx))
+            .collect();
+        if !targets.is_empty() {
+            debug!(
+                "Sand Slammer: Player {} active Pokémon deals {} checkup damage to all opponent Pokémon",
+                source_player, checkup_damage
+            );
+            handle_damage(state, (source_player, 0), &targets, false, None);
         }
     }
 }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -657,6 +657,7 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfDefenderPoisoned { extra_damage } => {
             extra_damage_if_defender_poisoned(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::DiscardTopSelfDeck => discard_top_self_deck(attack.fixed_damage),
     }
 }
 
@@ -1573,6 +1574,14 @@ fn discard_opponent_active_tools_before_damage(damage: u32, attack_name: String)
         );
         handle_knockouts(state, attacking_ref, true);
     }))
+}
+
+fn discard_top_self_deck(damage: u32) -> Outcomes {
+    active_damage_effect_doutcome(damage, |_, state, action| {
+        if let Some(card) = state.decks[action.actor].draw() {
+            state.discard_piles[action.actor].push(card);
+        }
+    })
 }
 
 /// For attacks that deal damage and discard cards from the top of opponent's deck

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -369,4 +369,6 @@ pub enum Mechanic {
     ExtraDamageIfDefenderPoisoned {
         extra_damage: u32,
     },
+    /// Discard the top card of the attacker's own deck after dealing damage.
+    DiscardTopSelfDeck,
 }

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -415,7 +415,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
                 amount: 1,
             },
         );
-        // map.insert("During Pokémon Checkup, if this Pokémon is in the Active Spot, do 10 damage to each of your opponent's Pokémon.", todo_implementation);
+        map.insert(
+            "During Pokémon Checkup, if this Pokémon is in the Active Spot, do 10 damage to each of your opponent's Pokémon.",
+            AbilityMechanic::CheckupDamageToAllOpponentPokemon { amount: 10 },
+        );
         // map.insert("Each of your evolved Pokémon can use any attack from its previous Evolutions. (You still need the necessary Energy to use each attack.)", todo_implementation);
         // map.insert("If you don't have Regirock, Regice, and Registeel on your Bench, this Pokémon can't attack.", todo_implementation);
         // map.insert("Once during your turn, after you flip any coins for an attack of 1 of your [R] Pokémon, you may ignore all results of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.", todo_implementation);

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1847,7 +1847,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("Discard a [D] Energy from this Pokémon.", todo_implementation);
     // map.insert("Discard a [R] Energy from your opponent's Active Pokémon.", todo_implementation);
     // map.insert("Discard a [W] Energy from this Pokémon, and this attack also does 40 damage to 1 of your opponent's Benched Pokémon.", todo_implementation);
-    // map.insert("Discard the top card of your deck.", todo_implementation);
+    map.insert(
+        "Discard the top card of your deck.",
+        Mechanic::DiscardTopSelfDeck,
+    );
     // map.insert("During your next turn, attacks used by your [F] Pokémon do +30 damage to your opponent's Active Pokémon.", todo_implementation);
     // map.insert("During your next turn, this Pokémon's Psych Up attack does +30 damage.", todo_implementation);
     // map.insert("During your opponent's next turn, they can't play any Pokémon from their hand to evolve their Pokémon.", todo_implementation);

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -117,6 +117,7 @@ fn can_use_ability_by_mechanic(
         }
         AbilityMechanic::CoinFlipToPreventDamage => false, // Passive ability
         AbilityMechanic::CheckupDamageToOpponentActive { .. } => false, // Passive ability
+        AbilityMechanic::CheckupDamageToAllOpponentPokemon { .. } => false, // Passive ability
         AbilityMechanic::BadDreamsEndOfTurn { .. } => false, // Passive ability
         AbilityMechanic::CoinFlipSleepOpponentActive => !card.ability_used,
         AbilityMechanic::DiscardEnergyToIncreaseTypeDamage { discard_energy, .. } => {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -30,6 +30,8 @@ mod darkrai_ex_test;
 mod dusknoir_shadow_void_test;
 #[path = "pokemon/emboar_flare_storm_test.rs"]
 mod emboar_flare_storm_test;
+#[path = "pokemon/flygon_ex_test.rs"]
+mod flygon_ex_test;
 #[path = "pokemon/gallade_test.rs"]
 mod gallade_test;
 #[path = "pokemon/grovyle_slicing_snipe_test.rs"]

--- a/tests/pokemon/flygon_ex_test.rs
+++ b/tests/pokemon/flygon_ex_test.rs
@@ -1,0 +1,89 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+#[test]
+fn test_flygon_ex_dragon_pulse_discards_top_card_of_own_deck() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3126FlygonEx).with_energy(vec![
+            EnergyType::Grass,
+            EnergyType::Fighting,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1053Squirtle)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    game.set_state(state);
+
+    let deck_size_before = game.get_state_clone().decks[0].cards.len();
+    let discard_size_before = game.get_state_clone().discard_piles[0].len();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.decks[0].cards.len(),
+        deck_size_before - 1,
+        "Dragon Pulse should discard the top card of Flygon ex's deck"
+    );
+    assert_eq!(
+        state.discard_piles[0].len(),
+        discard_size_before + 1,
+        "Dragon Pulse should put the discarded card into Flygon ex's discard pile"
+    );
+}
+
+#[test]
+fn test_flygon_ex_sand_slammer_damages_all_opponent_pokemon_on_checkup() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Player 0: Squirtle (active), Bulbasaur (bench)
+    // Player 1: Flygon ex (active, with Sand Slammer), Bulbasaur (bench)
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1053Squirtle),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::B3126FlygonEx),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    game.set_state(state);
+
+    let squirtle_hp = game.get_state_clone().get_remaining_hp(0, 0);
+    let bulbasaur_hp = game.get_state_clone().get_remaining_hp(0, 1);
+
+    // End player 0's turn — checkup fires, Sand Slammer deals 10 to all player 0's Pokémon
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_remaining_hp(0, 0),
+        squirtle_hp - 10,
+        "Sand Slammer should deal 10 damage to opponent's active Pokémon"
+    );
+    assert_eq!(
+        state.get_remaining_hp(0, 1),
+        bulbasaur_hp - 10,
+        "Sand Slammer should deal 10 damage to opponent's benched Pokémon"
+    );
+}


### PR DESCRIPTION
Dragon Pulse: adds DiscardTopSelfDeck attack mechanic that discards the
top card of the attacker's own deck after dealing 140 damage.

Sand Slammer: adds CheckupDamageToAllOpponentPokemon ability mechanic
that deals 10 damage to each of the opponent's Pokémon during Pokémon
Checkup when Flygon ex is in the Active Spot.

https://claude.ai/code/session_01RmASBMSwiqqeFyAsK1so2L