### PR TITLE
Add Miraidon ex and Roaring Moon ability implementations

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -184,4 +184,12 @@ pub enum AbilityMechanic {
     MoveFixedDamageFromActiveToThisBenched {
         amount: u32,
     },
+    /// "Once during your turn, when you put this Pokémon from your hand onto your Bench,
+    /// you may switch it with your Active Pokémon. If you do, move all of your Energy
+    /// in play to this Pokémon."
+    LegendaryDrive,
+    /// "Once during your turn, when you put this Pokémon from your hand onto your Bench,
+    /// you may switch out your opponent's Active Pokémon to the Bench.
+    /// (Your opponent chooses the new Active Pokémon.)"
+    AncientRoar,
 }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -259,6 +259,8 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::MoveFixedDamageFromActiveToThisBenched { amount } => {
             move_fixed_damage_from_active_to_this_benched(in_play_idx, *amount)
         }
+        AbilityMechanic::LegendaryDrive => legendary_drive(in_play_idx),
+        AbilityMechanic::AncientRoar => switch_out_opponent_active_to_bench(),
     }
 }
 
@@ -539,6 +541,42 @@ fn move_fixed_damage_from_active_to_this_benched(self_idx: usize, amount: u32) -
         state.get_active_mut(action.actor).heal(amount);
         let targets = vec![(amount, action.actor, self_idx)];
         handle_damage(state, (action.actor, 0), &targets, false, None);
