### PR TITLE
Add support for Iron Hands, Iron Moth, and Slither Wing Pokémon

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -658,6 +658,14 @@ fn forecast_effect_attack_by_mechanic(
             extra_damage_if_defender_poisoned(state, attack.fixed_damage, *extra_damage)
         }
         Mechanic::DiscardTopSelfDeck => discard_top_self_deck(attack.fixed_damage),
+        Mechanic::TieredCoinFlipDamage {
+            num_coins,
+            extra_damage_by_heads,
+        } => tiered_coin_flip_damage(
+            attack.fixed_damage,
+            *num_coins,
+            extra_damage_by_heads.clone(),
+        ),
     }
 }
 
@@ -1581,6 +1589,17 @@ fn discard_top_self_deck(damage: u32) -> Outcomes {
         if let Some(card) = state.decks[action.actor].draw() {
             state.discard_piles[action.actor].push(card);
         }
+    })
+}
+
+fn tiered_coin_flip_damage(
+    fixed_damage: u32,
+    num_coins: usize,
+    extra_damage_by_heads: Vec<u32>,
+) -> Outcomes {
+    Outcomes::binomial_by_heads(num_coins, move |heads| {
+        let extra = extra_damage_by_heads.get(heads).copied().unwrap_or(0);
+        active_damage_mutation(fixed_damage + extra)
     })
 }
 

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -371,4 +371,10 @@ pub enum Mechanic {
     },
     /// Discard the top card of the attacker's own deck after dealing damage.
     DiscardTopSelfDeck,
+    /// Tiered coin flip damage: flip `num_coins` coins and deal fixed_damage +
+    /// extra_damage_by_heads[heads_count] total damage.
+    TieredCoinFlipDamage {
+        num_coins: usize,
+        extra_damage_by_heads: Vec<u32>,
+    },
 }

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -483,6 +483,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("Flip 2 coins. This attack does 70 damage for each heads. If at least 1 of them is heads, your opponent's Active Pokémon is now Burned.", todo_implementation);
     map.insert(
+        "Flip 2 coins. This attack does 70 damage for each heads.",
+        Mechanic::ExtraDamageForEachHeads {
+            include_fixed_damage: false,
+            damage_per_head: 70,
+            num_coins: 2,
+        },
+    );
+    map.insert(
         "Flip 2 coins. This attack does 80 damage for each heads.",
         Mechanic::ExtraDamageForEachHeads {
             include_fixed_damage: false,
@@ -1114,6 +1122,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     map.insert(
         "This Pokémon also does 50 damage to itself.",
         Mechanic::SelfDamage { amount: 50 },
+    );
+    map.insert(
+        "This Pokémon also does 60 damage to itself.",
+        Mechanic::SelfDamage { amount: 60 },
     );
     map.insert(
         "This Pokémon also does 70 damage to itself.",
@@ -1961,5 +1973,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     // map.insert("This attack does 60 damage to 1 of your opponent's Pokémon that have damage on them.", todo_implementation);
+
+    // B3a Mechanics
+    map.insert(
+        "Flip 3 coins. If 1 of them is heads, this attack does 20 more damage. If 2 of them are heads, this attack does 50 more damage. If all of them are heads, this attack does 120 more damage.",
+        Mechanic::TieredCoinFlipDamage {
+            num_coins: 3,
+            extra_damage_by_heads: vec![0, 20, 50, 120],
+        },
+    );
     map
 });

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -42,6 +42,10 @@ mod grovyle_slicing_snipe_test;
 mod heracross_test;
 #[path = "pokemon/houndstone_last_respects_test.rs"]
 mod houndstone_last_respects_test;
+#[path = "pokemon/iron_hands_test.rs"]
+mod iron_hands_test;
+#[path = "pokemon/iron_moth_test.rs"]
+mod iron_moth_test;
 #[path = "pokemon/jolteon_ex_test.rs"]
 mod jolteon_ex_test;
 #[path = "pokemon/klefki_dismantling_keys_test.rs"]
@@ -74,6 +78,8 @@ mod porygonz_cyberjack_test;
 mod rampardos_head_smash_test;
 #[path = "pokemon/shinx_hide_test.rs"]
 mod shinx_hide_test;
+#[path = "pokemon/slither_wing_test.rs"]
+mod slither_wing_test;
 #[path = "pokemon/sunflora_quick_grow_beam_test.rs"]
 mod sunflora_quick_grow_beam_test;
 #[path = "pokemon/swift_shot_test.rs"]

--- a/tests/pokemon/iron_hands_test.rs
+++ b/tests/pokemon/iron_hands_test.rs
@@ -1,0 +1,125 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn played_with_hp(card_id: CardId, hp: u32) -> PlayedCard {
+    let card = deckgym::database::get_card_by_enum(card_id);
+    PlayedCard::new(card, 0, hp, vec![], false, vec![])
+}
+
+/// Successive Slapping does 70 damage per heads over 2 coin flips.
+/// Using Will (force heads) ensures 2 heads = 140 damage.
+#[test]
+fn test_iron_hands_successive_slapping_two_heads_with_will() {
+    use deckgym::{actions::Action, card_ids::CardId, database::get_card_by_enum, models::Card};
+
+    fn trainer_from_id(card_id: CardId) -> deckgym::models::TrainerCard {
+        match get_card_by_enum(card_id) {
+            Card::Trainer(t) => t,
+            _ => panic!("Expected trainer card"),
+        }
+    }
+
+    let mut game = get_initialized_game(0);
+    let will = trainer_from_id(CardId::A4156Will);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a017IronHands).with_energy(vec![
+                EnergyType::Lightning,
+                EnergyType::Lightning,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![played_with_hp(CardId::A1001Bulbasaur, 200)],
+    );
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.hands[0] = vec![Card::Trainer(will.clone())];
+    game.set_state(state);
+
+    // Play Will to force the first coin to be heads
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card: will },
+        is_stack: false,
+    });
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let final_state = game.get_state_clone();
+    // With Will guaranteeing at least 1 head (and typically 2 heads), test checks
+    // that damage is at least 70. With 2 heads: 200 - 140 = 60.
+    let opponent_hp = final_state.get_active(1).get_remaining_hp();
+    // At minimum 1 head forced by Will => at least 70 damage => hp at most 130
+    assert!(
+        opponent_hp <= 130,
+        "Successive Slapping with Will (at least 1 heads) should deal at least 70 damage, opponent hp={opponent_hp}"
+    );
+}
+
+/// Successive Slapping can produce 0 damage (0 heads), 70 (1 head), or 140 (2 heads).
+#[test]
+fn test_iron_hands_successive_slapping_variable_damage() {
+    let mut saw_zero = false;
+    let mut saw_seventy = false;
+    let mut saw_one_forty = false;
+
+    for seed in 0..200 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::B3a017IronHands).with_energy(vec![
+                    EnergyType::Lightning,
+                    EnergyType::Lightning,
+                    EnergyType::Colorless,
+                ]),
+            ],
+            vec![played_with_hp(CardId::A1001Bulbasaur, 200)],
+        );
+        state.current_player = 0;
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::Attack(0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let opponent_hp = game.get_state_clone().get_active(1).get_remaining_hp();
+        let damage_dealt = 200 - opponent_hp;
+
+        match damage_dealt {
+            0 => saw_zero = true,
+            70 => saw_seventy = true,
+            140 => saw_one_forty = true,
+            other => panic!("Unexpected damage from Successive Slapping: {other}"),
+        }
+
+        if saw_zero && saw_seventy && saw_one_forty {
+            break;
+        }
+    }
+
+    assert!(saw_zero, "Expected at least one 0-damage outcome (0 heads)");
+    assert!(
+        saw_seventy,
+        "Expected at least one 70-damage outcome (1 head)"
+    );
+    assert!(
+        saw_one_forty,
+        "Expected at least one 140-damage outcome (2 heads)"
+    );
+}

