### PR TITLE
Add support for Terapagos ex Prism Impact attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -457,6 +457,9 @@ fn forecast_effect_attack_by_mechanic(
             opponent,
             damage_per_energy,
         } => extra_damage_per_energy(state, attack.fixed_damage, *opponent, *damage_per_energy),
+        Mechanic::ExtraDamagePerEnergyType { damage_per_type } => {
+            extra_damage_per_energy_type(state, attack.fixed_damage, *damage_per_type)
+        }
         Mechanic::ExtraDamagePerRetreatCost { damage_per_energy } => {
             extra_damage_per_retreat_cost(state, attack.fixed_damage, *damage_per_energy)
         }
@@ -2094,6 +2097,17 @@ fn extra_damage_equal_to_self_damage(state: &State, base_damage: u32) -> Outcome
     let attacker = state.get_active(state.current_player);
     let self_damage = attacker.get_damage_counters();
     active_damage_doutcome(base_damage + self_damage)
+}
+
+fn extra_damage_per_energy_type(state: &State, base_damage: u32, damage_per_type: u32) -> Outcomes {
+    let attacker = state.get_active(state.current_player);
+    let energies = attacker.get_effective_attached_energy(state, state.current_player);
+    let mut seen = std::collections::HashSet::new();
+    for e in &energies {
+        seen.insert(*e);
+    }
+    let damage = base_damage + (seen.len() as u32) * damage_per_type;
+    active_damage_doutcome(damage)
 }
 
 fn extra_damage_per_energy(

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -269,6 +269,9 @@ pub enum Mechanic {
         opponent: bool,
         damage_per_energy: u32,
     },
+    ExtraDamagePerEnergyType {
+        damage_per_type: u32,
+    },
     ExtraDamagePerRetreatCost {
         damage_per_energy: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1321,6 +1321,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("This attack does 20 damage to each of your opponent's Pokémon.", todo_implementation);
     // map.insert("This attack does 20 damage to each of your opponent's Pokémon. During your next turn, this Pokémon's Wild Spin attack does +20 damage to each of your opponent's Pokémon.", todo_implementation);
     map.insert(
+        "This attack does 20 more damage for each type of Energy attached to this Pokémon.",
+        Mechanic::ExtraDamagePerEnergyType {
+            damage_per_type: 20,
+        },
+    );
+    map.insert(
         "This attack does 20 more damage for each Energy attached to this Pokémon.",
         Mechanic::ExtraDamagePerEnergy {
             opponent: false,

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -96,6 +96,8 @@ mod swift_shot_test;
 mod tapu_lele_energy_arrow_test;
 #[path = "pokemon/tepig_stoke_test.rs"]
 mod tepig_stoke_test;
+#[path = "pokemon/terapagos_ex_test.rs"]
+mod terapagos_ex_test;
 #[path = "pokemon/vaporeon_ex_test.rs"]
 mod vaporeon_ex_test;
 #[path = "pokemon/vulpix_tail_whip_test.rs"]

--- a/tests/pokemon/terapagos_ex_test.rs
+++ b/tests/pokemon/terapagos_ex_test.rs
@@ -1,0 +1,71 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn high_hp_target(card: CardId) -> PlayedCard {
+    let card_data = get_card_by_enum(card);
+    PlayedCard::new(card_data, 0, 300, vec![], false, vec![])
+}
+
+/// Prism Impact: 80 base + 20 for each unique Energy type attached.
+/// With 3 energies of the same type (1 unique type), damage should be 80 + 20 = 100.
+#[test]
+fn test_terapagos_prism_impact_single_type() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a068TerapagosEx).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![high_hp_target(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    // 1 unique type -> 80 + 20*1 = 100 damage
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 300 - 100);
+}
+
+/// With 2 different energy types attached, damage should be 80 + 20*2 = 120.
+#[test]
+fn test_terapagos_prism_impact_two_types() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a068TerapagosEx).with_energy(vec![
+                EnergyType::Fire,
+                EnergyType::Water,
+                EnergyType::Fire,
+            ]),
+        ],
+        vec![high_hp_target(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    // 2 unique types -> 80 + 20*2 = 120 damage
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 300 - 120);
+}


### PR DESCRIPTION
## Summary
Implement support for Terapagos ex's Prism Impact attack, which deals damage based on the number of unique energy types attached to the attacker.

## Changes
- **New Mechanic**: Added `ExtraDamagePerEnergyType` variant to the `Mechanic` enum to support attacks that scale with unique energy types rather than total energy count
- **Damage Calculation**: Implemented `extra_damage_per_energy_type()` function that counts distinct energy types attached to the active Pokémon and multiplies by the damage per type value
- **Effect Mapping**: Added mapping for "This attack does 20 more damage for each type of Energy attached to this Pokémon." text to the new mechanic
- **Attack Resolution**: Integrated the new mechanic into `forecast_effect_attack_by_mechanic()` to properly forecast damage during attack resolution
- **Tests**: Added comprehensive test coverage with two test cases:
  - Single energy type (3 Colorless): validates 80 + 20×1 = 100 damage
  - Multiple energy types (Fire/Water mix): validates 80 + 20×2 = 120 damage

## Implementation Details
The key distinction from the existing `ExtraDamagePerEnergy` mechanic is that this counts *unique* energy types using a `HashSet`, not total energy attachments. This allows proper implementation of attacks that reward energy type diversity.

https://claude.ai/code/session_019D4ycZ8pDozBgsMJAngbxD