+    })
+}
+
+fn legendary_drive(bench_idx: usize) -> Outcomes {
+    Outcomes::single_fn(move |_rng, state, action| {
+        let actor = action.actor;
+        debug!(
+            "Legendary Drive: switching bench index {bench_idx} to active and moving all energy"
+        );
+
+        // Swap bench pokemon with active
+        state.in_play_pokemon[actor].swap(0, bench_idx);
+
+        // Clear status of the pokemon that went to bench
+        if let Some(pokemon) = state.in_play_pokemon[actor][bench_idx].as_mut() {
+            pokemon.clear_status_and_effects();
+        }
+
+        // Mark the new active as having moved from bench to active this turn
+        if let Some(pokemon) = state.in_play_pokemon[actor][0].as_mut() {
+            pokemon.moved_to_active_this_turn = true;
+        }
+
+        // Prevent further retreating this turn (switching counts as the retreat action)
+        state.has_retreated = true;
+
+        // Move all energy from every benched pokemon to the newly-active pokemon
+        let mut gathered: Vec<EnergyType> = Vec::new();
+        for i in 1..state.in_play_pokemon[actor].len() {
+            if let Some(pokemon) = state.in_play_pokemon[actor][i].as_mut() {
+                gathered.append(&mut pokemon.attached_energy);
+            }
+        }
+        if let Some(active) = state.in_play_pokemon[actor][0].as_mut() {
+            active.attached_energy.extend(gathered);
+        }
     })
 }
 

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -545,39 +545,16 @@ fn move_fixed_damage_from_active_to_this_benched(self_idx: usize, amount: u32) -
 }
 
 fn legendary_drive(bench_idx: usize) -> Outcomes {
-    Outcomes::single_fn(move |_rng, state, action| {
-        let actor = action.actor;
-        debug!(
-            "Legendary Drive: switching bench index {bench_idx} to active and moving all energy"
-        );
-
-        // Swap bench pokemon with active
-        state.in_play_pokemon[actor].swap(0, bench_idx);
-
-        // Clear status of the pokemon that went to bench
-        if let Some(pokemon) = state.in_play_pokemon[actor][bench_idx].as_mut() {
-            pokemon.clear_status_and_effects();
-        }
-
-        // Mark the new active as having moved from bench to active this turn
-        if let Some(pokemon) = state.in_play_pokemon[actor][0].as_mut() {
-            pokemon.moved_to_active_this_turn = true;
-        }
-
-        // Prevent further retreating this turn (switching counts as the retreat action)
-        state.has_retreated = true;
-
-        // Move all energy from every benched pokemon to the newly-active pokemon
-        let mut gathered: Vec<EnergyType> = Vec::new();
-        for i in 1..state.in_play_pokemon[actor].len() {
-            if let Some(pokemon) = state.in_play_pokemon[actor][i].as_mut() {
-                gathered.append(&mut pokemon.attached_energy);
-            }
-        }
-        if let Some(active) = state.in_play_pokemon[actor][0].as_mut() {
-            active.attached_energy.extend(gathered);
-        }
-    })
+    Outcomes::single(Box::new(move |_, state, action| {
+        debug!("Legendary Drive: switching bench index {bench_idx} to active");
+        state.move_generation_stack.push((
+            action.actor,
+            vec![SimpleAction::Activate {
+                player: action.actor,
+                in_play_idx: bench_idx,
+            }],
+        ));
+    }))
 }
 
 fn switch_out_opponent_active_to_bench() -> Outcomes {

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -6,7 +6,7 @@ use rand::{rngs::StdRng, Rng};
 use crate::{
     actions::{
         abilities::AbilityMechanic,
-        apply_action_helpers::{handle_damage, handle_knockouts, Mutation},
+        apply_action_helpers::{apply_activate, handle_damage, handle_knockouts, Mutation},
         effect_ability_mechanic_map::ability_mechanic_from_effect,
         outcomes::Outcomes,
         shared_mutations::pokemon_search_outcomes,
@@ -546,14 +546,18 @@ fn move_fixed_damage_from_active_to_this_benched(self_idx: usize, amount: u32) -
 
 fn legendary_drive(bench_idx: usize) -> Outcomes {
     Outcomes::single(Box::new(move |_, state, action| {
-        debug!("Legendary Drive: switching bench index {bench_idx} to active");
-        state.move_generation_stack.push((
-            action.actor,
-            vec![SimpleAction::Activate {
-                player: action.actor,
-                in_play_idx: bench_idx,
-            }],
-        ));
+        let player = action.actor;
+        debug!("Legendary Drive: switching bench index {bench_idx} to active and moving all energy");
+        apply_activate(player, state, bench_idx);
+        let mut gathered: Vec<EnergyType> = Vec::new();
+        for i in 1..state.in_play_pokemon[player].len() {
+            if let Some(pokemon) = state.in_play_pokemon[player][i].as_mut() {
+                gathered.append(&mut pokemon.attached_energy);
+            }
+        }
+        if let Some(active) = state.in_play_pokemon[player][0].as_mut() {
+            active.attached_energy.extend(gathered);
+        }
     }))
 }
 

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -547,7 +547,9 @@ fn move_fixed_damage_from_active_to_this_benched(self_idx: usize, amount: u32) -
 fn legendary_drive(bench_idx: usize) -> Outcomes {
     Outcomes::single(Box::new(move |_, state, action| {
         let player = action.actor;
-        debug!("Legendary Drive: switching bench index {bench_idx} to active and moving all energy");
+        debug!(
+            "Legendary Drive: switching bench index {bench_idx} to active and moving all energy"
+        );
         apply_activate(player, state, bench_idx);
         let mut gathered: Vec<EnergyType> = Vec::new();
         for i in 1..state.in_play_pokemon[player].len() {

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -8,7 +8,7 @@ use crate::{
     actions::{
         abilities::AbilityMechanic,
         apply_abilities_action::forecast_ability,
-        apply_action_helpers::{wrap_with_common_logic, Mutation},
+        apply_action_helpers::{apply_activate, wrap_with_common_logic, Mutation},
         shared_mutations::{pokemon_search_outcomes, pokemon_search_outcomes_by_type_for_player},
     },
     effects::TurnEffect,
@@ -508,36 +508,7 @@ fn apply_retreat(player: usize, state: &mut State, bench_idx: usize, is_free: bo
         }
     }
 
-    state.in_play_pokemon[player].swap(0, bench_idx);
-
-    // Clear status and effects of the new bench Pokemon
-    if let Some(pokemon) = state.in_play_pokemon[player][bench_idx].as_mut() {
-        pokemon.clear_status_and_effects();
-    }
-
-    // Mark the new active Pokemon as having moved from bench to active this turn
-    if let Some(pokemon) = state.in_play_pokemon[player][0].as_mut() {
-        pokemon.moved_to_active_this_turn = true;
-    }
-
-    state.has_retreated = true;
-
-    // Legendary Drive: when ability_used is set on the newly-active pokemon, it means
-    // UseAbility was called for LegendaryDrive this turn; move all bench energy to it.
-    let legendary_drive_triggered = state.in_play_pokemon[player][0].as_ref().is_some_and(|p| {
-        p.ability_used && has_ability_mechanic(&p.card, &AbilityMechanic::LegendaryDrive)
-    });
-    if legendary_drive_triggered {
-        let mut gathered: Vec<EnergyType> = Vec::new();
-        for i in 1..state.in_play_pokemon[player].len() {
-            if let Some(pokemon) = state.in_play_pokemon[player][i].as_mut() {
-                gathered.append(&mut pokemon.attached_energy);
-            }
-        }
-        if let Some(active) = state.in_play_pokemon[player][0].as_mut() {
-            active.attached_energy.extend(gathered);
-        }
-    }
+    apply_activate(player, state, bench_idx);
 }
 
 // We will replace the PlayedCard, but taking into account the attached energy

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -12,7 +12,7 @@ use crate::{
         shared_mutations::{pokemon_search_outcomes, pokemon_search_outcomes_by_type_for_player},
     },
     effects::TurnEffect,
-    hooks::{get_retreat_cost, on_evolve, to_playable_card},
+    hooks::{get_retreat_cost, on_bench_from_hand, on_evolve, to_playable_card},
     models::{Card, EnergyType},
     stadiums::{is_fragrant_forest_active, is_mesagoza_active},
     state::State,
@@ -354,6 +354,9 @@ pub(crate) fn apply_place_card(
         let placed_in_bench = index != 0;
         if placed_in_bench && has_ability_mechanic(card, &AbilityMechanic::InfiltratingInspection) {
             debug!("Misdreavus's Infiltrating Inspection: Opponent's hand is revealed (no-op in AI context)");
+        }
+        if placed_in_bench {
+            on_bench_from_hand(actor, state, card, index);
         }
     }
 }

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -521,6 +521,23 @@ fn apply_retreat(player: usize, state: &mut State, bench_idx: usize, is_free: bo
     }
 
     state.has_retreated = true;
+
+    // Legendary Drive: when ability_used is set on the newly-active pokemon, it means
+    // UseAbility was called for LegendaryDrive this turn; move all bench energy to it.
+    let legendary_drive_triggered = state.in_play_pokemon[player][0].as_ref().is_some_and(|p| {
+        p.ability_used && has_ability_mechanic(&p.card, &AbilityMechanic::LegendaryDrive)
+    });
+    if legendary_drive_triggered {
+        let mut gathered: Vec<EnergyType> = Vec::new();
+        for i in 1..state.in_play_pokemon[player].len() {
+            if let Some(pokemon) = state.in_play_pokemon[player][i].as_mut() {
+                gathered.append(&mut pokemon.attached_energy);
+            }
+        }
+        if let Some(active) = state.in_play_pokemon[player][0].as_mut() {
+            active.attached_energy.extend(gathered);
+        }
+    }
 }
 
 // We will replace the PlayedCard, but taking into account the attached energy

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -649,6 +649,22 @@ fn get_knocked_out(state: &State) -> Vec<(usize, usize)> {
     knockouts
 }
 
+/// Swap a bench pokemon into the active spot, clearing status/effects and setting turn flags.
+/// This is the swap portion of retreat without energy payment.
+pub(crate) fn apply_activate(player: usize, state: &mut State, bench_idx: usize) {
+    state.in_play_pokemon[player].swap(0, bench_idx);
+
+    if let Some(pokemon) = state.in_play_pokemon[player][bench_idx].as_mut() {
+        pokemon.clear_status_and_effects();
+    }
+
+    if let Some(pokemon) = state.in_play_pokemon[player][0].as_mut() {
+        pokemon.moved_to_active_this_turn = true;
+    }
+
+    state.has_retreated = true;
+}
+
 // Apply common logic in outcomes
 pub(crate) fn wrap_with_common_logic(mutation: Mutation) -> Mutation {
     Box::new(move |rng, state, action| {

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -408,6 +408,16 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
         );
         map.insert("Once during your turn, you may switch your Active [M] Pokémon with 1 of your Benched Pokémon.", AbilityMechanic::SwitchActiveTypedWithBench { energy_type: EnergyType::Metal });
 
+        // b3a mechanics
+        map.insert(
+            "Once during your turn, when you put this Pokémon from your hand onto your Bench, you may switch it with your Active Pokémon. If you do, move all of your Energy in play to this Pokémon.",
+            AbilityMechanic::LegendaryDrive,
+        );
+        map.insert(
+            "Once during your turn, when you put this Pokémon from your hand onto your Bench, you may switch out your opponent's Active Pokémon to the Bench. (Your opponent chooses the new Active Pokémon.)",
+            AbilityMechanic::AncientRoar,
+        );
+
         // b3 mechanics
         // map.insert("As long as this Pokémon is in play, it is [F] and [D] type.", todo_implementation);
         // map.insert("As long as this Pokémon is in play, it is [W] and [F] type.", todo_implementation);

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1308,6 +1308,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     map.insert(
+        "This attack does 20 more damage for each [L] Energy attached to this Pokémon.",
+        Mechanic::ExtraDamagePerSpecificEnergy {
+            energy_type: EnergyType::Lightning,
+            damage_per_energy: 20,
+        },
+    );
+    map.insert(
         "This attack does 20 more damage for each [M] Energy attached to this Pokémon.",
         Mechanic::ExtraDamagePerSpecificEnergy {
             energy_type: EnergyType::Metal,

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -161,6 +161,44 @@ pub(crate) fn on_evolve(actor: usize, state: &mut State, to_card: &Card, from_ha
     }
 }
 
+/// Called when a basic Pokémon is placed from hand onto the bench (index > 0).
+pub(crate) fn on_bench_from_hand(actor: usize, state: &mut State, card: &Card, bench_idx: usize) {
+    match get_ability_mechanic(card) {
+        Some(AbilityMechanic::LegendaryDrive) => {
+            if state.maybe_get_active(actor).is_none() {
+                return;
+            }
+            debug!("Legendary Drive: offering switch to active");
+            state.move_generation_stack.push((
+                actor,
+                vec![
+                    SimpleAction::UseAbility {
+                        in_play_idx: bench_idx,
+                    },
+                    SimpleAction::Noop,
+                ],
+            ));
+        }
+        Some(AbilityMechanic::AncientRoar) => {
+            let opponent = (actor + 1) % 2;
+            if state.enumerate_bench_pokemon(opponent).next().is_none() {
+                return;
+            }
+            debug!("Ancient Roar: offering force-switch of opponent's active");
+            state.move_generation_stack.push((
+                actor,
+                vec![
+                    SimpleAction::UseAbility {
+                        in_play_idx: bench_idx,
+                    },
+                    SimpleAction::Noop,
+                ],
+            ));
+        }
+        _ => {}
+    }
+}
+
 /// Called when a basic Pokémon is played to the bench from hand
 pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
     // Check if active Pokémon has an end-of-turn ability

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -15,6 +15,7 @@ pub(crate) use core::get_stage;
 pub(crate) use core::is_ultra_beast;
 pub(crate) use core::modify_damage;
 pub(crate) use core::on_attack_knockout;
+pub(crate) use core::on_bench_from_hand;
 pub(crate) use core::on_end_turn;
 pub(crate) use core::on_evolve;
 pub(crate) use core::on_knockout;

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -169,6 +169,8 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::MoveFixedDamageFromActiveToThisBenched { amount } => {
             can_use_accept_pain(state, _in_play_index, card, *amount)
         }
+        AbilityMechanic::LegendaryDrive => false, // triggered on bench placement, not via UseAbility
+        AbilityMechanic::AncientRoar => false, // triggered on bench placement, not via UseAbility
     }
 }
 

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -66,12 +66,16 @@ mod mega_kangaskhan_double_punching_family_test;
 mod mega_sceptile_terminating_tail_test;
 #[path = "pokemon/mega_steelix_adamantine_rolling_test.rs"]
 mod mega_steelix_adamantine_rolling_test;
+#[path = "pokemon/miraidon_ex_test.rs"]
+mod miraidon_ex_test;
 #[path = "pokemon/morpeko_test.rs"]
 mod morpeko_test;
 #[path = "pokemon/porygonz_cyberjack_test.rs"]
 mod porygonz_cyberjack_test;
 #[path = "pokemon/rampardos_head_smash_test.rs"]
 mod rampardos_head_smash_test;
+#[path = "pokemon/roaring_moon_test.rs"]
+mod roaring_moon_test;
 #[path = "pokemon/shinx_hide_test.rs"]
 mod shinx_hide_test;
 #[path = "pokemon/sunflora_quick_grow_beam_test.rs"]

--- a/tests/pokemon/miraidon_ex_test.rs
+++ b/tests/pokemon/miraidon_ex_test.rs
@@ -59,26 +59,14 @@ fn test_legendary_drive_switches_to_active_and_moves_energy() {
         "Noop should be offered alongside Legendary Drive"
     );
 
-    // Choose to use Legendary Drive (pushes Activate onto the stack)
+    // Choose to use Legendary Drive (directly switches and moves energy in one step)
     game.apply_action(&Action {
         actor: 0,
         action: SimpleAction::UseAbility { in_play_idx: 2 },
         is_stack: true,
     });
 
-    // UseAbility queues the Activate; apply it to complete the switch
-    let activate_action = find_action(&game, |a| {
-        matches!(
-            a.action,
-            SimpleAction::Activate {
-                player: 0,
-                in_play_idx: 2
-            }
-        )
-    });
-    game.apply_action(&activate_action);
-
-    // After the switch, Miraidon ex should be the active pokemon
+    // After UseAbility, Miraidon ex should be the active pokemon
     let state = game.get_state_clone();
     assert_eq!(
         state.get_active(0).get_name(),
@@ -93,6 +81,15 @@ fn test_legendary_drive_switches_to_active_and_moves_energy() {
         3,
         "Miraidon ex should have all 3 energies (2 from Bulbasaur + 1 from Squirtle)"
     );
+
+    // Bench pokemon should have no energy remaining
+    for (_, pokemon) in state.enumerate_bench_pokemon(0) {
+        assert!(
+            pokemon.attached_energy.is_empty(),
+            "{} should have no energy after Legendary Drive moved it all",
+            pokemon.get_name()
+        );
+    }
 }
 
 /// Hadron Ray does 20 base + 20 more damage for each [L] Energy attached to Miraidon ex.

--- a/tests/pokemon/miraidon_ex_test.rs
+++ b/tests/pokemon/miraidon_ex_test.rs
@@ -1,0 +1,124 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_test_game_with_board,
+    Game,
+};
+
+fn find_action<F>(game: &Game, predicate: F) -> Action
+where
+    F: Fn(&Action) -> bool,
+{
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    actions
+        .into_iter()
+        .find(predicate)
+        .expect("expected action to be available")
+}
+
+/// When Miraidon ex is placed on the bench, the player should be offered a choice
+/// to use Legendary Drive (switch to active + move all energy) or pass (Noop).
+#[test]
+fn test_legendary_drive_switches_to_active_and_moves_energy() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::A1053Squirtle).with_energy(vec![EnergyType::Water]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::B3a019MiraidonEx));
+    game.set_state(state);
+
+    // Place Miraidon ex on bench slot 2 (index 2 since slot 1 already has Squirtle)
+    let place_action = find_action(
+        &game,
+        |a| matches!(a.action, SimpleAction::Place(ref c, 2) if c.get_name() == "Miraidon ex"),
+    );
+    game.apply_action(&place_action);
+
+    // After placement, the player should be offered UseAbility (Legendary Drive) or Noop
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::UseAbility { in_play_idx: 2 })),
+        "Legendary Drive should be offered as UseAbility after placing Miraidon ex on bench"
+    );
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Noop)),
+        "Noop should be offered alongside Legendary Drive"
+    );
+
+    // Choose to use Legendary Drive
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 2 },
+        is_stack: true,
+    });
+
+    // After the switch, Miraidon ex should be the active pokemon
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(0).get_name(),
+        "Miraidon ex",
+        "Miraidon ex should now be the active pokemon after Legendary Drive"
+    );
+
+    // All energy from Bulbasaur and Squirtle should have moved to Miraidon ex
+    let miraidon_energy = &state.get_active(0).attached_energy;
+    assert_eq!(
+        miraidon_energy.len(),
+        3,
+        "Miraidon ex should have all 3 energies (2 from Bulbasaur + 1 from Squirtle)"
+    );
+}
+
+/// Hadron Ray does 20 base + 20 more damage for each [L] Energy attached to Miraidon ex.
+#[test]
+fn test_hadron_ray_extra_damage_per_lightning_energy() {
+    // Miraidon ex with 3 [L] energies: 20 + 3*20 = 80 damage
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a019MiraidonEx).with_energy(vec![
+                EnergyType::Lightning,
+                EnergyType::Lightning,
+                EnergyType::Lightning,
+            ]),
+        ],
+        vec![PlayedCard::new(
+            get_card_by_enum(CardId::A1001Bulbasaur),
+            0,
+            200,
+            vec![],
+            false,
+            vec![],
+        )],
+    );
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // 20 + (3 * 20) = 80 damage, opponent had 200 HP → 120 remaining
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        120,
+        "Hadron Ray should deal 80 damage with 3 Lightning energies (20 + 3*20)"
+    );
+}

