### PR TITLE
Add Professor Sada and Professor Turo trainer card support

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -66,6 +66,7 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::DiscardToolFromPokemon { .. }
         | SimpleAction::DiscardActiveStadium
         | SimpleAction::DiscardRandomOpponentActiveEnergy
+        | SimpleAction::ProfessorSadaAttach { .. }
         | SimpleAction::Noop => forecast_deterministic_action(),
         SimpleAction::UseAbility { in_play_idx } => forecast_ability(state, action, *in_play_idx),
         SimpleAction::Attack(index) => forecast_attack(action.actor, state, *index),
@@ -258,6 +259,11 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
             let opponent = (action.actor + 1) % 2;
             if let Some(energy) = state.get_active(opponent).attached_energy.last().copied() {
                 state.discard_from_active(opponent, &[energy]);
+            }
+        }
+        SimpleAction::ProfessorSadaAttach { attachments } => {
+            for (energy, in_play_idx) in attachments {
+                state.attach_energy_from_discard(action.actor, *in_play_idx, &[*energy]);
             }
         }
         SimpleAction::Noop => {}

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     combinatorics::generate_combinations,
     effects::TurnEffect,
-    hooks::{get_stage, is_ultra_beast},
+    hooks::{get_stage, is_ancient_pokemon, is_future_pokemon, is_ultra_beast},
     models::{Card, EnergyType, StatusCondition, TrainerCard, TrainerType},
     tools::{enumerate_tool_choices, is_tool_effect_implemented},
     State,
@@ -192,6 +192,12 @@ pub fn forecast_trainer_action(
         ),
         CardId::B3152ParasolLady | CardId::B3193ParasolLady => {
             parasol_lady_effect(acting_player, state)
+        }
+        CardId::B3a072ProfessorSada | CardId::B3a087ProfessorSada => {
+            Outcomes::single_fn(professor_sada_effect)
+        }
+        CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
+            Outcomes::single_fn(professor_turo_effect)
         }
         _ => panic!("Unsupported Trainer Card"),
     }
@@ -1352,6 +1358,100 @@ fn team_rocket_grunt_outcomes() -> Outcomes {
             },
         )
     })
+}
+
+fn professor_sada_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    let player = action.actor;
+    let distinct_types: Vec<EnergyType> = {
+        let mut seen = std::collections::HashSet::new();
+        state.discard_energies[player]
+            .iter()
+            .filter(|e| seen.insert(**e))
+            .copied()
+            .collect()
+    };
+    let ancient_indices: Vec<usize> = state
+        .enumerate_in_play_pokemon(player)
+        .filter(|(_, p)| is_ancient_pokemon(&p.get_name()))
+        .map(|(idx, _)| idx)
+        .collect();
+
+    let energy_combos = generate_energy_type_combinations(&distinct_types, 3);
+    let mut choices: Vec<SimpleAction> = Vec::new();
+    for combo in energy_combos {
+        let distributions = generate_energy_distributions(&combo, &ancient_indices);
+        for dist in distributions {
+            let action = SimpleAction::ProfessorSadaAttach { attachments: dist };
+            if !choices.contains(&action) {
+                choices.push(action);
+            }
+        }
+    }
+    if !choices.is_empty() {
+        state.move_generation_stack.push((player, choices));
+    }
+}
+
+/// Generate all combinations of `count` distinct energy types from the available types.
+fn generate_energy_type_combinations(types: &[EnergyType], count: usize) -> Vec<Vec<EnergyType>> {
+    if types.len() < count {
+        if types.is_empty() {
+            return vec![vec![]];
+        }
+        return vec![types.to_vec()];
+    }
+    let mut result = Vec::new();
+    generate_combinations_helper(types, count, 0, &mut vec![], &mut result);
+    result
+}
+
+fn generate_combinations_helper(
+    types: &[EnergyType],
+    count: usize,
+    start: usize,
+    current: &mut Vec<EnergyType>,
+    result: &mut Vec<Vec<EnergyType>>,
+) {
+    if current.len() == count {
+        result.push(current.clone());
+        return;
+    }
+    for i in start..types.len() {
+        current.push(types[i]);
+        generate_combinations_helper(types, count, i + 1, current, result);
+        current.pop();
+    }
+}
+
+/// Generate all ways to distribute a list of energies to a set of in-play indices.
+fn generate_energy_distributions(
+    energies: &[EnergyType],
+    targets: &[usize],
+) -> Vec<Vec<(EnergyType, usize)>> {
+    if energies.is_empty() {
+        return vec![vec![]];
+    }
+    let mut result = Vec::new();
+    let rest = generate_energy_distributions(&energies[1..], targets);
+    for target in targets {
+        for mut dist in rest.clone() {
+            dist.insert(0, (energies[0], *target));
+            result.push(dist);
+        }
+    }
+    result
+}
+
+fn professor_turo_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    let player = action.actor;
+    let choices: Vec<SimpleAction> = state
+        .enumerate_in_play_pokemon(player)
+        .filter(|(_, p)| is_future_pokemon(&p.get_name()))
+        .map(|(idx, _)| SimpleAction::ReturnPokemonToHand { in_play_idx: idx })
+        .collect();
+    if !choices.is_empty() {
+        state.move_generation_stack.push((player, choices));
+    }
 }
 
 #[cfg(test)]

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -144,6 +144,10 @@ pub enum SimpleAction {
     DiscardActiveStadium,
     /// Crawdaunt's Unruly Claw: discard a random Energy from the opponent's Active Pokémon
     DiscardRandomOpponentActiveEnergy,
+    /// Professor Sada: attach 3 specific energy types from discard to Ancient Pokémon
+    ProfessorSadaAttach {
+        attachments: Vec<(EnergyType, usize)>, // (energy_type, in_play_idx)
+    },
     Noop, // No operation, used to have the user say "no" to a question
 }
 
