### PR TITLE
Implement Professor Sada trainer card mechanics

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -111,6 +111,7 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
             *in_play_idx,
             *num_random_energies,
         ),
+        SimpleAction::SadaAttach { assignments } => forecast_sada_attach(assignments),
         SimpleAction::UseStadium => forecast_use_stadium(state, action.actor),
         // acting_player is not passed here, because there is only 1 turn to end. The current turn.
         SimpleAction::EndTurn => {
@@ -740,6 +741,15 @@ fn generate_energy_combinations(energies: &[EnergyType]) -> Vec<(Vec<EnergyType>
         }
     }
     combination_counts.into_iter().collect()
+}
+
+fn forecast_sada_attach(assignments: &[(crate::models::EnergyType, usize)]) -> Outcomes {
+    let assignments = assignments.to_vec();
+    Outcomes::single_fn(move |_, state, action| {
+        for (energy, in_play_idx) in &assignments {
+            state.attach_energy_from_discard(action.actor, *in_play_idx, &[*energy]);
+        }
+    })
 }
 
 fn apply_eevee_bag_damage_boost(state: &mut State) {

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -18,7 +18,7 @@ use crate::{
     },
     combinatorics::generate_combinations,
     effects::TurnEffect,
-    hooks::{get_stage, is_future_pokemon, is_ultra_beast},
+    hooks::{get_stage, is_ancient_pokemon, is_future_pokemon, is_ultra_beast},
     models::{Card, EnergyType, StatusCondition, TrainerCard, TrainerType},
     tools::{enumerate_tool_choices, is_tool_effect_implemented},
     State,
@@ -199,6 +199,9 @@ pub fn forecast_trainer_action(
             1,
             |card| matches!(card, Card::Pokemon(p) if p.stage == 2),
         ),
+        CardId::B3a072ProfessorSada | CardId::B3a087ProfessorSada => {
+            Outcomes::single_fn(professor_sada_effect)
+        }
         CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
             professor_turo_effect(acting_player, state)
         }
@@ -1042,6 +1045,28 @@ fn silver_effect(_: &mut StdRng, state: &mut State, action: &Action) {
         state
             .move_generation_stack
             .push((player, possible_shuffles));
+    }
+}
+
+fn professor_sada_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    let player = action.actor;
+    let ancient_slots: Vec<usize> = state
+        .enumerate_in_play_pokemon(player)
+        .filter(|(_, pokemon)| is_ancient_pokemon(&pokemon.get_name()))
+        .map(|(idx, _)| idx)
+        .collect();
+
+    let choices: Vec<SimpleAction> =
+        crate::actions::professor_sada::generate_professor_sada_assignments(
+            &ancient_slots,
+            &state.discard_energies[player],
+        )
+        .into_iter()
+        .map(|assignments| SimpleAction::SadaAttach { assignments })
+        .collect();
+
+    if !choices.is_empty() {
+        state.move_generation_stack.push((player, choices));
     }
 }
 

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -10,6 +10,7 @@ mod effect_ability_mechanic_map;
 mod effect_mechanic_map;
 mod mutations;
 mod outcomes;
+pub mod professor_sada;
 mod shared_mutations;
 mod types;
 

