### PR TITLE
Implement Durant attack effects (Mountain Munch, Bite Together)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -427,6 +427,15 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfStage2OnBench { extra_damage } => {
             extra_damage_if_stage2_on_bench(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::ExtraDamageIfPokemonOnBench {
+            pokemon_name,
+            extra_damage,
+        } => extra_damage_if_pokemon_on_bench(
+            state,
+            attack.fixed_damage,
+            pokemon_name,
+            *extra_damage,
+        ),
         Mechanic::DamageEqualToSelfDamage => damage_equal_to_self_damage(state),
         Mechanic::ExtraDamageEqualToSelfDamage => {
             extra_damage_equal_to_self_damage(state, attack.fixed_damage)
@@ -520,10 +529,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::AttachEnergyToBenchedBasic { energy_type } => {
             attach_energy_to_benched_basic(state.current_player, *energy_type)
         }
-        Mechanic::DamageAndDiscardOpponentDeck {
-            damage,
-            discard_count,
-        } => damage_and_discard_opponent_deck(*damage, *discard_count),
+        Mechanic::DamageAndDiscardOpponentDeck { discard_count } => {
+            damage_and_discard_opponent_deck(attack.fixed_damage, *discard_count)
+        }
         Mechanic::MegaAmpharosExLightningLancer => mega_ampharos_lightning_lancer(),
         Mechanic::OminousClaw => ominous_claw_attack(state.current_player, attack.fixed_damage),
         Mechanic::DarknessClaw => darkness_claw_attack(state.current_player, attack.fixed_damage),
@@ -2091,6 +2099,22 @@ fn extra_damage_if_stage2_on_bench(state: &State, base: u32, extra: u32) -> Outc
         .enumerate_bench_pokemon(state.current_player)
         .any(|(_, p)| get_stage(p) == 2);
     if has_stage2 {
+        active_damage_doutcome(base + extra)
+    } else {
+        active_damage_doutcome(base)
+    }
+}
+
+fn extra_damage_if_pokemon_on_bench(
+    state: &State,
+    base: u32,
+    pokemon_name: &str,
+    extra: u32,
+) -> Outcomes {
+    let has_pokemon_on_bench = state
+        .enumerate_bench_pokemon(state.current_player)
+        .any(|(_, p)| p.get_name() == pokemon_name);
+    if has_pokemon_on_bench {
         active_damage_doutcome(base + extra)
     } else {
         active_damage_doutcome(base)

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -244,6 +244,10 @@ pub enum Mechanic {
     ExtraDamageIfStage2OnBench {
         extra_damage: u32,
     },
+    ExtraDamageIfPokemonOnBench {
+        pokemon_name: String,
+        extra_damage: u32,
+    },
     DamageEqualToSelfDamage,
     ExtraDamageEqualToSelfDamage,
     ExtraDamageIfKnockedOutLastTurn {
@@ -315,7 +319,6 @@ pub enum Mechanic {
         energy_type: EnergyType,
     },
     DamageAndDiscardOpponentDeck {
-        damage: u32,
         discard_count: usize,
     },
     MegaAmpharosExLightningLancer,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -191,14 +191,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("Discard the top 3 cards of your deck.", todo_implementation);
     map.insert(
         "Discard the top 3 cards of your opponent's deck.",
-        Mechanic::DamageAndDiscardOpponentDeck {
-            damage: 140,
-            discard_count: 3,
-        },
+        Mechanic::DamageAndDiscardOpponentDeck { discard_count: 3 },
     );
     // map.insert("Discard the top 5 cards of each player's deck.", todo_implementation);
     // map.insert("Discard the top card of your deck. If that card is a [F] Pokémon, this attack does 60 more damage.", todo_implementation);
-    // map.insert("Discard the top card of your opponent's deck.", todo_implementation);
+    map.insert(
+        "Discard the top card of your opponent's deck.",
+        Mechanic::DamageAndDiscardOpponentDeck { discard_count: 1 },
+    );
     // map.insert("Discard up to 2 Pokémon Tool cards from your hand. This attack does 50 damage for each card you discarded in this way.", todo_implementation);
     map.insert("Draw a card.", Mechanic::DrawCard { amount: 1 });
     // map.insert("Draw cards until you have the same number of cards in your hand as your opponent.", todo_implementation);
@@ -735,9 +735,27 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 20 more damage.", todo_implementation);
     // map.insert("If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 30 more damage.", todo_implementation);
     // map.insert("If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 60 more damage.", todo_implementation);
-    // map.insert("If Durant is on your Bench, this attack does 40 more damage.", todo_implementation);
-    // map.insert("If Latios is on your Bench, this attack does 20 more damage.", todo_implementation);
-    // map.insert("If Passimian is on your Bench, this attack does 40 more damage.", todo_implementation);
+    map.insert(
+        "If Durant is on your Bench, this attack does 40 more damage.",
+        Mechanic::ExtraDamageIfPokemonOnBench {
+            pokemon_name: "Durant".to_string(),
+            extra_damage: 40,
+        },
+    );
+    map.insert(
+        "If Latios is on your Bench, this attack does 20 more damage.",
+        Mechanic::ExtraDamageIfPokemonOnBench {
+            pokemon_name: "Latios".to_string(),
+            extra_damage: 20,
+        },
+    );
+    map.insert(
+        "If Passimian is on your Bench, this attack does 40 more damage.",
+        Mechanic::ExtraDamageIfPokemonOnBench {
+            pokemon_name: "Passimian".to_string(),
+            extra_damage: 40,
+        },
+    );
     // map.insert("If any of your Benched Pokémon have damage on them, this attack does 50 more damage.", todo_implementation);
     map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 60 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage: 60 });
     map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 40 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage: 40 });
@@ -1809,7 +1827,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::FlipCoinsBenchDamagePerHead { num_coins: 3, bench_damage_per_head: 20 },
     );
     // map.insert("If Electivire is on your Bench, this attack also does 20 damage to each of your opponent's Benched Pokémon.", todo_implementation);
-    // map.insert("If Magmortar is on your Bench, this attack does 70 more damage.", todo_implementation);
+    map.insert(
+        "If Magmortar is on your Bench, this attack does 70 more damage.",
+        Mechanic::ExtraDamageIfPokemonOnBench {
+            pokemon_name: "Magmortar".to_string(),
+            extra_damage: 70,
+        },
+    );
     // map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, your opponent's Active Pokémon is now Paralyzed.", todo_implementation);
     map.insert(
         "If this Pokémon's remaining HP is 110 or less, this attack does 80 more damage.",
@@ -1943,7 +1967,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Heal 30 damage from each of your Pokémon.",
         Mechanic::HealAllYourPokemon { amount: 30 },
     );
-    // map.insert("If Durant is on your Bench, this attack does 30 more damage.", todo_implementation);
+    map.insert(
+        "If Durant is on your Bench, this attack does 30 more damage.",
+        Mechanic::ExtraDamageIfPokemonOnBench {
+            pokemon_name: "Durant".to_string(),
+            extra_damage: 30,
+        },
+    );
     map.insert(
         "If a Stadium is in play, heal 20 damage from this Pokémon.",
         Mechanic::SelfHealIfStadiumInPlay { amount: 20 },

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -28,6 +28,8 @@ mod corviknight_line_test;
 mod crawdaunt_unruly_claw_test;
 #[path = "pokemon/darkrai_ex_test.rs"]
 mod darkrai_ex_test;
+#[path = "pokemon/durant_test.rs"]
+mod durant_test;
 #[path = "pokemon/dusknoir_shadow_void_test.rs"]
 mod dusknoir_shadow_void_test;
 #[path = "pokemon/emboar_flare_storm_test.rs"]

--- a/tests/pokemon/durant_test.rs
+++ b/tests/pokemon/durant_test.rs
@@ -1,0 +1,102 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+#[test]
+fn test_bite_together_extra_damage_with_durant_on_bench() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B1168Durant)
+                .with_energy(vec![EnergyType::Metal, EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::B1168Durant), // Durant on Bench
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // Bite Together: 40 base + 40 extra (Durant on Bench) = 80
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        150 - 80
+    );
+}
+
+#[test]
+fn test_bite_together_base_damage_without_durant_on_bench() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B1168Durant)
+                .with_energy(vec![EnergyType::Metal, EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur), // Not Durant
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // Bite Together: 40 base only (no Durant on Bench)
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        150 - 40
+    );
+}
+
+#[test]
+fn test_mountain_munch_discards_top_card_of_opponent_deck() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A4a007Durant)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let top_card = get_card_by_enum(CardId::A1001Bulbasaur);
+    state.decks[1].cards.insert(0, top_card.clone());
+    let deck_size_before = state.decks[1].cards.len();
+
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+
+    // Mountain Munch: 40 damage dealt
+    assert_eq!(state.get_active(1).get_remaining_hp(), 150 - 40);
+
+    // Top card of opponent's deck was discarded
+    assert_eq!(state.decks[1].cards.len(), deck_size_before - 1);
+    assert!(state.discard_piles[1].contains(&top_card));
+}


### PR DESCRIPTION
Adds a generic ExtraDamageIfPokemonOnBench mechanic for "If <Pokemon> is on
your Bench, this attack does X more damage." attacks (used by Durant,
Latios/Latias, Passimian, Magmortar/Electivire), and generalizes
DamageAndDiscardOpponentDeck to use the attack's own fixed_damage so it
covers "Discard the top card of your opponent's deck." (Durant, Gyarados,
Machamp, Paldean Clodsire) in addition to the existing 3-card variant.

https://claude.ai/code/session_01PdSnnMzQbdbZUuSEENk8b5