@@ -292,6 +296,9 @@ impl fmt::Display for SimpleAction {
                 write!(f, "DiscardToolFromPokemon({player}, {in_play_idx})")
             }
             SimpleAction::DiscardActiveStadium => write!(f, "DiscardActiveStadium"),
+            SimpleAction::ProfessorSadaAttach { attachments } => {
+                write!(f, "ProfessorSadaAttach({attachments:?})")
+            }
             SimpleAction::DiscardRandomOpponentActiveEnergy => {
                 write!(f, "DiscardRandomOpponentActiveEnergy")
             }

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use core::energy_missing;
 pub(crate) use core::get_attack_cost;
 pub(crate) use core::get_stage;
 pub(crate) use core::is_ancient_pokemon;
+pub(crate) use core::is_future_pokemon;
 pub(crate) use core::is_ultra_beast;
 pub(crate) use core::modify_damage;
 pub(crate) use core::on_attack_knockout;

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -5,7 +5,10 @@ use crate::{
         can_rare_candy_evolve, diantha_targets, ilima_targets, quick_grow_extract_candidates,
     },
     effects::TurnEffect,
-    hooks::{can_play_item, can_play_support, get_stage, is_ultra_beast},
+    hooks::{
+        can_play_item, can_play_support, get_stage, is_ancient_pokemon, is_future_pokemon,
+        is_ultra_beast,
+    },
     models::{Card, EnergyType, TrainerCard, TrainerType},
     stadiums::is_stadium_effect_implemented,
     tools::{enumerate_tool_choices, is_tool_effect_implemented},
@@ -226,6 +229,12 @@ pub fn trainer_move_generation_implementation(
         CardId::B3150Cabbie | CardId::B3191Cabbie => can_play_cabbie(state, trainer_card),
         CardId::B3152ParasolLady | CardId::B3193ParasolLady => {
             can_play_parasol_lady(state, trainer_card)
+        }
+        CardId::B3a072ProfessorSada | CardId::B3a087ProfessorSada => {
+            can_play_professor_sada(state, trainer_card)
+        }
+        CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
+            can_play_professor_turo(state, trainer_card)
         }
         _ => None,
     }
