### PR TITLE
Implement Professor Turo trainer card effect

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -63,6 +63,7 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::HealAllEeveeEvolutions
         | SimpleAction::DiscardFossil { .. }
         | SimpleAction::ReturnPokemonToHand { .. }
+        | SimpleAction::ShuffleInPlayPokemonIntoDeck { .. }
         | SimpleAction::DiscardToolFromPokemon { .. }
         | SimpleAction::DiscardActiveStadium
         | SimpleAction::DiscardRandomOpponentActiveEnergy
@@ -243,6 +244,9 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
         SimpleAction::ReturnPokemonToHand { in_play_idx } => {
             apply_return_pokemon_to_hand(action.actor, state, *in_play_idx)
         }
+        SimpleAction::ShuffleInPlayPokemonIntoDeck { in_play_idx } => {
+            apply_shuffle_in_play_pokemon_into_deck(action.actor, state, *in_play_idx)
+        }
         SimpleAction::DiscardToolFromPokemon {
             player,
             in_play_idx,
@@ -380,6 +384,23 @@ fn apply_return_pokemon_to_hand(acting_player: usize, state: &mut State, in_play
     state.hands[acting_player].extend(cards_to_collect);
 
     // If returning the active, trigger promotion or declare winner.
+    if in_play_idx == 0 {
+        state.trigger_promotion_or_declare_winner(acting_player);
+    }
+}
+
+fn apply_shuffle_in_play_pokemon_into_deck(
+    acting_player: usize,
+    state: &mut State,
+    in_play_idx: usize,
+) {
+    let played_card = state.in_play_pokemon[acting_player][in_play_idx]
+        .take()
+        .expect("Pokemon should be there if shuffling into deck");
+    let mut cards_to_shuffle = played_card.cards_behind.clone();
+    cards_to_shuffle.push(played_card.card.clone());
+    state.decks[acting_player].cards.extend(cards_to_shuffle);
+
     if in_play_idx == 0 {
         state.trigger_promotion_or_declare_winner(acting_player);
     }

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     combinatorics::generate_combinations,
     effects::TurnEffect,
-    hooks::{get_stage, is_ultra_beast},
+    hooks::{get_stage, is_future_pokemon, is_ultra_beast},
     models::{Card, EnergyType, StatusCondition, TrainerCard, TrainerType},
     tools::{enumerate_tool_choices, is_tool_effect_implemented},
     State,
@@ -193,6 +193,9 @@ pub fn forecast_trainer_action(
         CardId::B3152ParasolLady | CardId::B3193ParasolLady => {
             parasol_lady_effect(acting_player, state)
         }
+        CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
+            professor_turo_effect(acting_player, state)
+        }
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -365,6 +368,23 @@ fn parasol_lady_effect(acting_player: usize, state: &State) -> Outcomes {
             pokemon.get_energy_type() == Some(EnergyType::Water) && !pokemon.card.is_ex()
         })
         .map(|(in_play_idx, _)| SimpleAction::ReturnPokemonToHand { in_play_idx })
+        .collect();
+
+    Outcomes::single_fn(move |_, state, action| {
+        if !choices.is_empty() {
+            state
+                .move_generation_stack
+                .push((action.actor, choices.clone()));
+        }
+    })
+}
+
+fn professor_turo_effect(acting_player: usize, state: &State) -> Outcomes {
+    // Shuffle 1 of your Future Pokémon in play into your deck.
+    let choices: Vec<SimpleAction> = state
+        .enumerate_in_play_pokemon(acting_player)
+        .filter(|(_, pokemon)| is_future_pokemon(&pokemon.get_name()))
+        .map(|(in_play_idx, _)| SimpleAction::ShuffleInPlayPokemonIntoDeck { in_play_idx })
         .collect();
 
     Outcomes::single_fn(move |_, state, action| {

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -135,6 +135,10 @@ pub enum SimpleAction {
     ReturnPokemonToHand {
         in_play_idx: usize,
     },
+    /// Shuffle a Pokemon from play into its owner's deck (e.g., Professor Turo).
+    ShuffleInPlayPokemonIntoDeck {
+        in_play_idx: usize,
+    },
     /// Field Blower: discard the tool attached to a specific Pokémon (any player).
     DiscardToolFromPokemon {
         player: usize,
@@ -287,6 +291,9 @@ impl fmt::Display for SimpleAction {
             }
             SimpleAction::ReturnPokemonToHand { in_play_idx } => {
                 write!(f, "ReturnPokemonToHand({in_play_idx})")
+            }
+            SimpleAction::ShuffleInPlayPokemonIntoDeck { in_play_idx } => {
+                write!(f, "ShuffleInPlayPokemonIntoDeck({in_play_idx})")
             }
             SimpleAction::DiscardToolFromPokemon { player, in_play_idx } => {
                 write!(f, "DiscardToolFromPokemon({player}, {in_play_idx})")

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -13,6 +13,7 @@ pub(crate) use core::energy_missing;
 pub(crate) use core::get_attack_cost;
 pub(crate) use core::get_stage;
 pub(crate) use core::is_ancient_pokemon;
+pub(crate) use core::is_future_pokemon;
 pub(crate) use core::is_ultra_beast;
 pub(crate) use core::modify_damage;
 pub(crate) use core::on_attack_knockout;

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -5,7 +5,7 @@ use crate::{
         can_rare_candy_evolve, diantha_targets, ilima_targets, quick_grow_extract_candidates,
     },
     effects::TurnEffect,
-    hooks::{can_play_item, can_play_support, get_stage, is_ultra_beast},
+    hooks::{can_play_item, can_play_support, get_stage, is_future_pokemon, is_ultra_beast},
     models::{Card, EnergyType, TrainerCard, TrainerType},
     stadiums::is_stadium_effect_implemented,
     tools::{enumerate_tool_choices, is_tool_effect_implemented},
@@ -226,6 +226,9 @@ pub fn trainer_move_generation_implementation(
         CardId::B3150Cabbie | CardId::B3191Cabbie => can_play_cabbie(state, trainer_card),
         CardId::B3152ParasolLady | CardId::B3193ParasolLady => {
             can_play_parasol_lady(state, trainer_card)
+        }
+        CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
+            can_play_professor_turo(state, trainer_card)
         }
         _ => None,
     }
@@ -810,6 +813,18 @@ fn can_play_parasol_lady(state: &State, trainer_card: &TrainerCard) -> Option<Ve
             pokemon.get_energy_type() == Some(EnergyType::Water) && !pokemon.card.is_ex()
         });
     if has_target {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
+}
+
+/// Check if Professor Turo can be played (requires at least one Future Pokémon in play)
+fn can_play_professor_turo(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let has_future = state
+        .enumerate_in_play_pokemon(state.current_player)
+        .any(|(_, pokemon)| is_future_pokemon(&pokemon.get_name()));
+    if has_future {
         can_play_trainer(state, trainer_card)
     } else {
         cannot_play_trainer()

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -68,6 +68,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::HealAllEeveeEvolutions => 5,
         SimpleAction::DiscardFossil { .. } => 1, // Low weight to discard fossils
         SimpleAction::ReturnPokemonToHand { .. } => 5,
+        SimpleAction::ShuffleInPlayPokemonIntoDeck { .. } => 5,
         SimpleAction::DiscardToolFromPokemon { .. } => 5,
         SimpleAction::DiscardActiveStadium => 5,
         SimpleAction::DiscardRandomOpponentActiveEnergy => 10,

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -6,3 +6,5 @@ mod field_blower_test;
 mod iris_trainer_test;
 #[path = "trainers/korrina_cabbie_parasol_lady_test.rs"]
 mod korrina_cabbie_parasol_lady_test;
+#[path = "trainers/professor_turo_test.rs"]
+mod professor_turo_test;

--- a/tests/trainers/professor_turo_test.rs
+++ b/tests/trainers/professor_turo_test.rs
@@ -1,0 +1,141 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard, TrainerCard},
+    state::GameOutcome,
+    test_support::get_initialized_game,
+};
+
+fn make_turo_trainer_card() -> TrainerCard {
+    match get_card_by_enum(CardId::B3a073ProfessorTuro) {
+        Card::Trainer(tc) => tc,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+fn make_iron_hands() -> PlayedCard {
+    PlayedCard::from_id(CardId::B3a017IronHands)
+}
+
+/// When Professor Turo is played and the player chooses their Active Future Pokémon,
+/// they must then promote a Pokémon from the bench.
+#[test]
+fn test_professor_turo_active_triggers_promotion() {
+    let mut game = get_initialized_game(1);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    // Player 0: Iron Hands (Future) active + Bulbasaur on bench
+    state.set_board(
+        vec![
+            make_iron_hands(),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_turo_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card.clone()));
+    game.set_state(state);
+
+    // Play Professor Turo
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    // Now the game should ask which Future Pokémon to shuffle — choose the active (index 0)
+    let state = game.get_state_clone();
+    let (actor, choices) = state.generate_possible_actions();
+    assert_eq!(actor, 0);
+    let shuffle_active = choices.iter().find(|a| {
+        matches!(
+            &a.action,
+            SimpleAction::ShuffleInPlayPokemonIntoDeck { in_play_idx: 0 }
+        )
+    });
+    assert!(
+        shuffle_active.is_some(),
+        "Should be able to choose Active pokemon to shuffle, choices: {:?}",
+        choices
+    );
+
+    game.apply_action(shuffle_active.unwrap());
+
+    // After shuffling active, Iron Hands should be in the deck
+    let state = game.get_state_clone();
+    let iron_hands_card = get_card_by_enum(CardId::B3a017IronHands);
+    assert!(
+        state.decks[0].cards.contains(&iron_hands_card),
+        "Shuffled Pokemon should be in deck"
+    );
+
+    // Player 0 should now be prompted to promote a bench pokemon
+    let (promo_actor, promo_choices) = state.generate_possible_actions();
+    assert_eq!(promo_actor, 0);
+    assert!(
+        promo_choices
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Activate { in_play_idx: 1, .. })),
+        "Should be prompted to promote bench pokemon, choices: {:?}",
+        promo_choices
+    );
+}
+
+/// When Professor Turo is played with the Active Future Pokémon and no bench Pokémon,
+/// the player loses immediately.
+#[test]
+fn test_professor_turo_active_no_bench_loses() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    // Player 0: Iron Hands (Future) active only, no bench
+    state.set_board(
+        vec![make_iron_hands()],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_turo_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card.clone()));
+    game.set_state(state);
+
+    // Play Professor Turo
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    // Should only offer shuffling the active (no bench Future Pokemon either)
+    let state = game.get_state_clone();
+    let (actor, choices) = state.generate_possible_actions();
+    assert_eq!(actor, 0);
+    let shuffle_active = choices.iter().find(|a| {
+        matches!(
+            &a.action,
+            SimpleAction::ShuffleInPlayPokemonIntoDeck { in_play_idx: 0 }
+        )
+    });
+    assert!(
+        shuffle_active.is_some(),
+        "Should be able to choose Active pokemon, choices: {:?}",
+        choices
+    );
+
+    game.apply_action(shuffle_active.unwrap());
+
+    // With no bench pokemon, player 0 should lose
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.winner,
+        Some(GameOutcome::Win(1)),
+        "Player with no bench should lose when active is shuffled away"
+    );
+}


