### PR TITLE
Add first-attack bonus mechanics for Flutter Mane and Iron Bundle

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -666,6 +666,18 @@ fn forecast_effect_attack_by_mechanic(
             *num_coins,
             extra_damage_by_heads.clone(),
         ),
+        Mechanic::FirstAttackBonusTurnEffect { effect, duration } => {
+            first_attack_bonus_turn_effect(state, attack.fixed_damage, effect.clone(), *duration)
+        }
+        Mechanic::FirstAttackBonusDamageAndStatus {
+            extra_damage,
+            conditions,
+        } => first_attack_bonus_damage_and_status(
+            state,
+            attack.fixed_damage,
+            *extra_damage,
+            conditions.clone(),
+        ),
     }
 }
 
@@ -3144,6 +3156,54 @@ fn coin_flip_to_block_attack_next_turn(damage: u32) -> Outcomes {
         state
             .get_active_mut(opponent)
             .add_effect(CardEffect::CoinFlipToBlockAttack, 1);
+    })
+}
+
+fn first_attack_bonus_turn_effect(
+    state: &State,
+    base_damage: u32,
+    effect: TurnEffect,
+    duration: u8,
+) -> Outcomes {
+    let is_first = state.in_play_pokemon[state.current_player][0]
+        .as_ref()
+        .map(|p| !p.has_attacked_since_play)
+        .unwrap_or(false);
+    active_damage_effect_doutcome(base_damage, move |_, state, action| {
+        if is_first {
+            state.add_turn_effect(effect.clone(), duration);
+        }
+        if let Some(attacker) = state.in_play_pokemon[action.actor][0].as_mut() {
+            attacker.has_attacked_since_play = true;
+        }
+    })
+}
+
+fn first_attack_bonus_damage_and_status(
+    state: &State,
+    base_damage: u32,
+    extra_damage: u32,
+    conditions: Vec<StatusCondition>,
+) -> Outcomes {
+    let is_first = state.in_play_pokemon[state.current_player][0]
+        .as_ref()
+        .map(|p| !p.has_attacked_since_play)
+        .unwrap_or(false);
+    let damage = if is_first {
+        base_damage + extra_damage
+    } else {
+        base_damage
+    };
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        if is_first {
+            let opponent = (action.actor + 1) % 2;
+            for status in &conditions {
+                state.apply_status_condition(opponent, 0, *status);
+            }
+        }
+        if let Some(attacker) = state.in_play_pokemon[action.actor][0].as_mut() {
+            attacker.has_attacked_since_play = true;
+        }
     })
 }
 

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -377,4 +377,14 @@ pub enum Mechanic {
         num_coins: usize,
         extra_damage_by_heads: Vec<u32>,
     },
+    /// First attack after coming into play: conditionally apply a turn effect (e.g. Flutter Mane).
+    FirstAttackBonusTurnEffect {
+        effect: TurnEffect,
+        duration: u8,
+    },
+    /// First attack after coming into play: conditionally deal extra damage and inflict status (e.g. Iron Bundle).
+    FirstAttackBonusDamageAndStatus {
+        extra_damage: u32,
+        conditions: Vec<StatusCondition>,
+    },
 }

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -843,6 +843,20 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "If this Pokémon moved from your Bench to the Active Spot this turn, this attack does 60 more damage.",
         Mechanic::ExtraDamageIfMovedFromBench { extra_damage: 60 },
     );