--- a/tests/pokemon/miraidon_ex_test.rs
+++ b/tests/pokemon/miraidon_ex_test.rs
@@ -59,12 +59,24 @@ fn test_legendary_drive_switches_to_active_and_moves_energy() {
         "Noop should be offered alongside Legendary Drive"
     );
 
-    // Choose to use Legendary Drive
+    // Choose to use Legendary Drive (pushes Activate onto the stack)
     game.apply_action(&Action {
         actor: 0,
         action: SimpleAction::UseAbility { in_play_idx: 2 },
         is_stack: true,
     });
+
+    // UseAbility queues the Activate; apply it to complete the switch
+    let activate_action = find_action(&game, |a| {
+        matches!(
+            a.action,
+            SimpleAction::Activate {
+                player: 0,
+                in_play_idx: 2
+            }
+        )
+    });
+    game.apply_action(&activate_action);
 
     // After the switch, Miraidon ex should be the active pokemon
     let state = game.get_state_clone();

--- a/tests/pokemon/roaring_moon_test.rs
+++ b/tests/pokemon/roaring_moon_test.rs
@@ -1,0 +1,141 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::PlayedCard,
+    test_support::get_test_game_with_board,
+    Game,
+};
+
+fn find_action<F>(game: &Game, predicate: F) -> Action
+where
+    F: Fn(&Action) -> bool,
+{
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    actions
+        .into_iter()
+        .find(predicate)
+        .expect("expected action to be available")
+}
+
+/// When Roaring Moon is placed on the bench, the player is offered a choice to use
+/// Ancient Roar (force opponent's active to bench) or pass. If used, opponent chooses
+/// which bench pokemon becomes the new active.
+#[test]
+fn test_ancient_roar_forces_opponent_active_to_bench() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![
+            PlayedCard::from_id(CardId::A1053Squirtle),
+            PlayedCard::from_id(CardId::A1057Psyduck),
+        ],
+    );
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::B3a047RoaringMoon));
+    game.set_state(state);
+
+    // Place Roaring Moon on bench
+    let place_action = find_action(
+        &game,
+        |a| matches!(a.action, SimpleAction::Place(ref c, _) if c.get_name() == "Roaring Moon"),
+    );
+    game.apply_action(&place_action);
+
+    // Player 0 should be offered UseAbility (Ancient Roar) or Noop
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::UseAbility { .. })),
+        "Ancient Roar should be offered as UseAbility after placing Roaring Moon on bench"
+    );
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Noop)),
+        "Noop should be offered alongside Ancient Roar"
+    );
+
+    // Record the original opponent's active pokemon name
+    let original_active_name = game.get_state_clone().get_active(1).get_name().to_string();
+
+    // Use Ancient Roar (find the UseAbility action)
+    let use_ability_action = actions
+        .into_iter()
+        .find(|a| matches!(a.action, SimpleAction::UseAbility { .. }))
+        .unwrap();
+    game.apply_action(&use_ability_action);
+
+    // Now it's the OPPONENT's turn to choose a new active from their bench
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Activate { player: 1, .. })),
+        "Opponent should be asked to choose a new active pokemon after Ancient Roar"
+    );
+
+    // Opponent promotes Psyduck (index 2) as new active
+    let activate_action = actions
+        .into_iter()
+        .find(|a| matches!(a.action, SimpleAction::Activate { player: 1, .. }))
+        .unwrap();
+    game.apply_action(&activate_action);
+
+    let final_state = game.get_state_clone();
+
+    // The opponent's original active should now be on the bench
+    let opponent_bench: Vec<_> = final_state.enumerate_bench_pokemon(1).collect();
+    assert!(
+        opponent_bench
+            .iter()
+            .any(|(_, p)| p.get_name() == original_active_name),
+        "Opponent's original active ({original_active_name}) should now be on the bench"
+    );
+}
+
+/// When Noop is chosen for Ancient Roar, opponent's active stays in place.
+#[test]
+fn test_ancient_roar_noop_leaves_state_unchanged() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![
+            PlayedCard::from_id(CardId::A1053Squirtle),
+            PlayedCard::from_id(CardId::A1057Psyduck),
+        ],
+    );
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::B3a047RoaringMoon));
+    game.set_state(state);
+
+    let original_active_name = game.get_state_clone().get_active(1).get_name().to_string();
+
+    // Place Roaring Moon on bench
+    let place_action = find_action(
+        &game,
+        |a| matches!(a.action, SimpleAction::Place(ref c, _) if c.get_name() == "Roaring Moon"),
+    );
+    game.apply_action(&place_action);
+
+    // Choose Noop (don't use Ancient Roar)
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Noop,
+        is_stack: true,
+    });
+
+    let final_state = game.get_state_clone();
+
+    // Opponent's active should still be the same pokemon
+    assert_eq!(
+        final_state.get_active(1).get_name(),
+        original_active_name,
+        "Opponent's active should be unchanged when Ancient Roar is not used"
+    );
+}


