### PR TITLE
Implement Crawdaunt's Unruly Claw ability (A4 061, A4b 104, A4b 105, A4b 355)

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -155,6 +155,7 @@ pub enum AbilityMechanic {
     DamageOpponentActiveOnEvolve {
         amount: u32,
     },
+    DiscardRandomEnergyFromOpponentActiveOnEvolve,
     CanEvolveIntoEeveeEvolution,
     CanEvolveOnFirstTurnIfActive,
     CounterattackDamage {

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -220,6 +220,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::DamageOpponentActiveOnEvolve { .. } => {
             panic!("DamageOpponentActiveOnEvolve is triggered on evolve")
         }
+        AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve => {
+            panic!("DiscardRandomEnergyFromOpponentActiveOnEvolve is triggered on evolve")
+        }
         AbilityMechanic::CanEvolveIntoEeveeEvolution => {
             panic!("CanEvolveIntoEeveeEvolution is a passive ability")
         }

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -65,6 +65,7 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::ReturnPokemonToHand { .. }
         | SimpleAction::DiscardToolFromPokemon { .. }
         | SimpleAction::DiscardActiveStadium
+        | SimpleAction::DiscardRandomOpponentActiveEnergy
         | SimpleAction::Noop => forecast_deterministic_action(),
         SimpleAction::UseAbility { in_play_idx } => forecast_ability(state, action, *in_play_idx),
         SimpleAction::Attack(index) => forecast_attack(action.actor, state, *index),
@@ -251,6 +252,12 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
         SimpleAction::DiscardActiveStadium => {
             if let Some((stadium, owner)) = state.take_active_stadium() {
                 state.discard_piles[owner.unwrap_or(action.actor)].push(stadium);
+            }
+        }
+        SimpleAction::DiscardRandomOpponentActiveEnergy => {
+            let opponent = (action.actor + 1) % 2;
+            if let Some(energy) = state.get_active(opponent).attached_energy.last().copied() {
+                state.discard_from_active(opponent, &[energy]);
             }
         }
         SimpleAction::Noop => {}

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -181,7 +181,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "Once during your turn, if you have Arceus or Arceus ex in play, you may do 30 damage to your opponent's Active Pokémon.",
             AbilityMechanic::DamageOpponentActiveIfArceusInPlay { amount: 30 },
         );
-        // map.insert("Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may discard a random Energy from your opponent's Active Pokémon.", todo_implementation);
+        map.insert(
+            "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may discard a random Energy from your opponent's Active Pokémon.",
+            AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve,
+        );
         map.insert(
             "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may draw 2 cards.",
             AbilityMechanic::DrawCardsOnEvolve { amount: 2 },

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -142,6 +142,8 @@ pub enum SimpleAction {
     },
     /// Field Blower: discard the active stadium.
     DiscardActiveStadium,
+    /// Crawdaunt's Unruly Claw: discard a random Energy from the opponent's Active Pokémon
+    DiscardRandomOpponentActiveEnergy,
     Noop, // No operation, used to have the user say "no" to a question
 }
 
@@ -290,6 +292,9 @@ impl fmt::Display for SimpleAction {
                 write!(f, "DiscardToolFromPokemon({player}, {in_play_idx})")
             }
             SimpleAction::DiscardActiveStadium => write!(f, "DiscardActiveStadium"),
+            SimpleAction::DiscardRandomOpponentActiveEnergy => {
+                write!(f, "DiscardRandomOpponentActiveEnergy")
+            }
             SimpleAction::UseStadium => write!(f, "UseStadium"),
             SimpleAction::Noop => write!(f, "Noop"),
         }

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -142,6 +142,21 @@ pub(crate) fn on_evolve(actor: usize, state: &mut State, to_card: &Card, from_ha
                 ],
             ));
         }
