### PR TITLE
Implement Applin's Share attack heal mechanic

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -213,6 +213,9 @@ fn forecast_effect_attack_by_mechanic(
         ),
         Mechanic::SelfHeal { amount } => self_heal_attack(*amount, attack),
         Mechanic::HealOneYourPokemon { amount } => heal_one_your_pokemon_attack(*amount),
+        Mechanic::HealOneYourBenchedPokemon { amount } => {
+            heal_one_your_benched_pokemon_attack(*amount)
+        }
         Mechanic::HealAllYourPokemon { amount } => {
             heal_all_your_pokemon_attack(attack.fixed_damage, *amount)
         }
@@ -1726,6 +1729,23 @@ fn heal_one_your_pokemon_attack(amount: u32) -> Outcomes {
     Outcomes::single_fn(move |_rng, state, action| {
         let choices = state
             .enumerate_in_play_pokemon(action.actor)
+            .filter(|(_, pokemon)| pokemon.is_damaged())
+            .map(|(in_play_idx, _)| SimpleAction::Heal {
+                in_play_idx,
+                amount,
+                cure_status: false,
+            })
+            .collect::<Vec<_>>();
+        if !choices.is_empty() {
+            state.move_generation_stack.push((action.actor, choices));
+        }
+    })
+}
+
+fn heal_one_your_benched_pokemon_attack(amount: u32) -> Outcomes {
+    Outcomes::single_fn(move |_rng, state, action| {
+        let choices = state
+            .enumerate_bench_pokemon(action.actor)
             .filter(|(_, pokemon)| pokemon.is_damaged())
             .map(|(in_play_idx, _)| SimpleAction::Heal {
                 in_play_idx,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -25,6 +25,9 @@ pub enum Mechanic {
     HealOneYourPokemon {
         amount: u32,
     },
+    HealOneYourBenchedPokemon {
+        amount: u32,
+    },
     HealAllYourPokemon {
         amount: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1964,7 +1964,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::HealAllYourPokemon { amount: 10 },
     );
     // map.insert("Heal 20 damage from each of your [P] Pokémon.", todo_implementation);
-    // map.insert("Heal 30 damage from 1 of your Benched Pokémon.", todo_implementation);
+    map.insert(
+        "Heal 30 damage from 1 of your Benched Pokémon.",
+        Mechanic::HealOneYourBenchedPokemon { amount: 30 },
+    );
     map.insert(
         "Heal 30 damage from 1 of your Pokémon.",
         Mechanic::HealOneYourPokemon { amount: 30 },

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -2,6 +2,8 @@
 mod additional_ability_logic_test;
 #[path = "pokemon/altaria_dragon_arcana_test.rs"]
 mod altaria_dragon_arcana_test;
+#[path = "pokemon/applin_share_test.rs"]
+mod applin_share_test;
 #[path = "pokemon/arceus_ex_test.rs"]
 mod arceus_ex_test;
 #[path = "pokemon/audino_test.rs"]

--- a/tests/pokemon/applin_share_test.rs
+++ b/tests/pokemon/applin_share_test.rs
@@ -1,0 +1,103 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Test that Applin's "Share" attack lets the player heal 30 damage from one
+/// of their Benched Pokémon, but does not offer the active Applin itself.
+#[test]
+fn test_applin_share_heals_benched_pokemon() {
+    let mut game = get_initialized_game(0);
+
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3019Applin)
+                .with_energy(vec![EnergyType::Colorless])
+                .with_remaining_hp(10),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_remaining_hp(20),
+        ],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let attack_action = Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    };
+    game.apply_action(&attack_action);
+
+    // Player must choose which Pokémon to heal; only the Benched Bulbasaur
+    // should be offered, not the damaged active Applin.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(choices.len(), 1);
+    assert_eq!(
+        choices[0].action,
+        SimpleAction::Heal {
+            in_play_idx: 1,
+            amount: 30,
+            cure_status: false,
+        }
+    );
+
+    game.apply_action(&choices[0].clone());
+
+    let final_state = game.get_state_clone();
+    assert_eq!(
+        final_state.in_play_pokemon[0][1]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        50
+    );
+    // Active Applin should remain damaged.
+    assert_eq!(
+        final_state.in_play_pokemon[0][0]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        10
+    );
+}
+
+/// Test that Applin's "Share" attack does nothing if there is no damaged
+/// Benched Pokémon to heal.
+#[test]
+fn test_applin_share_no_choices_when_bench_undamaged() {
+    let mut game = get_initialized_game(0);
+
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3019Applin).with_energy(vec![EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let attack_action = Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    };
+    game.apply_action(&attack_action);
+
+    // No Pokémon to heal, so the only option is to end the turn.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(
+        choices,
+        vec![Action {
+            actor: 0,
+            action: SimpleAction::EndTurn,
+            is_stack: false,
+        }]
+    );
+}


### PR DESCRIPTION
## Summary
Adds support for Applin's "Share" attack, which heals 30 damage from one of the player's benched Pokémon. This introduces a new attack mechanic type for healing specifically benched Pokémon (excluding the active Pokémon).

## Key Changes
- Added `HealOneYourBenchedPokemon` mechanic variant to support attacks that heal benched Pokémon only
- Implemented `heal_one_your_benched_pokemon_attack()` function that:
  - Filters benched Pokémon to only those that are damaged
  - Generates heal action choices for each eligible benched Pokémon
  - Pushes choices to the move generation stack if any exist
- Mapped the effect text "Heal 30 damage from 1 of your Benched Pokémon." to the new mechanic
- Added comprehensive test coverage with two test cases:
  - Verifies healing works correctly and only offers benched Pokémon (not the active Pokémon)
  - Verifies no choices are generated when there are no damaged benched Pokémon

## Implementation Details
The implementation follows the existing pattern for conditional healing mechanics by filtering the bench Pokémon list and only offering choices for damaged Pokémon. This ensures the player cannot heal an undamaged Pokémon and the attack does nothing if there are no valid targets.

https://claude.ai/code/session_01Fp76Drr4V3K4mzKTboVxLg