### PR DESCRIPTION
## Summary
Implements two new Pokémon abilities from the Scarlet & Violet expansion: Miraidon ex's Legendary Drive and Roaring Moon's Ancient Roar. Both abilities trigger when placed from hand onto the bench and offer the player a choice to activate them or pass.

## Key Changes

- **Legendary Drive (Miraidon ex)**: When placed on the bench, allows switching to active and moving all energy from benched Pokémon to the newly active Miraidon ex. Prevents further retreating this turn.

- **Ancient Roar (Roaring Moon)**: When placed on the bench, allows forcing the opponent's active Pokémon to the bench (opponent chooses the replacement).

- **Hadron Ray attack**: Added damage calculation for Lightning energy scaling (20 base + 20 per [L] energy).

- **New hook**: `on_bench_from_hand()` in `hooks/core.rs` to handle abilities that trigger specifically when a basic Pokémon is placed from hand onto the bench (not active).

- **Ability mechanics**: Added `LegendaryDrive` and `AncientRoar` variants to the `AbilityMechanic` enum.

- **Effect mappings**: Registered both ability text patterns and the Hadron Ray damage scaling in the effect mechanic maps.

- **Comprehensive tests**: Added test suites for both abilities covering:
  - Legendary Drive switching and energy movement
  - Ancient Roar forcing opponent's active to bench
  - Noop behavior (passing on ability use)
  - Hadron Ray damage scaling with Lightning energy

## Implementation Details

The `on_bench_from_hand()` hook is called during card placement and pushes choice actions onto the move generation stack, allowing players to decide whether to activate the ability. For Ancient Roar, the opponent then gets to choose which benched Pokémon becomes active via an `Activate` action.

https://claude.ai/code/session_012quS6iWB9xuEYnzF4fjopp