--- a/src/actions/professor_sada.rs
+++ b/src/actions/professor_sada.rs
@@ -1,0 +1,192 @@
+use crate::combinatorics::generate_combinations;
+use crate::models::EnergyType;
+use std::collections::HashSet;
+
+/// Generate all valid ways to attach 3 different energy types from the discard pile
+/// to Ancient Pokémon in play.
+///
+/// `ancient_slots` are the in-play indices that hold Ancient Pokémon.
+/// `discard_energies` is the full discard-energy list for the player (duplicates allowed).
+///
+/// Returns every possible complete assignment as a vec of 3 `(EnergyType, in_play_idx)` pairs
+/// representing which energy goes to which Ancient Pokémon slot.
+pub fn generate_professor_sada_assignments(
+    ancient_slots: &[usize],
+    discard_energies: &[EnergyType],
+) -> Vec<Vec<(EnergyType, usize)>> {
+    if ancient_slots.is_empty() {
+        return vec![];
+    }
+
+    // Collect unique energy types, preserving first-seen order
+    let mut seen = HashSet::new();
+    let unique_types: Vec<EnergyType> = discard_energies
+        .iter()
+        .filter(|e| seen.insert(*e))
+        .copied()
+        .collect();
+
+    if unique_types.len() < 3 {
+        return vec![];
+    }
+
+    // For each 3-combination of distinct types, generate every possible target assignment
+    let mut results = Vec::new();
+    for types in generate_combinations(&unique_types, 3) {
+        for &slot0 in ancient_slots {
+            for &slot1 in ancient_slots {
+                for &slot2 in ancient_slots {
+                    results.push(vec![
+                        (types[0], slot0),
+                        (types[1], slot1),
+                        (types[2], slot2),
+                    ]);
+                }
+            }
+        }
+    }
+    results
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::EnergyType;
+
+    #[test]
+    fn test_no_ancient_pokemon() {
+        let result = generate_professor_sada_assignments(
+            &[],
+            &[EnergyType::Fire, EnergyType::Water, EnergyType::Grass],
+        );
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_fewer_than_3_types_in_discard() {
+        let result =
+            generate_professor_sada_assignments(&[0, 1], &[EnergyType::Fire, EnergyType::Water]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_single_type_in_discard() {
+        let result =
+            generate_professor_sada_assignments(&[0, 1], &[EnergyType::Fire, EnergyType::Fire]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_exactly_3_types_one_ancient_slot() {
+        let result = generate_professor_sada_assignments(
+            &[0],
+            &[EnergyType::Fire, EnergyType::Water, EnergyType::Grass],
+        );
+        // 1 type combo × 1^3 = 1 assignment (all energies go to the only slot)
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result[0],
+            vec![
+                (EnergyType::Fire, 0),
+                (EnergyType::Water, 0),
+                (EnergyType::Grass, 0),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_exactly_3_types_two_ancient_slots() {
+        let result = generate_professor_sada_assignments(
+            &[0, 1],
+            &[EnergyType::Fire, EnergyType::Water, EnergyType::Grass],
+        );
+        // 1 type combo × 2^3 = 8 assignments
+        assert_eq!(result.len(), 8);
+    }
+
+    #[test]
+    fn test_four_types_two_ancient_slots() {
+        let result = generate_professor_sada_assignments(
+            &[0, 1],
+            &[
+                EnergyType::Fire,
+                EnergyType::Water,
+                EnergyType::Grass,
+                EnergyType::Lightning,
+            ],
+        );
+        // C(4,3) × 2^3 = 4 × 8 = 32 assignments
+        assert_eq!(result.len(), 32);
+    }
+
+    #[test]
+    fn test_three_types_four_ancient_slots() {
+        let result = generate_professor_sada_assignments(
+            &[0, 1, 2, 3],
+            &[EnergyType::Fire, EnergyType::Water, EnergyType::Grass],
+        );
+        // 1 type combo × 4^3 = 64 assignments
+        assert_eq!(result.len(), 64);
+    }
+
+    #[test]
+    fn test_duplicate_energies_counted_as_one_type() {
+        // Duplicates in discard should not inflate the type count
+        let result = generate_professor_sada_assignments(
+            &[0, 1],
+            &[
+                EnergyType::Fire,
+                EnergyType::Fire,
+                EnergyType::Water,
+                EnergyType::Grass,
+            ],
+        );
+        // Same as 3 distinct types: 1 combo × 2^3 = 8
+        assert_eq!(result.len(), 8);
+    }
+
+    #[test]
+    fn test_all_assignments_have_exactly_3_entries() {
+        let result = generate_professor_sada_assignments(
+            &[0, 1],
+            &[EnergyType::Fire, EnergyType::Water, EnergyType::Grass],
+        );
+        for assignment in &result {
+            assert_eq!(assignment.len(), 3);
+        }
+    }
+
+    #[test]
+    fn test_each_assignment_uses_three_distinct_types() {
+        let result = generate_professor_sada_assignments(
+            &[0, 1],
+            &[
+                EnergyType::Fire,
+                EnergyType::Water,
+                EnergyType::Grass,
+                EnergyType::Lightning,
+            ],
+        );
+        for assignment in &result {
+            let types: HashSet<EnergyType> = assignment.iter().map(|(e, _)| *e).collect();
+            assert_eq!(types.len(), 3, "Each assignment must use 3 distinct types");
+        }
+    }
+
+    #[test]
+    fn test_all_slots_are_valid_ancient_slots() {
+        let ancient_slots = &[0_usize, 2];
+        let result = generate_professor_sada_assignments(
+            ancient_slots,
+            &[EnergyType::Fire, EnergyType::Water, EnergyType::Grass],
+        );
+        for assignment in &result {
+            for (_, slot) in assignment {
+                assert!(
+                    ancient_slots.contains(slot),
+                    "Slot {slot} is not a valid ancient slot"
+                );
+            }
+        }
+    }
+}

--- a/src/actions/professor_sada.rs
+++ b/src/actions/professor_sada.rs
@@ -2,19 +2,21 @@ use crate::combinatorics::generate_combinations;
 use crate::models::EnergyType;
 use std::collections::HashSet;
 
-/// Generate all valid ways to attach 3 different energy types from the discard pile
+/// Generate all valid ways to attach up to 3 different energy types from the discard pile
 /// to Ancient Pokémon in play.
+///
+/// Attaches `min(3, distinct_types_in_discard)` energies — one of each chosen type.
+/// If there are more than 3 distinct types the player also chooses which 3 to use.
 ///
 /// `ancient_slots` are the in-play indices that hold Ancient Pokémon.
 /// `discard_energies` is the full discard-energy list for the player (duplicates allowed).
 ///
-/// Returns every possible complete assignment as a vec of 3 `(EnergyType, in_play_idx)` pairs
-/// representing which energy goes to which Ancient Pokémon slot.
+/// Returns every possible complete assignment as a vec of `(EnergyType, in_play_idx)` pairs.
 pub fn generate_professor_sada_assignments(
     ancient_slots: &[usize],
     discard_energies: &[EnergyType],
 ) -> Vec<Vec<(EnergyType, usize)>> {
-    if ancient_slots.is_empty() {
+    if ancient_slots.is_empty() || discard_energies.is_empty() {
         return vec![];
     }
 
@@ -26,26 +28,33 @@ pub fn generate_professor_sada_assignments(
         .copied()
         .collect();
 
-    if unique_types.len() < 3 {
-        return vec![];
-    }
-
-    // For each 3-combination of distinct types, generate every possible target assignment
+    let n_to_attach = unique_types.len().min(3);
     let mut results = Vec::new();
-    for types in generate_combinations(&unique_types, 3) {
-        for &slot0 in ancient_slots {
-            for &slot1 in ancient_slots {
-                for &slot2 in ancient_slots {
-                    results.push(vec![
-                        (types[0], slot0),
-                        (types[1], slot1),
-                        (types[2], slot2),
-                    ]);
-                }
-            }
-        }
+    for types in generate_combinations(&unique_types, n_to_attach) {
+        results.extend(all_slot_assignments(&types, ancient_slots));
     }
     results
+}
+
+/// Generate every way to assign each energy type (in order) to any ancient slot.
+/// This is the Cartesian product of `ancient_slots` taken `types.len()` times, zipped with types.
+fn all_slot_assignments(
+    types: &[EnergyType],
+    ancient_slots: &[usize],
+) -> Vec<Vec<(EnergyType, usize)>> {
+    if types.is_empty() {
+        return vec![vec![]];
+    }
+    let tails = all_slot_assignments(&types[1..], ancient_slots);
+    let mut result = Vec::new();
+    for &slot in ancient_slots {
+        for tail in &tails {
+            let mut assignment = vec![(types[0], slot)];
+            assignment.extend_from_slice(tail);
+            result.push(assignment);
+        }
+    }
+    result
 }
 
 #[cfg(test)]
@@ -63,17 +72,30 @@ mod tests {
     }
 
     #[test]
-    fn test_fewer_than_3_types_in_discard() {
-        let result =
-            generate_professor_sada_assignments(&[0, 1], &[EnergyType::Fire, EnergyType::Water]);
+    fn test_empty_discard() {
+        let result = generate_professor_sada_assignments(&[0, 1], &[]);
         assert!(result.is_empty());
     }
 
     #[test]
-    fn test_single_type_in_discard() {
+    fn test_one_type_two_ancient_slots() {
+        // 1 distinct type → attach 1 energy, player picks which slot
         let result =
             generate_professor_sada_assignments(&[0, 1], &[EnergyType::Fire, EnergyType::Fire]);
-        assert!(result.is_empty());
+        // C(1,1) × 2^1 = 2 assignments
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|a| a.len() == 1));
+        assert!(result.iter().all(|a| a[0].0 == EnergyType::Fire));
+    }
+
+    #[test]
+    fn test_two_types_two_ancient_slots() {
+        // 2 distinct types → attach 2 energies (one of each)
+        let result =
+            generate_professor_sada_assignments(&[0, 1], &[EnergyType::Fire, EnergyType::Water]);
+        // C(2,2) × 2^2 = 1 × 4 = 4 assignments
+        assert_eq!(result.len(), 4);
+        assert!(result.iter().all(|a| a.len() == 2));
     }
 
     #[test]
@@ -131,7 +153,7 @@ mod tests {
 
     #[test]
     fn test_duplicate_energies_counted_as_one_type() {
-        // Duplicates in discard should not inflate the type count
+        // Duplicates should not inflate the type count
         let result = generate_professor_sada_assignments(
             &[0, 1],
             &[
@@ -141,23 +163,12 @@ mod tests {
                 EnergyType::Grass,
             ],
         );
-        // Same as 3 distinct types: 1 combo × 2^3 = 8
+        // 3 distinct types: 1 combo × 2^3 = 8
         assert_eq!(result.len(), 8);
     }
 
     #[test]
-    fn test_all_assignments_have_exactly_3_entries() {
-        let result = generate_professor_sada_assignments(
-            &[0, 1],
-            &[EnergyType::Fire, EnergyType::Water, EnergyType::Grass],
-        );
-        for assignment in &result {
-            assert_eq!(assignment.len(), 3);
-        }
-    }
-
-    #[test]
-    fn test_each_assignment_uses_three_distinct_types() {
+    fn test_each_assignment_uses_distinct_types() {
         let result = generate_professor_sada_assignments(
             &[0, 1],
             &[
@@ -169,7 +180,11 @@ mod tests {
         );
         for assignment in &result {
             let types: HashSet<EnergyType> = assignment.iter().map(|(e, _)| *e).collect();
-            assert_eq!(types.len(), 3, "Each assignment must use 3 distinct types");
+            assert_eq!(
+                types.len(),
+                assignment.len(),
+                "Each assignment must use distinct types"
+            );
         }
     }
 

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -121,6 +121,10 @@ pub enum SimpleAction {
         in_play_idx: usize,
         num_random_energies: usize,
     },
+    /// Professor Sada: attach 3 specific different-typed energies from discard to Ancient Pokémon
+    SadaAttach {
+        assignments: Vec<(EnergyType, usize)>, // (energy_type, in_play_idx) × 3
+    },
     /// Eevee Bag Option 1: Apply damage boost for Eevee evolutions this turn
     ApplyEeveeBagDamageBoost,
     /// Eevee Bag Option 2: Heal all Eevee evolutions
@@ -279,6 +283,14 @@ impl fmt::Display for SimpleAction {
                 num_random_energies,
             } => {
                 write!(f, "AttachFromDiscard({in_play_idx}, {num_random_energies})")
+            }
+            SimpleAction::SadaAttach { assignments } => {
+                let s = assignments
+                    .iter()
+                    .map(|(e, idx)| format!("{e:?}→{idx}"))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(f, "SadaAttach([{s}])")
             }
             SimpleAction::ApplyEeveeBagDamageBoost => {
                 write!(f, "ApplyEeveeBagDamageBoost")

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -569,9 +569,7 @@ fn can_play_professor_sada(state: &State, trainer_card: &TrainerCard) -> Option<
         return cannot_play_trainer();
     }
 
-    let unique_types: std::collections::HashSet<_> =
-        state.discard_energies[player].iter().collect();
-    if unique_types.len() < 3 {
+    if state.discard_energies[player].is_empty() {
         return cannot_play_trainer();
     }
 

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -5,7 +5,10 @@ use crate::{
         can_rare_candy_evolve, diantha_targets, ilima_targets, quick_grow_extract_candidates,
     },
     effects::TurnEffect,
-    hooks::{can_play_item, can_play_support, get_stage, is_future_pokemon, is_ultra_beast},
+    hooks::{
+        can_play_item, can_play_support, get_stage, is_ancient_pokemon, is_future_pokemon,
+        is_ultra_beast,
+    },
     models::{Card, EnergyType, TrainerCard, TrainerType},
     stadiums::is_stadium_effect_implemented,
     tools::{enumerate_tool_choices, is_tool_effect_implemented},
@@ -228,6 +231,9 @@ pub fn trainer_move_generation_implementation(
             can_play_parasol_lady(state, trainer_card)
         }
         CardId::B3a071Juliana | CardId::B3a086Juliana => can_play_trainer(state, trainer_card),
+        CardId::B3a072ProfessorSada | CardId::B3a087ProfessorSada => {
+            can_play_professor_sada(state, trainer_card)
+        }
         CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
             can_play_professor_turo(state, trainer_card)
         }
@@ -550,6 +556,26 @@ fn can_play_gladion(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Sim
     } else {
         can_play_trainer(state, trainer_card)
     }
+}
+
+fn can_play_professor_sada(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let player = state.current_player;
+
+    let has_ancient = state.in_play_pokemon[player]
+        .iter()
+        .flatten()
+        .any(|pokemon| is_ancient_pokemon(&pokemon.get_name()));
+    if !has_ancient {
+        return cannot_play_trainer();
+    }
+
+    let unique_types: std::collections::HashSet<_> =
+        state.discard_energies[player].iter().collect();
+    if unique_types.len() < 3 {
+        return cannot_play_trainer();
+    }
+
+    can_play_trainer(state, trainer_card)
 }
 
 /// Check if Lusamine can be played (requires opponent has >= 1 point, player has Ultra Beast, >= 1 energy in discard)

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -64,6 +64,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::DiscardOpponentSupporter { .. } => 5,
         SimpleAction::DiscardOwnCards { .. } => 5,
         SimpleAction::AttachFromDiscard { .. } => 10,
+        SimpleAction::SadaAttach { .. } => 10,
         SimpleAction::ApplyEeveeBagDamageBoost => 5,
         SimpleAction::HealAllEeveeEvolutions => 5,
         SimpleAction::DiscardFossil { .. } => 1, // Low weight to discard fossils

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -8,5 +8,7 @@ mod iris_trainer_test;
 mod juliana_test;
 #[path = "trainers/korrina_cabbie_parasol_lady_test.rs"]
 mod korrina_cabbie_parasol_lady_test;
+#[path = "trainers/professor_sada_test.rs"]
+mod professor_sada_test;
 #[path = "trainers/professor_turo_test.rs"]
 mod professor_turo_test;

--- a/tests/trainers/professor_sada_test.rs
+++ b/tests/trainers/professor_sada_test.rs
@@ -30,12 +30,8 @@ fn test_cannot_play_sada_no_ancient_pokemon() {
     let mut state = game.get_state_clone();
     state.current_player = 0;
 
-    // Both players have only non-Ancient Pokémon
     state.set_board(
-        vec![
-            PlayedCard::from_id(CardId::A1001Bulbasaur),
-            PlayedCard::from_id(CardId::A1001Bulbasaur),
-        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
         vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
     );
 
@@ -55,9 +51,9 @@ fn test_cannot_play_sada_no_ancient_pokemon() {
     );
 }
 
-/// Professor Sada cannot be played when the discard has fewer than 3 distinct energy types.
+/// Professor Sada cannot be played when the discard has no energies at all.
 #[test]
-fn test_cannot_play_sada_insufficient_energy_types() {
+fn test_cannot_play_sada_empty_discard() {
     let mut game = get_initialized_game(0);
     let mut state = game.get_state_clone();
     state.current_player = 0;
@@ -70,8 +66,7 @@ fn test_cannot_play_sada_insufficient_energy_types() {
     state.hands[0].clear();
     let trainer_card = make_sada_trainer_card();
     state.hands[0].push(Card::Trainer(trainer_card));
-    // Only 2 distinct types — not enough
-    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Fire, EnergyType::Water];
+    state.discard_energies[0] = vec![]; // empty
     game.set_state(state);
 
     let (_, actions) = game.get_state_clone().generate_possible_actions();
@@ -80,8 +75,104 @@ fn test_cannot_play_sada_insufficient_energy_types() {
         .any(|a| matches!(&a.action, SimpleAction::Play { .. }));
     assert!(
         !can_play,
-        "Should not be able to play Sada with only 2 distinct energy types, actions: {actions:?}"
+        "Should not be able to play Sada with empty discard, actions: {actions:?}"
     );
+}
+
+/// With only 1 distinct energy type in the discard, Sada attaches that 1 energy.
+/// The player chooses which Ancient Pokémon receives it.
+#[test]
+fn test_sada_one_type_gives_one_choice_per_ancient_slot() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a003BruteBonnet),
+            PlayedCard::from_id(CardId::B3a034GreatTusk),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_sada_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card));
+    // 3 Fire but only 1 distinct type
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Fire, EnergyType::Fire];
+    game.set_state(state);
+
+    play_sada(&mut game);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let sada_choices: Vec<_> = choices
+        .iter()
+        .filter(|a| matches!(&a.action, SimpleAction::SadaAttach { .. }))
+        .collect();
+    // C(1,1) × 2 slots = 2 choices (attach Fire to active, or to bench)
+    assert_eq!(
+        sada_choices.len(),
+        2,
+        "1 type × 2 ancient slots = 2 choices; got: {sada_choices:?}"
+    );
+    assert!(
+        sada_choices
+            .iter()
+            .all(|a| matches!(&a.action, SimpleAction::SadaAttach { assignments } if assignments.len() == 1)),
+        "Each choice should attach exactly 1 energy"
+    );
+}
+
+/// With 2 distinct energy types, Sada attaches both (one of each).
+#[test]
+fn test_sada_two_types_attaches_both() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3a003BruteBonnet)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_sada_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card));
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Water];
+    game.set_state(state);
+
+    play_sada(&mut game);
+
+    // Only 1 ancient slot, so both energies must go there: 1 choice
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    let sada_choices: Vec<_> = choices
+        .iter()
+        .filter(|a| matches!(&a.action, SimpleAction::SadaAttach { .. }))
+        .collect();
+    assert_eq!(
+        sada_choices.len(),
+        1,
+        "1 ancient slot, 2 types → 1 choice; got: {sada_choices:?}"
+    );
+    assert!(
+        matches!(&sada_choices[0].action, SimpleAction::SadaAttach { assignments } if assignments.len() == 2),
+        "Should attach 2 energies"
+    );
+
+    game.apply_action(sada_choices[0]);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.discard_energies[0].len(),
+        0,
+        "Both discard energies should be consumed"
+    );
+    let active_energies = &state.in_play_pokemon[0][0]
+        .as_ref()
+        .unwrap()
+        .attached_energy;
+    assert_eq!(active_energies.len(), 2);
 }
 
 /// Playing Professor Sada with one Ancient Pokémon and exactly 3 energy types presents
@@ -155,7 +246,7 @@ fn test_sada_two_ancient_three_types_gives_eight_choices() {
     );
 }
 
-/// After choosing an assignment, the 3 energies are removed from discard
+/// After choosing an assignment, the energies are removed from discard
 /// and attached to the correct Pokémon.
 #[test]
 fn test_sada_attaches_energies_and_clears_discard() {
@@ -196,23 +287,15 @@ fn test_sada_attaches_energies_and_clears_discard() {
     game.apply_action(all_to_active.unwrap());
 
     let state = game.get_state_clone();
-
-    // Discard energies should be empty
     assert!(
         state.discard_energies[0].is_empty(),
         "All 3 energies should have been removed from discard"
     );
 
-    // Active (Brute Bonnet) should have 3 energies attached
     let active = state.in_play_pokemon[0][0]
         .as_ref()
         .expect("Active should exist");
-    assert_eq!(
-        active.attached_energy.len(),
-        3,
-        "Active should have 3 energies attached, got: {:?}",
-        active.attached_energy
-    );
+    assert_eq!(active.attached_energy.len(), 3);
     let attached: std::collections::HashSet<_> = active.attached_energy.iter().collect();
     assert!(attached.contains(&EnergyType::Fire));
     assert!(attached.contains(&EnergyType::Water));

--- a/tests/trainers/professor_sada_test.rs
+++ b/tests/trainers/professor_sada_test.rs
@@ -1,0 +1,262 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard, TrainerCard},
+    test_support::get_initialized_game,
+};
+
+fn make_sada_trainer_card() -> TrainerCard {
+    match get_card_by_enum(CardId::B3a072ProfessorSada) {
+        Card::Trainer(tc) => tc,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+fn play_sada(game: &mut deckgym::Game) {
+    let trainer_card = make_sada_trainer_card();
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+}
+
+/// Professor Sada cannot be played when there are no Ancient Pokémon on the board.
+#[test]
+fn test_cannot_play_sada_no_ancient_pokemon() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    // Both players have only non-Ancient Pokémon
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_sada_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card));
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Water, EnergyType::Grass];
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    let can_play = actions
+        .iter()
+        .any(|a| matches!(&a.action, SimpleAction::Play { .. }));
+    assert!(
+        !can_play,
+        "Should not be able to play Sada without Ancient Pokémon, actions: {actions:?}"
+    );
+}
+
+/// Professor Sada cannot be played when the discard has fewer than 3 distinct energy types.
+#[test]
+fn test_cannot_play_sada_insufficient_energy_types() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3a003BruteBonnet)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_sada_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card));
+    // Only 2 distinct types — not enough
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Fire, EnergyType::Water];
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    let can_play = actions
+        .iter()
+        .any(|a| matches!(&a.action, SimpleAction::Play { .. }));
+    assert!(
+        !can_play,
+        "Should not be able to play Sada with only 2 distinct energy types, actions: {actions:?}"
+    );
+}
+
+/// Playing Professor Sada with one Ancient Pokémon and exactly 3 energy types presents
+/// exactly 1 assignment (all 3 energies go to the only Ancient Pokémon).
+#[test]
+fn test_sada_one_ancient_three_types_gives_one_choice() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3a003BruteBonnet)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_sada_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card));
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Water, EnergyType::Grass];
+    game.set_state(state);
+
+    play_sada(&mut game);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let sada_choices: Vec<_> = choices
+        .iter()
+        .filter(|a| matches!(&a.action, SimpleAction::SadaAttach { .. }))
+        .collect();
+    assert_eq!(
+        sada_choices.len(),
+        1,
+        "1 ancient slot × 1 type combo × 1^3 = 1 choice; got: {sada_choices:?}"
+    );
+}
+
+/// Playing Professor Sada with two Ancient Pokémon and exactly 3 energy types presents
+/// exactly 8 assignments (2^3 ways to assign 3 energies to 2 targets).
+#[test]
+fn test_sada_two_ancient_three_types_gives_eight_choices() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a003BruteBonnet),
+            PlayedCard::from_id(CardId::B3a034GreatTusk),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_sada_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card));
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Water, EnergyType::Grass];
+    game.set_state(state);
+
+    play_sada(&mut game);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let sada_choices: Vec<_> = choices
+        .iter()
+        .filter(|a| matches!(&a.action, SimpleAction::SadaAttach { .. }))
+        .collect();
+    assert_eq!(
+        sada_choices.len(),
+        8,
+        "2 ancient slots × 1 combo × 2^3 = 8 choices; got: {sada_choices:?}"
+    );
+}
+
+/// After choosing an assignment, the 3 energies are removed from discard
+/// and attached to the correct Pokémon.
+#[test]
+fn test_sada_attaches_energies_and_clears_discard() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a003BruteBonnet), // active — slot 0
+            PlayedCard::from_id(CardId::B3a034GreatTusk),   // bench — slot 1
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_sada_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card));
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Water, EnergyType::Grass];
+    game.set_state(state);
+
+    play_sada(&mut game);
+
+    // Pick the assignment that puts all 3 energies on the active (slot 0)
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    let all_to_active = choices.iter().find(|a| {
+        matches!(
+            &a.action,
+            SimpleAction::SadaAttach { assignments }
+            if assignments.iter().all(|(_, idx)| *idx == 0)
+        )
+    });
+    assert!(
+        all_to_active.is_some(),
+        "Should have an all-to-active choice"
+    );
+
+    game.apply_action(all_to_active.unwrap());
+
+    let state = game.get_state_clone();
+
+    // Discard energies should be empty
+    assert!(
+        state.discard_energies[0].is_empty(),
+        "All 3 energies should have been removed from discard"
+    );
+
+    // Active (Brute Bonnet) should have 3 energies attached
+    let active = state.in_play_pokemon[0][0]
+        .as_ref()
+        .expect("Active should exist");
+    assert_eq!(
+        active.attached_energy.len(),
+        3,
+        "Active should have 3 energies attached, got: {:?}",
+        active.attached_energy
+    );
+    let attached: std::collections::HashSet<_> = active.attached_energy.iter().collect();
+    assert!(attached.contains(&EnergyType::Fire));
+    assert!(attached.contains(&EnergyType::Water));
+    assert!(attached.contains(&EnergyType::Grass));
+}
+
+/// The full-art variant (B3a 087) behaves identically.
+#[test]
+fn test_sada_full_art_variant_works() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3a003BruteBonnet)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let full_art_card = match get_card_by_enum(CardId::B3a087ProfessorSada) {
+        Card::Trainer(tc) => tc,
+        _ => panic!("Expected trainer card"),
+    };
+    state.hands[0].push(Card::Trainer(full_art_card.clone()));
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Water, EnergyType::Grass];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: full_art_card,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    let sada_choices: Vec<_> = choices
+        .iter()
+        .filter(|a| matches!(&a.action, SimpleAction::SadaAttach { .. }))
+        .collect();
+    assert_eq!(
+        sada_choices.len(),
+        1,
+        "Full-art variant should work identically"
+    );
+}