### PR DESCRIPTION
## Summary
Adds support for Professor Turo trainer card, which allows players to shuffle one of their Future Pokémon in play into their deck. This includes proper handling of the promotion requirement when the active Pokémon is shuffled away.

## Changes
- **New action type**: `ShuffleInPlayPokemonIntoDeck` to handle shuffling Pokémon from play into deck
- **Trainer effect implementation**: `professor_turo_effect()` filters in-play Pokémon by Future type and generates shuffle choices
- **Playability check**: `can_play_professor_turo()` validates that at least one Future Pokémon is in play before allowing the card to be played
- **Action application**: `apply_shuffle_in_play_pokemon_into_deck()` moves the Pokémon and its attached cards into the deck, then triggers promotion logic if the active Pokémon was shuffled (which can result in a loss if no bench Pokémon are available)
- **Helper function**: Added `is_future_pokemon()` hook to identify Future-type Pokémon
- **Comprehensive tests**: Two test cases covering the promotion flow and the loss condition when no bench Pokémon are available

## Implementation Details
- Supports both card variants: `B3a073ProfessorTuro` and `B3a088ProfessorTuro`
- Properly integrates with the existing promotion system via `trigger_promotion_or_declare_winner()`
- Weighted random player updated to handle the new action type

https://claude.ai/code/session_0122jUgwTMkRdsNQFLLcCoeF