--- a/tests/pokemon/iron_moth_test.rs
+++ b/tests/pokemon/iron_moth_test.rs
@@ -1,0 +1,113 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn played_with_hp(card_id: CardId, hp: u32) -> PlayedCard {
+    let card = deckgym::database::get_card_by_enum(card_id);
+    PlayedCard::new(card, 0, hp, vec![], false, vec![])
+}
+
+/// Thermal Gust: 3-coin tiered damage attack.
+/// With Will (force first coin heads), at least 1 head is guaranteed.
+/// Uses Squirtle (Water, not weak to Fire) to avoid weakness modifier.
+#[test]
+fn test_iron_moth_thermal_gust_at_least_one_head_with_will() {
+    use deckgym::{database::get_card_by_enum, models::Card};
+
+    fn trainer_from_id(card_id: CardId) -> deckgym::models::TrainerCard {
+        match get_card_by_enum(card_id) {
+            Card::Trainer(t) => t,
+            _ => panic!("Expected trainer card"),
+        }
+    }
+
+    let mut game = get_initialized_game(0);
+    let will = trainer_from_id(CardId::A4156Will);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3a005IronMoth)
+            .with_energy(vec![EnergyType::Fire, EnergyType::Colorless])],
+        vec![played_with_hp(CardId::A1053Squirtle, 200)],
+    );
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.hands[0] = vec![Card::Trainer(will.clone())];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card: will },
+        is_stack: false,
+    });
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let final_state = game.get_state_clone();
+    let damage_dealt = 200 - final_state.get_active(1).get_remaining_hp();
+    // Will forces first coin to be heads, so at least 1 head => at least 30 damage
+    assert!(
+        damage_dealt >= 30,
+        "Iron Moth with Will should deal at least 30 damage (1+ heads), got {damage_dealt}"
+    );
+}
+
+/// Thermal Gust produces exactly 4 outcomes: 10 (0 heads), 30 (1), 60 (2), 130 (3).
+/// Uses Squirtle (Water, not weak to Fire) to avoid the +20 weakness modifier.
+#[test]
+fn test_iron_moth_thermal_gust_all_damage_tiers() {
+    let mut saw_ten = false;
+    let mut saw_thirty = false;
+    let mut saw_sixty = false;
+    let mut saw_one_thirty = false;
+
+    for seed in 0..400 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B3a005IronMoth)
+                .with_energy(vec![EnergyType::Fire, EnergyType::Colorless])],
+            vec![played_with_hp(CardId::A1053Squirtle, 200)],
+        );
+        state.current_player = 0;
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::Attack(0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let damage_dealt = 200 - game.get_state_clone().get_active(1).get_remaining_hp();
+
+        match damage_dealt {
+            10 => saw_ten = true,
+            30 => saw_thirty = true,
+            60 => saw_sixty = true,
+            130 => saw_one_thirty = true,
+            other => panic!("Unexpected damage from Thermal Gust: {other}"),
+        }
+
+        if saw_ten && saw_thirty && saw_sixty && saw_one_thirty {
+            break;
+        }
+    }
+
+    assert!(saw_ten, "Expected 10-damage outcome (0 heads)");
+    assert!(saw_thirty, "Expected 30-damage outcome (1 head, +20)");
+    assert!(saw_sixty, "Expected 60-damage outcome (2 heads, +50)");
+    assert!(
+        saw_one_thirty,
+        "Expected 130-damage outcome (3 heads, +120)"
+    );
+}

