### PR TITLE
Implement Area Zero stadium effect

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -14,7 +14,7 @@ use crate::{
     effects::TurnEffect,
     hooks::{get_retreat_cost, on_bench_from_hand, on_evolve, to_playable_card},
     models::{Card, EnergyType},
-    stadiums::{is_fragrant_forest_active, is_mesagoza_active},
+    stadiums::{is_area_zero_active, is_fragrant_forest_active, is_mesagoza_active},
     state::State,
     tools,
 };
@@ -758,7 +758,7 @@ fn apply_heal_all_eevee_evolutions(acting_player: usize, state: &mut State) {
     }
 }
 
-/// Forecasts the UseStadium action for activated stadiums like Mesagoza and Fragrant Forest.
+/// Forecasts the UseStadium action for activated stadiums like Mesagoza, Fragrant Forest, and Area Zero.
 fn forecast_use_stadium(state: &State, acting_player: usize) -> Outcomes {
     if is_mesagoza_active(state) {
         return forecast_mesagoza_effect(state, acting_player);
@@ -766,7 +766,31 @@ fn forecast_use_stadium(state: &State, acting_player: usize) -> Outcomes {
     if is_fragrant_forest_active(state) {
         return forecast_fragrant_forest_effect(state, acting_player);
     }
+    if is_area_zero_active(state) {
+        return forecast_area_zero_effect(state, acting_player);
+    }
     Outcomes::single_fn(|_, _, _| {})
+}
+
+/// Area Zero: Once during each player's turn, that player may shuffle a Basic Pokémon from their
+/// hand into their deck. If they do, they draw a card.
+fn forecast_area_zero_effect(state: &State, acting_player: usize) -> Outcomes {
+    let choices: Vec<SimpleAction> = state.hands[acting_player]
+        .iter()
+        .filter(|card| card.is_basic())
+        .map(|card| SimpleAction::ShuffleOwnCardsIntoDeck {
+            cards: vec![card.clone()],
+        })
+        .collect();
+
+    Outcomes::single_fn(move |_, state, action| {
+        state.has_used_stadium[action.actor] = true;
+        if !choices.is_empty() {
+            state
+                .move_generation_stack
+                .push((action.actor, choices.clone()));
+        }
+    })
 }
 
 /// Mesagoza: Once during each player's turn, that player may flip a coin.

--- a/src/move_generation/mod.rs
+++ b/src/move_generation/mod.rs
@@ -5,7 +5,7 @@ mod move_generation_trainer;
 use crate::actions::{abilities::AbilityMechanic, get_ability_mechanic, Action, SimpleAction};
 use crate::hooks::{can_evolve_into, can_retreat, contains_energy, get_retreat_cost};
 use crate::models::Card;
-use crate::stadiums::{can_use_fragrant_forest, can_use_mesagoza};
+use crate::stadiums::{can_use_area_zero, can_use_fragrant_forest, can_use_mesagoza};
 use crate::state::State;
 
 use attacks::generate_attack_actions;
@@ -109,8 +109,11 @@ pub fn generate_possible_actions(state: &State) -> (usize, Vec<Action>) {
     let ability_actions = generate_ability_actions(state);
     actions.extend(ability_actions);
 
-    // Add actions given by active stadium (activated stadiums like Mesagoza, Fragrant Forest)
-    if can_use_mesagoza(state, current_player) || can_use_fragrant_forest(state, current_player) {
+    // Add actions given by active stadium (activated stadiums like Mesagoza, Fragrant Forest, Area Zero)
+    if can_use_mesagoza(state, current_player)
+        || can_use_fragrant_forest(state, current_player)
+        || can_use_area_zero(state, current_player)
+    {
         actions.push(SimpleAction::UseStadium);
     }
 

--- a/src/stadiums.rs
+++ b/src/stadiums.rs
@@ -46,6 +46,8 @@ static ARENA_OF_ANTIQUITY_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3154ArenaofAntiquity));
 static FRAGRANT_FOREST_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3153FragrantForest));
+static AREA_ZERO_EFFECT: LazyLock<String> =
+    LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3a074AreaZero));
 
 pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
     ensure_stadium_trainer(trainer_card);
@@ -60,6 +62,7 @@ pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == BOUNDED_FIELD_EFFECT.as_str()
             || e == ARENA_OF_ANTIQUITY_EFFECT.as_str()
             || e == FRAGRANT_FOREST_EFFECT.as_str()
+            || e == AREA_ZERO_EFFECT.as_str()
     )
 }
 
@@ -161,4 +164,19 @@ pub fn can_use_fragrant_forest(state: &State, player: usize) -> bool {
         .cards
         .iter()
         .any(|card| matches!(card, Card::Pokemon(p) if p.stage == 0 && p.energy_type == EnergyType::Grass))
+}
+
+pub fn is_area_zero_active(state: &State) -> bool {
+    has_stadium(state, CardId::B3a074AreaZero)
+}
+
+/// Returns true if the player can use Area Zero's effect (stadium is active, not used this turn, hand has Basic Pokemon)
+pub fn can_use_area_zero(state: &State, player: usize) -> bool {
+    if !is_area_zero_active(state) {
+        return false;
+    }
+    if state.has_used_stadium[player] {
+        return false;
+    }
+    state.hands[player].iter().any(|card| card.is_basic())
 }

--- a/tests/stadiums.rs
+++ b/tests/stadiums.rs
@@ -1,3 +1,5 @@
+#[path = "stadiums/area_zero_test.rs"]
+mod area_zero_test;
 #[path = "stadiums/arena_of_antiquity_test.rs"]
 mod arena_of_antiquity_test;
 #[path = "stadiums/fragrant_forest_test.rs"]