### PR DESCRIPTION
## Summary
Adds full implementation of the Professor Sada trainer card (both regular and full-art variants), which allows players to attach 3 different energy types from their discard pile to their Ancient Pokémon in play.

## Key Changes

- **New action type**: Added `SimpleAction::SadaAttach` to represent energy attachment decisions for Professor Sada
- **Core logic module**: Created `src/actions/professor_sada.rs` with `generate_professor_sada_assignments()` that:
  - Validates at least one Ancient Pokémon is in play
  - Requires at least 3 distinct energy types in the discard pile
  - Generates all valid combinations of 3 distinct types
  - For each type combination, generates all possible target assignments across Ancient Pokémon slots
  - Returns complete assignments as `Vec<(EnergyType, in_play_idx)>` tuples
- **Play validation**: Updated `can_play_professor_sada()` in move generation to check prerequisites (Ancient Pokémon present, 3+ distinct energy types in discard)
- **Effect resolution**: Implemented `professor_sada_effect()` to queue energy attachment choices and `forecast_sada_attach()` to apply the chosen assignment
- **Comprehensive test suite**: Added 6 integration tests covering:
  - Cannot play without Ancient Pokémon
  - Cannot play with fewer than 3 distinct energy types
  - Correct number of choices for various board states (1 ancient/1 combo = 1 choice; 2 ancients/1 combo = 8 choices)
  - Energy attachment and discard clearing
  - Full-art variant (B3a 087) works identically
- **Unit tests**: Added 11 unit tests for assignment generation logic validating edge cases and combinatorial correctness

## Implementation Details

The assignment generation uses a combinatorial approach:
- Extracts unique energy types from discard (preserving order)
- For each 3-combination of distinct types, generates all possible target assignments (Cartesian product across Ancient Pokémon slots)
- Example: 2 Ancient Pokémon + 3 distinct types = 1 type combo × 2³ = 8 possible assignments

Both card variants (B3a072 and B3a087) are supported and routed to the same implementation.

https://claude.ai/code/session_013GtJxcESqXWRpUjSfPgq5q