### PR TITLE
Implement Iron Leaves' Avenging Edge attack

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -741,6 +741,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("If any of your Benched Pokémon have damage on them, this attack does 50 more damage.", todo_implementation);
     map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 60 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage: 60 });
     map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 40 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage: 40 });
+    map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 50 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage: 50 });
     map.insert("If the Defending Pokémon is a Basic Pokémon, it can't attack during your opponent's next turn.", Mechanic::BlockBasicAttack);
     // map.insert("If the Defending Pokémon tries to use an attack, your opponent flips a coin. If tails, that attack doesn't happen. This effect lasts until the Defending Pokémon leaves the Active Spot, and it doesn't stack.", todo_implementation);
     map.insert(

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -48,6 +48,8 @@ mod houndstone_last_respects_test;
 mod iron_bundle_ex_test;
 #[path = "pokemon/iron_hands_test.rs"]
 mod iron_hands_test;
+#[path = "pokemon/iron_leaves_test.rs"]
+mod iron_leaves_test;
 #[path = "pokemon/iron_moth_test.rs"]
 mod iron_moth_test;
 #[path = "pokemon/iron_thorns_test.rs"]

--- a/tests/pokemon/iron_leaves_test.rs
+++ b/tests/pokemon/iron_leaves_test.rs
@@ -1,0 +1,78 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn played_card_with_base_hp(card_id: CardId, base_hp: u32) -> PlayedCard {
+    let card = deckgym::database::get_card_by_enum(card_id);
+    PlayedCard::new(card, 0, base_hp, vec![], false, vec![])
+}
+
+/// Test Iron Leaves' Avenging Edge base damage (50) when no KO happened last turn
+#[test]
+fn test_iron_leaves_avenging_edge_base_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a028IronLeaves).with_energy(vec![
+                EnergyType::Psychic,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.set_knocked_out_by_opponent_attack_last_turn(false);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let final_state = game.get_state_clone();
+    let opponent_hp = final_state.get_active(1).get_remaining_hp();
+    // Bulbasaur has 70 HP; 70 - 50 = 20
+    assert_eq!(opponent_hp, 20, "Avenging Edge should deal 50 base damage");
+}
+
+/// Test Iron Leaves' Avenging Edge boosted damage (50 + 50 = 100) when KO happened last turn
+#[test]
+fn test_iron_leaves_avenging_edge_boosted_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a028IronLeaves).with_energy(vec![
+                EnergyType::Psychic,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![played_card_with_base_hp(CardId::A1001Bulbasaur, 150)],
+    );
+    state.current_player = 0;
+    state.set_knocked_out_by_opponent_attack_last_turn(true);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let final_state = game.get_state_clone();
+    let opponent_hp = final_state.get_active(1).get_remaining_hp();
+    // 150 - (50 + 50) = 50
+    assert_eq!(
+        opponent_hp, 50,
+        "Avenging Edge should deal 100 damage with KO bonus"
+    );
+}


### PR DESCRIPTION
Maps the 50-more-damage KO bonus effect to the existing
ExtraDamageIfKnockedOutLastTurn mechanic.

https://claude.ai/code/session_01MvoJaKwDchi8YoCDH1vin2