--- a/tests/pokemon/slither_wing_test.rs
+++ b/tests/pokemon/slither_wing_test.rs
@@ -1,0 +1,90 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn played_with_hp(card_id: CardId, hp: u32) -> PlayedCard {
+    let card = deckgym::database::get_card_by_enum(card_id);
+    PlayedCard::new(card, 0, hp, vec![], false, vec![])
+}
+
+/// Wildly Writhe deals 120 damage to the opponent and 60 recoil to Slither Wing.
+#[test]
+fn test_slither_wing_wildly_writhe_damage_and_self_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a004SlitherWing).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Grass,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![played_with_hp(CardId::A1001Bulbasaur, 200)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let final_state = game.get_state_clone();
+
+    // Opponent takes 120 damage (200 - 120 = 80 HP remaining)
+    let opponent_hp = final_state.get_active(1).get_remaining_hp();
+    assert_eq!(
+        opponent_hp, 80,
+        "Wildly Writhe should deal 120 damage (200 - 120 = 80)"
+    );
+
+    // Slither Wing takes 60 self-damage (120 - 60 = 60 HP remaining)
+    let slither_wing_hp = final_state.get_active(0).get_remaining_hp();
+    assert_eq!(
+        slither_wing_hp, 60,
+        "Slither Wing should take 60 self-damage (120 - 60 = 60 HP remaining)"
+    );
+}
+
+/// Wildly Writhe self-damage can reduce Slither Wing's HP to 0.
+#[test]
+fn test_slither_wing_wildly_writhe_self_ko() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            played_with_hp(CardId::B3a004SlitherWing, 60).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Grass,
+                EnergyType::Colorless,
+            ]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![played_with_hp(CardId::A1001Bulbasaur, 200)],
+    );
+    state.current_player = 0;
+    state.points = [0, 0];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let final_state = game.get_state_clone();
+
+    // Slither Wing (60 HP remaining before attack) should be KO'd by its own recoil
+    assert_eq!(
+        final_state.points[1], 1,
+        "Opponent should earn a point when Slither Wing KO's itself with recoil"
+    );
+}


### PR DESCRIPTION
## Summary
This PR adds game mechanics support for three new Pokémon cards from the B3a set: Iron Hands, Iron Moth, and Slither Wing. It introduces a new tiered coin flip damage mechanic and adds comprehensive test coverage for all three cards.

## Key Changes

- **New Mechanic: TieredCoinFlipDamage**
  - Supports attacks that flip multiple coins and deal damage based on the number of heads
  - Damage is determined by a lookup table mapping head count to extra damage
  - Used by Iron Moth's "Thermal Gust" attack (3-coin flip with tiered damage: 0/20/50/120)

- **Effect Mechanic Map Updates**
  - Added "Flip 2 coins. This attack does 70 damage for each heads." → ExtraDamageForEachHeads (Iron Hands' "Successive Slapping")
  - Added "Flip 3 coins..." tiered damage mechanic (Iron Moth's "Thermal Gust")
  - Added "This Pokémon also does 60 damage to itself." self-damage mechanic (Slither Wing's "Wildly Writhe")

- **Test Coverage**
  - **Iron Hands tests**: Verify Successive Slapping produces correct variable damage (0/70/140) across multiple coin flip outcomes
  - **Iron Moth tests**: Verify Thermal Gust produces all four damage tiers (10/30/60/130) and respects non-weakness scenarios
  - **Slither Wing tests**: Verify Wildly Writhe deals 120 damage to opponent with 60 self-recoil, and that self-damage can KO the attacker

## Implementation Details

- The `TieredCoinFlipDamage` mechanic uses `Outcomes::binomial_by_heads()` to generate all possible outcomes based on coin flip results
- Tests use deterministic seeding and the Will trainer card to control coin flip outcomes where needed
- Slither Wing tests verify both normal damage application and edge cases (self-KO scenarios)

https://claude.ai/code/session_01Vhm2r82u9Ht9yXTZKbBWqh