### PR TITLE
Add support for Juliana trainer card

### DIFF
--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -193,6 +193,12 @@ pub fn forecast_trainer_action(
         CardId::B3152ParasolLady | CardId::B3193ParasolLady => {
             parasol_lady_effect(acting_player, state)
         }
+        CardId::B3a071Juliana | CardId::B3a086Juliana => card_search_outcomes_with_filter_multiple(
+            acting_player,
+            state,
+            1,
+            |card| matches!(card, Card::Pokemon(p) if p.stage == 2),
+        ),
         _ => panic!("Unsupported Trainer Card"),
     }
 }

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -227,6 +227,7 @@ pub fn trainer_move_generation_implementation(
         CardId::B3152ParasolLady | CardId::B3193ParasolLady => {
             can_play_parasol_lady(state, trainer_card)
         }
+        CardId::B3a071Juliana | CardId::B3a086Juliana => can_play_trainer(state, trainer_card),
         _ => None,
     }
 }

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -4,5 +4,7 @@ mod barry_test;
 mod field_blower_test;
 #[path = "trainers/iris_trainer_test.rs"]
 mod iris_trainer_test;
+#[path = "trainers/juliana_test.rs"]
+mod juliana_test;
 #[path = "trainers/korrina_cabbie_parasol_lady_test.rs"]
 mod korrina_cabbie_parasol_lady_test;

--- a/tests/trainers/juliana_test.rs
+++ b/tests/trainers/juliana_test.rs
@@ -1,0 +1,96 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn make_trainer_card(card_id: CardId) -> deckgym::models::TrainerCard {
+    get_card_by_enum(card_id).as_trainer()
+}
+
+#[test]
+fn test_juliana_puts_stage2_from_deck_into_hand() {
+    // Juliana: "Put a random Stage 2 Pokémon from your deck into your hand."
+    // Deck has one Stage 2 (Venusaur); after playing Juliana it should appear in hand.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let venusaur_card = get_card_by_enum(CardId::A1003Venusaur);
+    state.decks[0].cards = vec![venusaur_card.clone()];
+
+    let juliana = make_trainer_card(CardId::B3a071Juliana);
+    state.hands[0] = vec![Card::Trainer(juliana.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: juliana,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    let hand = &state.hands[0];
+    let has_venusaur = hand
+        .iter()
+        .any(|c| matches!(c, Card::Pokemon(p) if p.id == "A1 003"));
+    assert!(
+        has_venusaur,
+        "Venusaur (Stage 2) should be in hand after playing Juliana"
+    );
+    assert!(
+        state.decks[0].cards.is_empty(),
+        "Deck should be empty after transferring the only card"
+    );
+}
+
+#[test]
+fn test_juliana_no_stage2_in_deck_does_nothing() {
+    // If no Stage 2 in deck, Juliana has no effect (deck has only a Basic).
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let bulbasaur_card = get_card_by_enum(CardId::A1001Bulbasaur);
+    state.decks[0].cards = vec![bulbasaur_card];
+
+    let juliana = make_trainer_card(CardId::B3a071Juliana);
+    state.hands[0] = vec![Card::Trainer(juliana.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: juliana,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    // Hand should contain no Pokemon (Bulbasaur stayed in deck, not moved)
+    let has_bulbasaur_in_hand = state.hands[0]
+        .iter()
+        .any(|c| matches!(c, Card::Pokemon(p) if p.id == "A1 001"));
+    assert!(
+        !has_bulbasaur_in_hand,
+        "Bulbasaur (Basic) should NOT be moved to hand by Juliana"
+    );
+}


### PR DESCRIPTION
## Summary
Implements support for the Juliana trainer card, which searches the player's deck for a random Stage 2 Pokémon and puts it into their hand.

## Changes
- **Action handling**: Added Juliana card IDs (B3a071Juliana and B3a086Juliana) to the trainer action forecasting logic using `card_search_outcomes_with_filter_multiple` with a filter for Stage 2 Pokémon
- **Move generation**: Added Juliana to the move generation logic with standard trainer card playability checks
- **Tests**: Added comprehensive test coverage with two test cases:
  - `test_juliana_puts_stage2_from_deck_into_hand`: Verifies that a Stage 2 Pokémon is successfully moved from deck to hand
  - `test_juliana_no_stage2_in_deck_does_nothing`: Verifies that Juliana has no effect when no Stage 2 Pokémon exists in the deck

## Implementation Details
The card uses the existing `card_search_outcomes_with_filter_multiple` utility with a filter predicate that matches only Pokémon cards with stage 2, allowing it to integrate seamlessly with the existing card search framework.

https://claude.ai/code/session_01TbEtgZD4cqn3xD2ZmKjjo2