@@ -810,6 +819,38 @@ fn can_play_parasol_lady(state: &State, trainer_card: &TrainerCard) -> Option<Ve
             pokemon.get_energy_type() == Some(EnergyType::Water) && !pokemon.card.is_ex()
         });
     if has_target {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
+}
+
+/// Check if Professor Sada can be played.
+/// Requires: at least 1 Ancient Pokémon in play AND at least 3 distinct energy types in discard.
+fn can_play_professor_sada(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let player = state.current_player;
+    let has_ancient = state
+        .enumerate_in_play_pokemon(player)
+        .any(|(_, p)| is_ancient_pokemon(&p.get_name()));
+    if !has_ancient {
+        return cannot_play_trainer();
+    }
+    let distinct_types: std::collections::HashSet<EnergyType> =
+        state.discard_energies[player].iter().copied().collect();
+    if distinct_types.len() < 3 {
+        return cannot_play_trainer();
+    }
+    can_play_trainer(state, trainer_card)
+}
+
+/// Check if Professor Turo can be played.
+/// Requires: at least 1 Future Pokémon in play.
+fn can_play_professor_turo(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let player = state.current_player;
+    let has_future = state
+        .enumerate_in_play_pokemon(player)
+        .any(|(_, p)| is_future_pokemon(&p.get_name()));
+    if has_future {
         can_play_trainer(state, trainer_card)
     } else {
         cannot_play_trainer()

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -64,6 +64,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::DiscardOpponentSupporter { .. } => 5,
         SimpleAction::DiscardOwnCards { .. } => 5,
         SimpleAction::AttachFromDiscard { .. } => 10,
+        SimpleAction::ProfessorSadaAttach { .. } => 10,
         SimpleAction::ApplyEeveeBagDamageBoost => 5,
         SimpleAction::HealAllEeveeEvolutions => 5,
         SimpleAction::DiscardFossil { .. } => 1, // Low weight to discard fossils

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -42,6 +42,7 @@ fn action_priority_for_tui(action: &SimpleAction) -> u8 {
         SimpleAction::Play { .. } => 2,
         SimpleAction::Attach { .. }
         | SimpleAction::AttachFromDiscard { .. }
+        | SimpleAction::ProfessorSadaAttach { .. }
         | SimpleAction::AttachTool { .. } => 3,
         SimpleAction::Attack(_) | SimpleAction::UseCopiedAttack { .. } => 4,
         SimpleAction::Retreat(_) => 5,

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -6,3 +6,5 @@ mod field_blower_test;
 mod iris_trainer_test;
 #[path = "trainers/korrina_cabbie_parasol_lady_test.rs"]
 mod korrina_cabbie_parasol_lady_test;
+#[path = "trainers/professor_sada_test.rs"]
+mod professor_sada_test;

--- a/tests/trainers/professor_sada_test.rs
+++ b/tests/trainers/professor_sada_test.rs
@@ -1,0 +1,105 @@
+use deckgym::{
+    actions::SimpleAction,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Professor Sada attaches 3 different energy types from the discard pile to Ancient Pokémon.
+#[test]
+fn test_professor_sada_attaches_three_energies_to_ancient_pokemon() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a036KoraidonEx),
+            PlayedCard::from_id(CardId::B3a047RoaringMoon),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 1;
+    // 3 different energy types in discard
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Fighting, EnergyType::Darkness];
+    state.hands[0] = vec![get_card_by_enum(CardId::B3a072ProfessorSada)];
+    game.set_state(state);
+
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    let play_action = actions
+        .iter()
+        .find(|a| {
+            matches!(
+                &a.action,
+                SimpleAction::Play { trainer_card } if trainer_card.name == "Professor Sada"
+            )
+        })
+        .expect("Professor Sada should be playable");
+    game.apply_action(play_action);
+
+    // Should now prompt for attachment distribution choices
+    let state = game.get_state_clone();
+    let (_actor, attach_choices) = state.generate_possible_actions();
+    assert!(
+        !attach_choices.is_empty(),
+        "There should be attachment choices after playing Professor Sada"
+    );
+    assert!(
+        attach_choices
+            .iter()
+            .all(|a| matches!(a.action, SimpleAction::ProfessorSadaAttach { .. })),
+        "Choices should all be ProfessorSadaAttach actions"
+    );
+
+    // Apply first choice and verify 3 energies attached total to Ancient Pokémon
+    game.apply_action(&attach_choices[0]);
+
+    let final_state = game.get_state_clone();
+    let total_energy_on_ancient: usize = final_state.in_play_pokemon[0]
+        .iter()
+        .flatten()
+        .filter(|p| matches!(p.get_name().as_str(), "Koraidon ex" | "Roaring Moon"))
+        .map(|p| p.attached_energy.len())
+        .sum();
+    assert_eq!(
+        total_energy_on_ancient, 3,
+        "All 3 energies should be on Ancient Pokémon"
+    );
+    assert!(
+        final_state.discard_energies[0].is_empty(),
+        "Discard pile should be empty after attaching all 3 energies"
+    );
+}
+
+/// Professor Sada cannot be played if there are fewer than 3 distinct energy types in discard.
+#[test]
+fn test_professor_sada_not_playable_with_fewer_than_three_types() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3a036KoraidonEx)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 1;
+    // Only 2 different types in discard
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Fire, EnergyType::Fighting];
+    state.hands[0] = vec![get_card_by_enum(CardId::B3a072ProfessorSada)];
+    game.set_state(state);
+
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    let play_action = actions.iter().find(|a| {
+        matches!(
+            &a.action,
+            SimpleAction::Play { trainer_card } if trainer_card.name == "Professor Sada"
+        )
+    });
+    assert!(
+        play_action.is_none(),
+        "Professor Sada should not be playable with fewer than 3 distinct energy types"
+    );
+}


### PR DESCRIPTION
## Summary
Implements support for Professor Sada and Professor Turo trainer cards from the Pokémon TCG. These cards enable energy attachment and Pokémon retrieval mechanics for Ancient and Future Pokémon respectively.

## Key Changes
- **Professor Sada Implementation**: Attaches 3 different energy types from the discard pile to Ancient Pokémon in play. Includes validation to ensure at least 3 distinct energy types are available in discard and at least one Ancient Pokémon is in play.
- **Professor Turo Implementation**: Returns a Future Pokémon from play to hand. Requires at least one Future Pokémon in play to be playable.
- **New Action Type**: Added `ProfessorSadaAttach` action variant to handle energy attachment distribution choices with support for multiple target Pokémon.
- **Helper Functions**: Implemented energy type combination generation and energy distribution logic to support all valid attachment configurations.
- **Playability Checks**: Added validation functions in move generation to enforce card play conditions.
- **Test Coverage**: Added comprehensive tests verifying Professor Sada attaches exactly 3 energies to Ancient Pokémon and cannot be played with insufficient energy types in discard.

## Implementation Details
- Energy distribution uses recursive combinatorics to generate all valid ways to assign 3 distinct energy types to available Ancient Pokémon targets
- Playability validation checks both the presence of valid targets and resource availability (distinct energy types in discard)
- The action system properly integrates with existing move generation and action application pipelines
- UI and weighted random player logic updated to handle the new action type

https://claude.ai/code/session_01Ak5jFbnu8iM55PPNyND1TL