### PR TITLE
Implement Hatterene's Mental Crush attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -663,6 +663,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfDefenderPoisoned { extra_damage } => {
             extra_damage_if_defender_poisoned(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::ExtraDamageIfDefenderConfused { extra_damage } => {
+            extra_damage_if_defender_confused(state, attack.fixed_damage, *extra_damage)
+        }
         Mechanic::DiscardTopSelfDeck => discard_top_self_deck(attack.fixed_damage),
         Mechanic::TieredCoinFlipDamage {
             num_coins,
@@ -2618,6 +2621,20 @@ fn extra_damage_if_defender_poisoned(
 ) -> Outcomes {
     let opponent = (state.current_player + 1) % 2;
     let damage = if state.get_active(opponent).is_poisoned() {
+        base_damage + extra_damage
+    } else {
+        base_damage
+    };
+    active_damage_doutcome(damage)
+}
+
+fn extra_damage_if_defender_confused(
+    state: &State,
+    base_damage: u32,
+    extra_damage: u32,
+) -> Outcomes {
+    let opponent = (state.current_player + 1) % 2;
+    let damage = if state.get_active(opponent).is_confused() {
         base_damage + extra_damage
     } else {
         base_damage

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -375,6 +375,10 @@ pub enum Mechanic {
     ExtraDamageIfDefenderPoisoned {
         extra_damage: u32,
     },
+    /// Hatterene – Mental Crush: extra damage if opponent's active is Confused.
+    ExtraDamageIfDefenderConfused {
+        extra_damage: u32,
+    },
     /// Discard the top card of the attacker's own deck after dealing damage.
     DiscardTopSelfDeck,
     /// Tiered coin flip damage: flip `num_coins` coins and deal fixed_damage +

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1993,7 +1993,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("If your opponent has any [P] Pokémon in play, this attack does 50 more damage.", todo_implementation);
     // map.insert("If your opponent's Active Pokémon is Asleep, this attack does 60 more damage.", todo_implementation);
-    // map.insert("If your opponent's Active Pokémon is Confused, this attack does 70 more damage.", todo_implementation);
+    map.insert(
+        "If your opponent's Active Pokémon is Confused, this attack does 70 more damage.",
+        Mechanic::ExtraDamageIfDefenderConfused { extra_damage: 70 },
+    );
     // map.insert("Move 2 random Energy from this Pokémon to 1 of your Benched Pokémon.", todo_implementation);
     // map.insert("Reveal all of your Pokémon in play and in your hand that have the Puppy Pile attack, and this attack does 20 damage for each Pokémon you revealed in this way.", todo_implementation);
     // map.insert("Take a [C] Energy from your Energy Zone and attach it to this Pokémon.", todo_implementation);

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -40,6 +40,8 @@ mod flygon_ex_test;
 mod gallade_test;
 #[path = "pokemon/grovyle_slicing_snipe_test.rs"]
 mod grovyle_slicing_snipe_test;
+#[path = "pokemon/hatterene_test.rs"]
+mod hatterene_test;
 #[path = "pokemon/heracross_test.rs"]
 mod heracross_test;
 #[path = "pokemon/houndstone_last_respects_test.rs"]

--- a/tests/pokemon/hatterene_test.rs
+++ b/tests/pokemon/hatterene_test.rs
@@ -1,0 +1,67 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard, StatusCondition},
+    test_support::get_initialized_game,
+};
+
+/// Hatterene's Mental Crush deals 70 damage normally, or 70 + 70 = 140 damage
+/// if the opponent's Active Pokémon is Confused.
+#[test]
+fn test_mental_crush_extra_damage_when_opponent_confused() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Player 0: Hatterene (Psychic) with 2 Psychic energy (enough for Mental Crush).
+    // Player 1: Snorlax (150 HP, weak to Fighting - no weakness bonus vs Psychic).
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3071Hatterene)
+            .with_energy(vec![EnergyType::Psychic, EnergyType::Psychic])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.current_player = 0;
+    state.apply_status_condition(1, 0, StatusCondition::Confused);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    // Snorlax 150 HP - 140 (70 base + 70 confused bonus) = 10.
+    let hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        hp, 10,
+        "Mental Crush should deal 140 damage to a Confused opponent"
+    );
+}
+
+/// When the opponent's Active Pokémon is not Confused, Mental Crush deals only
+/// its base 70 damage.
+#[test]
+fn test_mental_crush_base_damage_when_opponent_not_confused() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3071Hatterene)
+            .with_energy(vec![EnergyType::Psychic, EnergyType::Psychic])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    // Snorlax 150 HP - 70 (base damage only) = 80.
+    let hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        hp, 80,
+        "Mental Crush should deal only base 70 damage when opponent is not Confused"
+    );
+}


### PR DESCRIPTION
Adds ExtraDamageIfDefenderConfused mechanic: deals 70 base damage,
plus 70 more if the opponent's Active Pokemon is Confused.

https://claude.ai/code/session_01T7XT1rVKdpB5Vqbvqaotqz