+    map.insert(
+        "If this is the first time this Pokémon has used an attack after coming into play, this attack does 20 more damage, and your opponent's Active Pokémon is now Paralyzed.",
+        Mechanic::FirstAttackBonusDamageAndStatus {
+            extra_damage: 20,
+            conditions: vec![StatusCondition::Paralyzed],
+        },
+    );
+    map.insert(
+        "If this is the first time this Pokémon has used an attack after coming into play, during your opponent's next turn, they can't use any Trainer cards from their hand.",
+        Mechanic::FirstAttackBonusTurnEffect {
+            effect: TurnEffect::NoTrainerCards,
+            duration: 1,
+        },
+    );
     // map.insert("If this Pokémon was damaged by an attack during your opponent's last turn while it was in the Active Spot, this attack does 50 more damage.", todo_implementation);
     // map.insert("If this Pokémon's remaining HP is 30 or less, this attack does 60 more damage.", todo_implementation);
     // map.insert("If you have exactly 1, 3, or 5 cards in your hand, this attack does 60 more damage.", todo_implementation);

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -32,6 +32,7 @@ pub struct PlayedCard {
     confused: bool,
     pub cards_behind: Vec<Card>,
     pub prevent_first_attack_damage_used: bool,
+    pub has_attacked_since_play: bool,
 
     /// Effects that should be cleared if moved to the bench (by retreat or similar).
     /// The second value is the number of turns left for the effect.
@@ -65,6 +66,7 @@ impl PlayedCard {
             confused: false,
             effects: vec![],
             prevent_first_attack_damage_used: false,
+            has_attacked_since_play: false,
         }
     }
 

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -32,6 +32,8 @@ mod darkrai_ex_test;
 mod dusknoir_shadow_void_test;
 #[path = "pokemon/emboar_flare_storm_test.rs"]
 mod emboar_flare_storm_test;
+#[path = "pokemon/flutter_mane_ex_test.rs"]
+mod flutter_mane_ex_test;
 #[path = "pokemon/flygon_ex_test.rs"]
 mod flygon_ex_test;
 #[path = "pokemon/gallade_test.rs"]
@@ -42,6 +44,8 @@ mod grovyle_slicing_snipe_test;
 mod heracross_test;
 #[path = "pokemon/houndstone_last_respects_test.rs"]
 mod houndstone_last_respects_test;
+#[path = "pokemon/iron_bundle_ex_test.rs"]
+mod iron_bundle_ex_test;
 #[path = "pokemon/iron_hands_test.rs"]
 mod iron_hands_test;
 #[path = "pokemon/iron_moth_test.rs"]

--- a/tests/pokemon/flutter_mane_ex_test.rs
+++ b/tests/pokemon/flutter_mane_ex_test.rs
@@ -1,0 +1,119 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard, TrainerCard},
+    test_support::get_initialized_game,
+};
+
+fn trainer_from_id(card_id: CardId) -> TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+fn bulbasaur_with_hp(hp: u32) -> PlayedCard {
+    PlayedCard::new(
+        get_card_by_enum(CardId::A1001Bulbasaur),
+        0,
+        hp,
+        vec![],
+        false,
+        vec![],
+    )
+}
+
+/// Flutter Mane's first Spellbinding Start blocks opponent from playing trainers next turn.
+#[test]
+fn test_flutter_mane_spellbinding_start_first_attack_blocks_trainers() {
+    let potion = trainer_from_id(CardId::PA001Potion);
+
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3a026FlutterManeEx)
+            .with_energy(vec![EnergyType::Psychic, EnergyType::Psychic])],
+        vec![bulbasaur_with_hp(200)],
+    );
+    game.set_state(state);
+
+    // First attack
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // Now it's player 1's turn — give them a trainer card
+    let mut state = game.get_state_clone();
+    state.hands[1] = vec![Card::Trainer(potion.clone())];
+    game.set_state(state);
+
+    let (actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 1, "It should be player 1's turn");
+    let can_play_trainer = actions.iter().any(|a| {
+        matches!(&a.action, SimpleAction::Play { trainer_card } if trainer_card.id == potion.id)
+    });
+    assert!(
+        !can_play_trainer,
+        "Spellbinding Start should prevent opponent from playing trainer cards"
+    );
+}
+
+/// Flutter Mane's second Spellbinding Start (not first attack) does NOT block trainers.
+#[test]
+fn test_flutter_mane_spellbinding_start_second_attack_no_trainer_block() {
+    let potion = trainer_from_id(CardId::PA001Potion);
+
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    let mut flutter_mane = PlayedCard::from_id(CardId::B3a026FlutterManeEx)
+        .with_energy(vec![EnergyType::Psychic, EnergyType::Psychic]);
+    // Simulate that this Pokémon has already attacked since coming into play
+    flutter_mane.has_attacked_since_play = true;
+
+    state.set_board(vec![flutter_mane], vec![bulbasaur_with_hp(200)]);
+    game.set_state(state);
+
+    // Second attack — no first-attack bonus
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // Give opponent a trainer card
+    let mut state = game.get_state_clone();
+    state.hands[1] = vec![Card::Trainer(potion.clone())];
+    game.set_state(state);
+
+    let (actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 1, "It should be player 1's turn");
+    let can_play_trainer = actions.iter().any(|a| {
+        matches!(&a.action, SimpleAction::Play { trainer_card } if trainer_card.id == potion.id)
+    });
+    assert!(
+        can_play_trainer,
+        "Subsequent Spellbinding Start should NOT block trainer cards"
+    );
+}