--- a/tests/stadiums/area_zero_test.rs
+++ b/tests/stadiums/area_zero_test.rs
@@ -1,0 +1,165 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn trainer_from_id(card_id: CardId) -> deckgym::models::TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+/// Sets up a game with Area Zero active and a Basic Pokemon in player 0's hand.
+fn setup_game_with_area_zero(basic_in_hand: bool) -> deckgym::Game<'static> {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+
+    let mut hand = vec![get_card_by_enum(CardId::B3a074AreaZero)];
+    if basic_in_hand {
+        hand.push(get_card_by_enum(CardId::A1033Charmander));
+    } else {
+        // Non-basic Trainer card only
+        hand.push(get_card_by_enum(CardId::PA001Potion));
+    }
+    state.hands[0] = hand;
+
+    game.set_state(state);
+
+    let trainer_card = trainer_from_id(CardId::B3a074AreaZero);
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    });
+
+    game
+}
+
+#[test]
+fn test_area_zero_use_stadium_available_with_basic_in_hand() {
+    let game = setup_game_with_area_zero(true);
+    let state = game.get_state_clone();
+
+    assert!(state.active_stadium.is_some(), "Area Zero should be active");
+
+    let (_actor, actions) = state.generate_possible_actions();
+    let has_use_stadium = actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium));
+
+    assert!(
+        has_use_stadium,
+        "UseStadium should be available when Area Zero is active and hand has a Basic Pokemon"
+    );
+}
+
+#[test]
+fn test_area_zero_use_stadium_not_available_without_basic_in_hand() {
+    let game = setup_game_with_area_zero(false);
+    let state = game.get_state_clone();
+
+    let (_actor, actions) = state.generate_possible_actions();
+    let has_use_stadium = actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium));
+
+    assert!(
+        !has_use_stadium,
+        "UseStadium should NOT be available when hand has no Basic Pokemon"
+    );
+}
+
+#[test]
+fn test_area_zero_shuffles_basic_into_deck_and_draws_card() {
+    let mut game = setup_game_with_area_zero(true);
+    let state = game.get_state_clone();
+
+    let hand_size_before = state.hands[0].len();
+    let deck_size_before = state.decks[0].cards.len();
+
+    // Use the stadium effect
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseStadium,
+        is_stack: false,
+    });
+
+    // The game queues a choice — pick the first option (shuffle the Basic Pokemon)
+    let state = game.get_state_clone();
+    let stack_top = state.move_generation_stack.last().cloned();
+    if let Some((_actor, choices)) = stack_top {
+        let choice = choices[0].clone();
+        game.apply_action(&Action {
+            actor: 0,
+            action: choice,
+            is_stack: true,
+        });
+    }
+
+    let state = game.get_state_clone();
+
+    // Hand size should be unchanged: shuffled one Pokemon in, drew one card
+    assert_eq!(
+        state.hands[0].len(),
+        hand_size_before,
+        "Hand size should be unchanged after shuffling a Pokemon in and drawing a card"
+    );
+
+    // Deck should have one more card (Basic Pokemon shuffled in) and one less (drawn card), net 0
+    assert_eq!(
+        state.decks[0].cards.len(),
+        deck_size_before,
+        "Deck size should be unchanged (one shuffled in, one drawn)"
+    );
+
+    // has_used_stadium should be true
+    assert!(
+        state.has_used_stadium[0],
+        "has_used_stadium[0] should be true after using Area Zero"
+    );
+}
+
+#[test]
+fn test_area_zero_cannot_use_twice_per_turn() {
+    let mut game = setup_game_with_area_zero(true);
+
+    // Use the stadium once
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseStadium,
+        is_stack: false,
+    });
+
+    // Resolve the queued choice
+    let state = game.get_state_clone();
+    if let Some((_actor, choices)) = state.move_generation_stack.last().cloned() {
+        game.apply_action(&Action {
+            actor: 0,
+            action: choices[0].clone(),
+            is_stack: true,
+        });
+    }
+
+    // Now check UseStadium is no longer available
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    let has_use_stadium = actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium));
+
+    assert!(
+        !has_use_stadium,
+        "UseStadium should NOT be available after using Area Zero once this turn"
+    );
+}


### PR DESCRIPTION
## Summary
Adds support for the Area Zero stadium card, which allows players to shuffle a Basic Pokémon from their hand into their deck and draw a card once per turn.

## Changes
- **Stadium effect implementation**: Added `is_area_zero_active()` and `can_use_area_zero()` functions to check if Area Zero is active and usable
- **Action forecasting**: Implemented `forecast_area_zero_effect()` to generate the choice of which Basic Pokémon to shuffle into the deck
- **Move generation**: Updated action generation to include UseStadium when Area Zero is active and the player has a Basic Pokémon in hand
- **Stadium registry**: Added Area Zero to the list of implemented stadium effects
- **Comprehensive tests**: Added full test suite covering:
  - UseStadium availability with/without Basic Pokémon in hand
  - Correct shuffling and drawing behavior
  - Once-per-turn usage restriction

## Implementation Details
- Area Zero effect filters the player's hand for Basic Pokémon and creates shuffle choices
- The `has_used_stadium` flag is set when the effect is used, preventing multiple uses per turn
- Hand and deck sizes remain unchanged after the effect (one card shuffled in, one drawn)

https://claude.ai/code/session_018oyAQaJLzzEwJCULYf6tqJ