### PR TITLE
Implement Meowstic's Perplexing Ears ability (ConfuseOpponentActive)

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -99,6 +99,7 @@ pub enum AbilityMechanic {
         amount: u32,
     },
     PoisonOpponentActive,
+    ConfuseOpponentActive,
     RemoveRandomSpecialConditionFromActive,
     HealActiveYourPokemon {
         amount: u32,

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -168,6 +168,7 @@ fn forecast_ability_by_mechanic(
             amount,
         } => discard_energy_to_increase_type_damage(*discard_energy, *attack_type, *amount),
         AbilityMechanic::PoisonOpponentActive => poison_opponent_active(),
+        AbilityMechanic::ConfuseOpponentActive => confuse_opponent_active(),
         AbilityMechanic::RemoveRandomSpecialConditionFromActive => {
             remove_random_special_condition_from_active()
         }
@@ -492,6 +493,13 @@ fn poison_opponent_active() -> Outcomes {
     Outcomes::single_fn(|_rng, state, action| {
         let opponent = (action.actor + 1) % 2;
         state.apply_status_condition(opponent, 0, StatusCondition::Poisoned);
+    })
+}
+
+fn confuse_opponent_active() -> Outcomes {
+    Outcomes::single_fn(|_rng, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        state.apply_status_condition(opponent, 0, StatusCondition::Confused);
     })
 }
 

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -439,7 +439,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
         // map.insert("Each of your evolved Pokémon can use any attack from its previous Evolutions. (You still need the necessary Energy to use each attack.)", todo_implementation);
         // map.insert("If you don't have Regirock, Regice, and Registeel on your Bench, this Pokémon can't attack.", todo_implementation);
         // map.insert("Once during your turn, after you flip any coins for an attack of 1 of your [R] Pokémon, you may ignore all results of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.", todo_implementation);
-        // map.insert("Once during your turn, if this Pokémon is in the Active Spot, you may make your opponent's Active Pokémon Confused.", todo_implementation);
+        map.insert(
+            "Once during your turn, if this Pokémon is in the Active Spot, you may make your opponent's Active Pokémon Confused.",
+            AbilityMechanic::ConfuseOpponentActive,
+        );
         // map.insert("Once during your turn, if this Pokémon is in the Active Spot, you may switch out your opponent's Active Pokémon to the Bench. (Your opponent chooses the new Active Pokémon.)", todo_implementation);
         map.insert(
             "Once during your turn, if this Pokémon is on your Bench, you may move 30 damage that your Active Pokémon has on it to this Pokémon.",

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -124,6 +124,7 @@ fn can_use_ability_by_mechanic(
             !card.ability_used && card.attached_energy.contains(discard_energy)
         }
         AbilityMechanic::PoisonOpponentActive => _in_play_index == 0 && !card.ability_used,
+        AbilityMechanic::ConfuseOpponentActive => _in_play_index == 0 && !card.ability_used,
         AbilityMechanic::RemoveRandomSpecialConditionFromActive => {
             can_use_remove_random_special_condition_from_active(state, card)
         }

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -80,6 +80,8 @@ mod mega_kangaskhan_double_punching_family_test;
 mod mega_sceptile_terminating_tail_test;
 #[path = "pokemon/mega_steelix_adamantine_rolling_test.rs"]
 mod mega_steelix_adamantine_rolling_test;
+#[path = "pokemon/meowstic_test.rs"]
+mod meowstic_test;
 #[path = "pokemon/miraidon_ex_test.rs"]
 mod miraidon_ex_test;
 #[path = "pokemon/morpeko_test.rs"]

--- a/tests/pokemon/meowstic_test.rs
+++ b/tests/pokemon/meowstic_test.rs
@@ -1,0 +1,49 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::PlayedCard,
+    test_support::get_test_game_with_board,
+};
+
+#[test]
+fn test_meowstic_perplexing_ears_confuses_opponent_active() {
+    // Meowstic's Perplexing Ears: Once during your turn, if this Pokémon is in the Active Spot,
+    // you may make your opponent's Active Pokémon Confused.
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3066Meowstic)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 0 },
+        is_stack: false,
+    });
+
+    assert!(
+        game.get_state_clone().get_active(1).is_confused(),
+        "Meowstic's Perplexing Ears should confuse the opponent's Active Pokémon"
+    );
+}
+
+#[test]
+fn test_meowstic_perplexing_ears_not_available_from_bench() {
+    // Perplexing Ears requires Meowstic to be in the Active Spot.
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::B3066Meowstic),
+        ],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+
+    let (actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let has_bench_ability = actions
+        .iter()
+        .any(|a| matches!(a.action, SimpleAction::UseAbility { in_play_idx: 1 }));
+    assert!(
+        !has_bench_ability,
+        "Perplexing Ears should not be available when Meowstic is on the Bench"
+    );
+}


### PR DESCRIPTION
Adds ConfuseOpponentActive AbilityMechanic for B3 066 and B3 165 Meowstic,
mapping the "make your opponent's Active Pokémon Confused" effect text and
wiring it through move generation and apply-action following the same
pattern as PoisonOpponentActive.

https://claude.ai/code/session_016VsS9cNvsRRbBAYhyURGWB