+        Some(AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve) => {
+            let opponent = (actor + 1) % 2;
+            let has_energy = state
+                .maybe_get_active(opponent)
+                .is_some_and(|active| !active.attached_energy.is_empty());
+            if has_energy {
+                state.move_generation_stack.push((
+                    actor,
+                    vec![
+                        SimpleAction::DiscardRandomOpponentActiveEnergy,
+                        SimpleAction::Noop,
+                    ],
+                ));
+            }
+        }
         _ => {}
     }
 }

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -152,6 +152,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::HealTypedPokemonOnEvolve { .. } => false,
         AbilityMechanic::AttachEnergyFromZoneToActiveTypedOnEvolve { .. } => false,
         AbilityMechanic::DamageOpponentActiveOnEvolve { .. } => false,
+        AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve => false,
         AbilityMechanic::CanEvolveIntoEeveeEvolution => false,
         AbilityMechanic::CanEvolveOnFirstTurnIfActive => false,
         AbilityMechanic::CounterattackDamage { .. } => false,

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -70,6 +70,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::ReturnPokemonToHand { .. } => 5,
         SimpleAction::DiscardToolFromPokemon { .. } => 5,
         SimpleAction::DiscardActiveStadium => 5,
+        SimpleAction::DiscardRandomOpponentActiveEnergy => 10,
         SimpleAction::UseStadium => 5, // Stadium abilities like Mesagoza
         SimpleAction::Noop => 0,       // No operation has no weight
     }

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -24,6 +24,8 @@ mod charmeleon_ignition_test;
 mod comfey_flower_shield_test;
 #[path = "pokemon/corviknight_line_test.rs"]
 mod corviknight_line_test;
+#[path = "pokemon/crawdaunt_unruly_claw_test.rs"]
+mod crawdaunt_unruly_claw_test;
 #[path = "pokemon/darkrai_ex_test.rs"]
 mod darkrai_ex_test;
 #[path = "pokemon/dusknoir_shadow_void_test.rs"]

--- a/tests/pokemon/crawdaunt_unruly_claw_test.rs
+++ b/tests/pokemon/crawdaunt_unruly_claw_test.rs
@@ -1,0 +1,124 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+#[test]
+fn test_crawdaunt_unruly_claw_offers_discard_and_noop_on_evolve() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A4060Corphish)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass])],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::A4061Crawdaunt));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Evolve {
+            evolution: get_card_by_enum(CardId::A4061Crawdaunt),
+            in_play_idx: 0,
+            from_deck: false,
+        },
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(
+        choices.len(),
+        2,
+        "Unruly Claw should be optional (2 choices)"
+    );
+    assert!(
+        choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::Noop)),
+        "Noop should be an option"
+    );
+    assert!(
+        choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::DiscardRandomOpponentActiveEnergy)),
+        "Discard choice should be offered when opponent has energy"
+    );
+}
+
+#[test]
+fn test_crawdaunt_unruly_claw_discards_opponent_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A4060Corphish)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass])],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::A4061Crawdaunt));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Evolve {
+            evolution: get_card_by_enum(CardId::A4061Crawdaunt),
+            in_play_idx: 0,
+            from_deck: false,
+        },
+        is_stack: false,
+    });
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::DiscardRandomOpponentActiveEnergy,
+        is_stack: true,
+    });
+
+    assert!(
+        game.get_state_clone()
+            .get_active(1)
+            .attached_energy
+            .is_empty(),
+        "Opponent's active should have no energy after Unruly Claw"
+    );
+}
+
+#[test]
+fn test_crawdaunt_unruly_claw_does_not_offer_choice_without_opponent_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A4060Corphish)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::A4061Crawdaunt));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Evolve {
+            evolution: get_card_by_enum(CardId::A4061Crawdaunt),
+            in_play_idx: 0,
+            from_deck: false,
+        },
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::DiscardRandomOpponentActiveEnergy)),
+        "No discard choice when opponent's active has no energy"
+    );
+}


### PR DESCRIPTION
Adds the on-evolve ability that discards a random Energy from the opponent's
Active Pokémon when Crawdaunt is played from hand to evolve. Introduces a new
DiscardRandomOpponentActiveEnergy SimpleAction to represent this effect, wired
through the on_evolve hook and the full action pipeline.

https://claude.ai/code/session_01KJ7MAjyoVEEURdSGrDCqgq