### PR TITLE
Implement Future System ability for Future Pokémon

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -192,4 +192,6 @@ pub enum AbilityMechanic {
     /// you may switch out your opponent's Active Pokémon to the Bench.
     /// (Your opponent chooses the new Active Pokémon.)"
     AncientRoar,
+    /// "Attacks used by your Future Pokémon cost 1 less [C] Energy."
+    FutureSystem,
 }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -261,6 +261,7 @@ fn forecast_ability_by_mechanic(
         }
         AbilityMechanic::LegendaryDrive => legendary_drive(in_play_idx),
         AbilityMechanic::AncientRoar => switch_out_opponent_active_to_bench(),
+        AbilityMechanic::FutureSystem => panic!("FutureSystem is a passive ability"),
     }
 }
 

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -417,6 +417,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "Once during your turn, when you put this Pokémon from your hand onto your Bench, you may switch out your opponent's Active Pokémon to the Bench. (Your opponent chooses the new Active Pokémon.)",
             AbilityMechanic::AncientRoar,
         );
+        map.insert(
+            "Attacks used by your Future Pokémon cost 1 less [C] Energy.",
+            AbilityMechanic::FutureSystem,
+        );
 
         // b3 mechanics
         // map.insert("As long as this Pokémon is in play, it is [F] and [D] type.", todo_implementation);

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -1120,28 +1120,27 @@ pub(crate) fn get_attack_cost(
         }
     }
 
-    apply_future_system_reduction(&mut modified_cost, state, attacking_player);
+    modified_cost = future_system_cost(modified_cost, state, attacking_player);
 
     modified_cost
 }
 
-fn apply_future_system_reduction(cost: &mut Vec<EnergyType>, state: &State, player: usize) {
+fn future_system_cost(mut cost: Vec<EnergyType>, state: &State, player: usize) -> Vec<EnergyType> {
     let attacker_is_future = state.in_play_pokemon[player][0]
         .as_ref()
         .is_some_and(|active| is_future_pokemon(&active.get_name()));
-    if !attacker_is_future {
-        return;
-    }
-    let has_future_system = state.in_play_pokemon[player]
-        .iter()
-        .flatten()
-        .any(|p| matches!(get_ability_mechanic(&p.card), Some(AbilityMechanic::FutureSystem)));
+    let has_future_system = attacker_is_future
+        && state.in_play_pokemon[player]
+            .iter()
+            .flatten()
+            .any(|p| matches!(get_ability_mechanic(&p.card), Some(AbilityMechanic::FutureSystem)));
     if has_future_system {
         if let Some(pos) = cost.iter().position(|e| *e == EnergyType::Colorless) {
             debug!("Future System: Reducing attack cost by 1 Colorless");
             cost.remove(pos);
         }
     }
+    cost
 }
 
 // Check if attached satisfies cost (considering Colorless and Serperior's ability)

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -1120,6 +1120,32 @@ pub(crate) fn get_attack_cost(
         }
     }
 
+    // Future System: if any in-play Pokémon has FutureSystem and the attacker is a Future Pokémon,
+    // reduce cost by 1 Colorless.
+    let attacker_is_future = state.in_play_pokemon[attacking_player][0]
+        .as_ref()
+        .is_some_and(|active| is_future_pokemon(&active.get_name()));
+    if attacker_is_future {
+        let has_future_system = state.in_play_pokemon[attacking_player]
+            .iter()
+            .flatten()
+            .any(|p| {
+                matches!(
+                    get_ability_mechanic(&p.card),
+                    Some(AbilityMechanic::FutureSystem)
+                )
+            });
+        if has_future_system {
+            if let Some(pos) = modified_cost
+                .iter()
+                .position(|e| *e == EnergyType::Colorless)
+            {
+                debug!("Future System: Reducing attack cost by 1 Colorless");
+                modified_cost.remove(pos);
+            }
+        }
+    }
+
     modified_cost
 }
 

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -1120,33 +1120,28 @@ pub(crate) fn get_attack_cost(
         }
     }
 
-    // Future System: if any in-play Pokémon has FutureSystem and the attacker is a Future Pokémon,
-    // reduce cost by 1 Colorless.
-    let attacker_is_future = state.in_play_pokemon[attacking_player][0]
-        .as_ref()
-        .is_some_and(|active| is_future_pokemon(&active.get_name()));
-    if attacker_is_future {
-        let has_future_system = state.in_play_pokemon[attacking_player]
-            .iter()
-            .flatten()
-            .any(|p| {
-                matches!(
-                    get_ability_mechanic(&p.card),
-                    Some(AbilityMechanic::FutureSystem)
-                )
-            });
-        if has_future_system {
-            if let Some(pos) = modified_cost
-                .iter()
-                .position(|e| *e == EnergyType::Colorless)
-            {
-                debug!("Future System: Reducing attack cost by 1 Colorless");
-                modified_cost.remove(pos);
-            }
-        }
-    }
+    apply_future_system_reduction(&mut modified_cost, state, attacking_player);
 
     modified_cost
