### PR TITLE
Implement Iron Thorns' Binary Thunder attack (ExtraDamageIfEx +40)

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -924,6 +924,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::ExtraDamageIfEx { extra_damage: 30 },
     );
     map.insert(
+        "If your opponent's Active Pokémon is a Pokémon ex, this attack does 40 more damage.",
+        Mechanic::ExtraDamageIfEx { extra_damage: 40 },
+    );
+    map.insert(
         "If your opponent's Active Pokémon is a Pokémon ex, this attack does 70 more damage.",
         Mechanic::ExtraDamageIfEx { extra_damage: 70 },
     );

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -50,6 +50,8 @@ mod iron_bundle_ex_test;
 mod iron_hands_test;
 #[path = "pokemon/iron_moth_test.rs"]
 mod iron_moth_test;
+#[path = "pokemon/iron_thorns_test.rs"]
+mod iron_thorns_test;
 #[path = "pokemon/jolteon_ex_test.rs"]
 mod jolteon_ex_test;
 #[path = "pokemon/klefki_dismantling_keys_test.rs"]

--- a/tests/pokemon/iron_thorns_test.rs
+++ b/tests/pokemon/iron_thorns_test.rs
@@ -1,0 +1,65 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn played_with_hp(card_id: CardId, hp: u32) -> PlayedCard {
+    let card = deckgym::database::get_card_by_enum(card_id);
+    PlayedCard::new(card, 0, hp, vec![], false, vec![])
+}
+
+/// Binary Thunder deals base 40 damage against a non-ex Pokémon.
+#[test]
+fn test_iron_thorns_binary_thunder_base_damage_vs_non_ex() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3a018IronThorns)
+            .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning])],
+        vec![played_with_hp(CardId::A1001Bulbasaur, 200)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let damage = 200 - game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        damage, 40,
+        "Binary Thunder should deal 40 damage against a non-ex Pokémon, got {damage}"
+    );
+}
+
+/// Binary Thunder deals 80 damage (40 + 40 bonus) against a Pokémon ex.
+#[test]
+fn test_iron_thorns_binary_thunder_bonus_damage_vs_ex() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3a018IronThorns)
+            .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning])],
+        vec![played_with_hp(CardId::A1096PikachuEx, 300)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let damage = 300 - game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        damage, 80,
+        "Binary Thunder should deal 80 damage against a Pokémon ex (40 + 40 bonus), got {damage}"
+    );
+}


### PR DESCRIPTION
Adds the missing effect_mechanic_map entry for "If your opponent's Active
Pokémon is a Pokémon ex, this attack does 40 more damage." and wires it to
the existing ExtraDamageIfEx mechanic, enabling B3a 018 Iron Thorns.

https://claude.ai/code/session_019De2tredx9B5zjfiHA7NhX