### PR TITLE
Fix replaced Stadium discard owner

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -249,8 +249,8 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
             state.discard_tool(*player, *in_play_idx);
         }
         SimpleAction::DiscardActiveStadium => {
-            if let Some(stadium) = state.active_stadium.take() {
-                state.discard_piles[action.actor].push(stadium);
+            if let Some((stadium, owner)) = state.take_active_stadium() {
+                state.discard_piles[owner.unwrap_or(action.actor)].push(stadium);
             }
         }
         SimpleAction::Noop => {}

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -658,9 +658,11 @@ pub(crate) fn wrap_with_common_logic(mutation: Mutation) -> Mutation {
         if let SimpleAction::Play { trainer_card } = &action.action {
             let card = Card::Trainer(trainer_card.clone());
             if trainer_card.trainer_card_type == TrainerType::Stadium {
-                // Replace old stadium (discard it if exists)
-                if let Some(old_stadium) = state.set_active_stadium(card.clone()) {
-                    state.discard_piles[action.actor].push(old_stadium);
+                // Replaced Stadium cards go to the discard pile of the player who played them.
+                if let Some((old_stadium, old_owner)) =
+                    state.set_active_stadium_for_player(action.actor, card.clone())
+                {
+                    state.discard_piles[old_owner.unwrap_or(action.actor)].push(old_stadium);
                 }
                 state.remove_card_from_hand(action.actor, &card);
                 state.refresh_starting_plains_bonus_all();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -60,6 +60,8 @@ pub struct State {
     pub in_play_pokemon: [[Option<PlayedCard>; 4]; 2],
     // Stadium card currently in play (affects both players)
     pub active_stadium: Option<Card>,
+    #[serde(default)]
+    pub active_stadium_owner: Option<usize>,
 
     // Turn Flags (remember to reset these in reset_turn_states)
     pub(crate) has_played_support: bool,
@@ -87,6 +89,7 @@ impl State {
             discard_energies: [Vec::new(), Vec::new()],
             in_play_pokemon: [[None, None, None, None], [None, None, None, None]],
             active_stadium: None,
+            active_stadium_owner: None,
             has_played_support: false,
             has_retreated: false,
             has_used_stadium: [false, false],
@@ -102,7 +105,24 @@ impl State {
     }
 
     pub fn set_active_stadium(&mut self, stadium: Card) -> Option<Card> {
+        self.active_stadium_owner = None;
         self.active_stadium.replace(stadium)
+    }
+
+    pub fn set_active_stadium_for_player(
+        &mut self,
+        player: usize,
+        stadium: Card,
+    ) -> Option<(Card, Option<usize>)> {
+        let old_stadium = self.active_stadium.replace(stadium);
+        let old_owner = self.active_stadium_owner.replace(player);
+        old_stadium.map(|stadium| (stadium, old_owner))
+    }
+
+    pub fn take_active_stadium(&mut self) -> Option<(Card, Option<usize>)> {
+        let stadium = self.active_stadium.take();
+        let owner = self.active_stadium_owner.take();
+        stadium.map(|stadium| (stadium, owner))
     }
 
     pub(crate) fn refresh_starting_plains_bonus_all(&mut self) {

--- a/tests/stadiums/stadium_test.rs
+++ b/tests/stadiums/stadium_test.rs
@@ -258,6 +258,64 @@ fn test_stadium_is_discarded_when_replaced() {
     assert!(matches!(&state.discard_piles[0][0], Card::Trainer(t) if t.name == "Peculiar Plaza"));
 }
 
+#[test]
+fn test_replaced_stadium_goes_to_original_players_discard() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.hands[0] = vec![get_card_by_enum(CardId::B2155PeculiarPlaza)];
+    state.hands[1] = vec![get_card_by_enum(CardId::B2153TrainingArea)];
+    game.set_state(state);
+
+    let play_peculiar_plaza = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: trainer_from_id(CardId::B2155PeculiarPlaza),
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_peculiar_plaza);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.active_stadium_owner, Some(0));
+    assert!(state.discard_piles[0].is_empty());
+    assert!(state.discard_piles[1].is_empty());
+
+    let play_training_area = Action {
+        actor: 1,
+        action: SimpleAction::Play {
+            trainer_card: trainer_from_id(CardId::B2153TrainingArea),
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_training_area);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active_stadium_name(),
+        Some("Training Area".to_string())
+    );
+    assert_eq!(state.active_stadium_owner, Some(1));
+    assert!(
+        state.discard_piles[0]
+            .iter()
+            .any(|card| matches!(card, Card::Trainer(trainer) if trainer.name == "Peculiar Plaza")),
+        "Player 0's replaced Stadium should go to Player 0's discard pile"
+    );
+    assert!(
+        !state.discard_piles[1]
+            .iter()
+            .any(|card| matches!(card, Card::Trainer(trainer) if trainer.name == "Peculiar Plaza")),
+        "Player 0's replaced Stadium should not go to Player 1's discard pile"
+    );
+}
+
 // ============================================================================
 // Training Area Tests
 // ============================================================================


### PR DESCRIPTION
Fixes #258.

## Summary
- track the player who played the currently active Stadium
- discard replaced Stadium cards to their original owner's discard pile
- apply the same owner-aware removal path when an active Stadium is discarded directly
- add a regression test for player 1 replacing player 0's Stadium

## Testing
- `cargo test --features "tui test-utils" --test stadiums`
- `cargo test --features "tui test-utils" field_blower`
- `cargo clippy --features tui -- -D warnings`
- `cargo test --features "tui test-utils"`