+}
+
+fn apply_future_system_reduction(cost: &mut Vec<EnergyType>, state: &State, player: usize) {
+    let attacker_is_future = state.in_play_pokemon[player][0]
+        .as_ref()
+        .is_some_and(|active| is_future_pokemon(&active.get_name()));
+    if !attacker_is_future {
+        return;
+    }
+    let has_future_system = state.in_play_pokemon[player]
+        .iter()
+        .flatten()
+        .any(|p| matches!(get_ability_mechanic(&p.card), Some(AbilityMechanic::FutureSystem)));
+    if has_future_system {
+        if let Some(pos) = cost.iter().position(|e| *e == EnergyType::Colorless) {
+            debug!("Future System: Reducing attack cost by 1 Colorless");
+            cost.remove(pos);
+        }
+    }
 }
 
 // Check if attached satisfies cost (considering Colorless and Serperior's ability)

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -1130,10 +1130,12 @@ fn future_system_cost(mut cost: Vec<EnergyType>, state: &State, player: usize) -
         .as_ref()
         .is_some_and(|active| is_future_pokemon(&active.get_name()));
     let has_future_system = attacker_is_future
-        && state.in_play_pokemon[player]
-            .iter()
-            .flatten()
-            .any(|p| matches!(get_ability_mechanic(&p.card), Some(AbilityMechanic::FutureSystem)));
+        && state.in_play_pokemon[player].iter().flatten().any(|p| {
+            matches!(
+                get_ability_mechanic(&p.card),
+                Some(AbilityMechanic::FutureSystem)
+            )
+        });
     if has_future_system {
         if let Some(pos) = cost.iter().position(|e| *e == EnergyType::Colorless) {
             debug!("Future System: Reducing attack cost by 1 Colorless");

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -171,6 +171,7 @@ fn can_use_ability_by_mechanic(
         }
         AbilityMechanic::LegendaryDrive => false, // triggered on bench placement, not via UseAbility
         AbilityMechanic::AncientRoar => false, // triggered on bench placement, not via UseAbility
+        AbilityMechanic::FutureSystem => false, // passive ability
     }
 }
 

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -52,6 +52,8 @@ mod iron_hands_test;
 mod iron_moth_test;
 #[path = "pokemon/iron_thorns_test.rs"]
 mod iron_thorns_test;
+#[path = "pokemon/iron_valiant_future_system_test.rs"]
+mod iron_valiant_future_system_test;
 #[path = "pokemon/jolteon_ex_test.rs"]
 mod jolteon_ex_test;
 #[path = "pokemon/klefki_dismantling_keys_test.rs"]

--- a/tests/pokemon/iron_valiant_future_system_test.rs
+++ b/tests/pokemon/iron_valiant_future_system_test.rs
@@ -1,0 +1,65 @@
+use deckgym::{
+    actions::SimpleAction,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Future System reduces attack cost for Future Pokémon by 1 Colorless.
+/// Iron Boulder needs [P][P][C][C] but with Iron Valiant on bench only [P][P][C] suffices.
+#[test]
+fn test_future_system_reduces_future_pokemon_attack_cost() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    // Iron Boulder active with [P][P][C] — one Colorless short without Future System
+    let iron_boulder = PlayedCard::from_id(CardId::B3a029IronBoulder).with_energy(vec![
+        EnergyType::Psychic,
+        EnergyType::Psychic,
+        EnergyType::Colorless,
+    ]);
+    // Iron Valiant on bench, providing Future System
+    let iron_valiant = PlayedCard::from_id(CardId::B3a027IronValiant);
+    state.set_board(
+        vec![iron_boulder, iron_valiant],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    game.set_state(state);
+
+    let (actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Attack(0))),
+        "Iron Boulder should be able to attack with [P][P][C] thanks to Future System"
+    );
+}
+
+/// Future System does NOT reduce attack cost for non-Future Pokémon.
+/// Bulbasaur needs [G][C]; with only [G] attached and Iron Valiant on bench, it cannot attack.
+#[test]
+fn test_future_system_does_not_reduce_non_future_pokemon_attack_cost() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    // Bulbasaur active with only [G] — missing [C] for Vine Whip
+    let bulbasaur =
+        PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass]);
+    // Iron Valiant on bench
+    let iron_valiant = PlayedCard::from_id(CardId::B3a027IronValiant);
+    state.set_board(
+        vec![bulbasaur, iron_valiant],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    game.set_state(state);
+
+    let (actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        !actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Attack(_))),
+        "Bulbasaur should NOT be able to attack with only [G] — Future System only helps Future Pokémon"
+    );
+}


### PR DESCRIPTION
## Summary
Adds support for the Future System ability, which reduces attack costs for Future Pokémon by 1 Colorless energy. This ability is passive and applies whenever a Future Pokémon is attacking and any in-play Pokémon has the Future System ability.

## Key Changes
- **New Ability Mechanic**: Added `FutureSystem` variant to `AbilityMechanic` enum
- **Ability Mapping**: Registered "Attacks used by your Future Pokémon cost 1 less [C] Energy." text to the `FutureSystem` mechanic
- **Cost Reduction Logic**: Implemented Future System cost reduction in `get_attack_cost()` that:
  - Checks if the attacking Pokémon is a Future Pokémon
  - Checks if any in-play Pokémon has the Future System ability
  - Removes one Colorless energy from the attack cost if both conditions are met
- **Passive Ability Handling**: Marked Future System as a passive ability (not usable via `UseAbility` action and panics if forecasted)
- **Test Coverage**: Added comprehensive tests validating:
  - Future Pokémon attacks cost 1 less Colorless with Future System in play
  - Non-Future Pokémon are not affected by Future System

## Implementation Details
The Future System check is performed during attack cost calculation by iterating through all in-play Pokémon to find any with the ability, ensuring it works regardless of which Pokémon has the ability (active or benched).

https://claude.ai/code/session_017MbZt1QtPNYbN4LAwsxVMC