--- a/tests/pokemon/iron_bundle_ex_test.rs
+++ b/tests/pokemon/iron_bundle_ex_test.rs
@@ -1,0 +1,94 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn bulbasaur_with_hp(hp: u32) -> PlayedCard {
+    PlayedCard::new(
+        get_card_by_enum(CardId::A1001Bulbasaur),
+        0,
+        hp,
+        vec![],
+        false,
+        vec![],
+    )
+}
+
+/// Iron Bundle's first Cold Start deals 80 damage (60 + 20) and Paralyzes.
+#[test]
+fn test_iron_bundle_cold_start_first_attack_extra_damage_and_paralysis() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a013IronBundleEx).with_energy(vec![
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![bulbasaur_with_hp(200)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    let opponent_hp = state.get_active(1).get_remaining_hp();
+    assert_eq!(
+        opponent_hp, 120,
+        "Cold Start first attack should deal 80 damage (200 - 80 = 120)"
+    );
+    assert!(
+        state.get_active(1).is_paralyzed(),
+        "Cold Start first attack should Paralyze the opponent"
+    );
+}
+
+/// Iron Bundle's second Cold Start (not first attack) deals 60 damage and no Paralysis.
+#[test]
+fn test_iron_bundle_cold_start_second_attack_base_damage_only() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    let mut iron_bundle = PlayedCard::from_id(CardId::B3a013IronBundleEx).with_energy(vec![
+        EnergyType::Water,
+        EnergyType::Water,
+        EnergyType::Colorless,
+    ]);
+    // Simulate this Pokémon has already attacked since coming into play
+    iron_bundle.has_attacked_since_play = true;
+
+    state.set_board(vec![iron_bundle], vec![bulbasaur_with_hp(200)]);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    let opponent_hp = state.get_active(1).get_remaining_hp();
+    assert_eq!(
+        opponent_hp, 140,
+        "Subsequent Cold Start should deal only 60 damage (200 - 60 = 140)"
+    );
+    assert!(
+        !state.get_active(1).is_paralyzed(),
+        "Subsequent Cold Start should NOT Paralyze the opponent"
+    );
+}


### PR DESCRIPTION
## Summary
Implement support for Pokémon attacks that have special effects only on their first use after coming into play. This adds two new mechanic types to handle conditional bonuses based on attack history.

## Key Changes
- **New Mechanic Types**: Added `FirstAttackBonusTurnEffect` and `FirstAttackBonusDamageAndStatus` to `src/actions/attacks/mechanic.rs` to represent first-attack-only bonuses
- **PlayedCard Tracking**: Added `has_attacked_since_play` field to `PlayedCard` to track whether a Pokémon has attacked since entering play
- **Attack Resolution**: Implemented `first_attack_bonus_turn_effect()` and `first_attack_bonus_damage_and_status()` functions in `src/actions/apply_attack_action.rs` to apply conditional effects during attack resolution
- **Effect Mapping**: Added two new mechanic mappings in `src/actions/effect_mechanic_map.rs`:
  - Iron Bundle's Cold Start: +20 damage and Paralysis on first attack
  - Flutter Mane's Spellbinding Start: blocks opponent's Trainer cards next turn on first attack
- **Test Coverage**: Added comprehensive tests for both Pokémon:
  - `flutter_mane_ex_test.rs`: Verifies trainer blocking only applies to first attack
  - `iron_bundle_ex_test.rs`: Verifies damage bonus and paralysis only apply to first attack

## Implementation Details
The solution checks `has_attacked_since_play` at attack forecast time to determine if bonuses should apply. The flag is set to `true` after any attack resolves, ensuring subsequent attacks use only base effects. This approach cleanly separates first-attack logic from the core damage calculation while maintaining the existing attack resolution pipeline.

https://claude.ai/code/session_015XzCnTMGiHQa8nWzndZFBN