### PR TITLE
Added Smoochum Shivery Wave attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -471,21 +471,8 @@ fn forecast_effect_attack_by_mechanic(
             *include_fixed_damage,
             *damage_per,
         ),
-        Mechanic::ExtraDamagePerEnergy {
-            opponent,
-            damage_per_energy,
-        } => {
-            let base = if attack
-                .effect
-                .as_deref()
-                .is_some_and(|e| e.contains("more damage"))
-            {
-                attack.fixed_damage
-            } else {
-                0
-            };
-            extra_damage_per_energy(state, base, *opponent, *damage_per_energy)
-        }
+        Mechanic::ExtraDamagePerEnergy { opponent, damage_per_energy, include_fixed_damage } => 
+            extra_damage_per_energy(state, if *include_fixed_damage { attack.fixed_damage } else { 0 }, *opponent, *damage_per_energy),
         Mechanic::ExtraDamagePerEnergyType { damage_per_type } => {
             extra_damage_per_energy_type(state, attack.fixed_damage, *damage_per_type)
         }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -474,7 +474,18 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamagePerEnergy {
             opponent,
             damage_per_energy,
-        } => extra_damage_per_energy(state, attack.fixed_damage, *opponent, *damage_per_energy),
+        } => {
+            let base = if attack
+                .effect
+                .as_deref()
+                .is_some_and(|e| e.contains("more damage"))
+            {
+                attack.fixed_damage
+            } else {
+                0
+            };
+            extra_damage_per_energy(state, base, *opponent, *damage_per_energy)
+        }
         Mechanic::ExtraDamagePerEnergyType { damage_per_type } => {
             extra_damage_per_energy_type(state, attack.fixed_damage, *damage_per_type)
         }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -471,8 +471,20 @@ fn forecast_effect_attack_by_mechanic(
             *include_fixed_damage,
             *damage_per,
         ),
-        Mechanic::ExtraDamagePerEnergy { opponent, damage_per_energy, include_fixed_damage } => 
-            extra_damage_per_energy(state, if *include_fixed_damage { attack.fixed_damage } else { 0 }, *opponent, *damage_per_energy),
+        Mechanic::ExtraDamagePerEnergy {
+            opponent,
+            damage_per_energy,
+            include_fixed_damage,
+        } => extra_damage_per_energy(
+            state,
+            if *include_fixed_damage {
+                attack.fixed_damage
+            } else {
+                0
+            },
+            *opponent,
+            *damage_per_energy,
+        ),
         Mechanic::ExtraDamagePerEnergyType { damage_per_type } => {
             extra_damage_per_energy_type(state, attack.fixed_damage, *damage_per_type)
         }

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -274,6 +274,7 @@ pub enum Mechanic {
         damage_per: u32,
     },
     ExtraDamagePerEnergy {
+        include_fixed_damage: bool,
         opponent: bool,
         damage_per_energy: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1365,6 +1365,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per_energy: 20,
         },
     );
+    map.insert(
+        "This attack does 20 damage for each Energy attached to your opponent's Active Pokémon.",
+        Mechanic::ExtraDamagePerEnergy {
+            opponent: true,
+            damage_per_energy: 20,
+        },
+    );
     map.insert("This attack does 20 more damage for each Energy attached to your opponent's Active Pokémon.", 
         Mechanic::ExtraDamagePerEnergy {
             opponent: true,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1361,6 +1361,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     map.insert(
         "This attack does 20 more damage for each Energy attached to this Pokémon.",
         Mechanic::ExtraDamagePerEnergy {
+            include_fixed_damage: true,
             opponent: false,
             damage_per_energy: 20,
         },
@@ -1368,12 +1369,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     map.insert(
         "This attack does 20 damage for each Energy attached to your opponent's Active Pokémon.",
         Mechanic::ExtraDamagePerEnergy {
+            include_fixed_damage: false,
             opponent: true,
             damage_per_energy: 20,
         },
     );
     map.insert("This attack does 20 more damage for each Energy attached to your opponent's Active Pokémon.", 
         Mechanic::ExtraDamagePerEnergy {
+            include_fixed_damage: true,
             opponent: true,
             damage_per_energy: 20,
         },
@@ -1446,6 +1449,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     map.insert(
         "This attack does 30 more damage for each Energy attached to your opponent's Active Pokémon.",
         Mechanic::ExtraDamagePerEnergy {
+            include_fixed_damage: true,
             opponent: true,
             damage_per_energy: 30,
         },

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -102,6 +102,8 @@ mod roaring_moon_test;
 mod shinx_hide_test;
 #[path = "pokemon/slither_wing_test.rs"]
 mod slither_wing_test;
+#[path = "pokemon/smoochum_test.rs"]
+mod smoochum_test;
 #[path = "pokemon/sunflora_quick_grow_beam_test.rs"]
 mod sunflora_quick_grow_beam_test;
 #[path = "pokemon/swift_shot_test.rs"]

--- a/tests/pokemon/smoochum_test.rs
+++ b/tests/pokemon/smoochum_test.rs
@@ -1,0 +1,72 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+#[test]
+fn test_smoochum_shivery_wave_damage_scales_with_opponent_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Setup: Player 0 Active = Smoochum. Player 1 Active = Bulbasaur (70 HP) with 3 energies.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A4075Smoochum)],
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Grass,
+                EnergyType::Grass,
+            ]),
+        ],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    game.set_state(state);
+
+    // Act: Apply Shivery Wave (index 0)
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    // Assert: 3 energies * 20 damage = 60 damage.
+    // Bulbasaur starts with 70 HP. 70 - 60 = 10 HP remaining.
+    let final_state = game.get_state_clone();
+    let opponent_hp = final_state.get_active(1).get_remaining_hp();
+    assert_eq!(
+        opponent_hp, 10,
+        "Shivery Wave should deal 60 damage for 3 energies"
+    );
+}
+
+#[test]
+fn test_smoochum_shivery_wave_zero_damage_with_no_opponent_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Setup: Player 1 active has NO energy.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A4075Smoochum)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    // Assert: 0 energies * 20 damage = 0 damage.
+    let final_state = game.get_state_clone();
+    let opponent_hp = final_state.get_active(1).get_remaining_hp();
+    assert_eq!(
+        opponent_hp, 70,
+        "Shivery Wave should deal 0 damage when opponent has no energy"
+    );
+}


### PR DESCRIPTION
Implements Shivery Wave attack that deals 20 damage per opponent energy. 

This one should be different compared to others because the other ones use 20 "more" damage so I'm not sure if the code implementation is correct. 

All tests passed locally (cargo fmt, clippy, test), just the logic for the attack implementation. I hope I'm correct. 

Feel free to make changes if something is missing or not.