### PR TITLE
Implement SearchToHandByEvolvesFrom mechanic for Spewpa and Rockruff

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -32,7 +32,7 @@ use super::{
     outcomes::{CoinSeq, Outcomes},
     shared_mutations::{
         pokemon_search_outcomes, pokemon_search_outcomes_by_type, search_and_bench_basic,
-        search_and_bench_by_name, supporter_search_outcomes,
+        search_and_bench_by_name, search_to_hand_by_evolves_from, supporter_search_outcomes,
     },
     SimpleAction,
 };
@@ -252,6 +252,9 @@ fn forecast_effect_attack_by_mechanic(
         }
         Mechanic::SearchRandomPokemonToHand => {
             pokemon_search_outcomes(state.current_player, state, false)
+        }
+        Mechanic::SearchToHandByEvolvesFrom { name } => {
+            search_to_hand_by_evolves_from(state, name.clone())
         }
         Mechanic::SearchToHandSupporterCard => {
             supporter_search_outcomes(state.current_player, state)

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -39,6 +39,9 @@ pub enum Mechanic {
     },
     SearchToBenchBasic,
     SearchRandomPokemonToHand,
+    SearchToHandByEvolvesFrom {
+        name: String,
+    },
     SearchToHandSupporterCard,
     InflictStatusConditions {
         conditions: Vec<StatusCondition>,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1033,7 +1033,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::SearchRandomPokemonToHand,
     );
     map.insert("Put a random card from your deck that evolves from this Pokémon onto this Pokémon to evolve it.", Mechanic::MagikarpWaterfallEvolution);
-    // map.insert("Put a random card that evolves from Rockruff from your deck into your hand.", todo_implementation);
+    map.insert(
+        "Put a random card that evolves from Rockruff from your deck into your hand.",
+        Mechanic::SearchToHandByEvolvesFrom {
+            name: "Rockruff".to_string(),
+        },
+    );
     // map.insert("Reveal the top 3 cards of your deck. This attack does 60 damage for each Pokémon with a Retreat Cost of 3 or more you find there. Shuffle the revealed cards back into your deck.", todo_implementation);
     // map.insert("Shuffle your hand into your deck. Draw a card for each card in your opponent's hand.", todo_implementation);
     map.insert(
@@ -1716,7 +1721,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("If your opponent has gotten exactly 1 points, this attack does 40 more damage.", todo_implementation);
     // map.insert("If your opponent's Active Pokémon has damage on it, this attack does 50 more damage.", todo_implementation);
     // map.insert("Put 3 random cards from among Tandemaus and Maushold from your deck onto your Bench.", todo_implementation);
-    // map.insert("Put a random card that evolves from Spewpa from your deck into your hand.", todo_implementation);
+    map.insert(
+        "Put a random card that evolves from Spewpa from your deck into your hand.",
+        Mechanic::SearchToHandByEvolvesFrom {
+            name: "Spewpa".to_string(),
+        },
+    );
     // map.insert("Take 2 [P] Energy from your Energy Zone and attach it to 1 of your Benched [P] Pokémon.", todo_implementation);
     map.insert(
         "Take 3 [P] Energy from your Energy Zone and attach it to your [P] Pokémon in any way you like.",

--- a/src/actions/shared_mutations.rs
+++ b/src/actions/shared_mutations.rs
@@ -43,6 +43,14 @@ pub(crate) fn pokemon_search_outcomes_by_type_for_player(
     })
 }
 
+pub(crate) fn search_to_hand_by_evolves_from(state: &State, name: String) -> Outcomes {
+    card_search_outcomes_with_filter(
+        state.current_player,
+        state,
+        move |card: &&Card| matches!(card, Card::Pokemon(pokemon_card) if pokemon_card.evolves_from.as_deref() == Some(name.as_str())),
+    )
+}
+
 pub(crate) fn item_search_outcomes(acting_player: usize, state: &State) -> Outcomes {
     card_search_outcomes_with_filter(
         acting_player,

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -102,6 +102,8 @@ mod roaring_moon_test;
 mod shinx_hide_test;
 #[path = "pokemon/slither_wing_test.rs"]
 mod slither_wing_test;
+#[path = "pokemon/spewpa_signs_of_evolution_test.rs"]
+mod spewpa_signs_of_evolution_test;
 #[path = "pokemon/sunflora_quick_grow_beam_test.rs"]
 mod sunflora_quick_grow_beam_test;
 #[path = "pokemon/swift_shot_test.rs"]

--- a/tests/pokemon/spewpa_signs_of_evolution_test.rs
+++ b/tests/pokemon/spewpa_signs_of_evolution_test.rs
@@ -1,0 +1,69 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+#[test]
+fn test_spewpa_signs_of_evolution_puts_vivillon_into_hand() {
+    let mut game = get_initialized_game(0);
+    game.play_until_stable();
+
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2012Spewpa).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+
+    // Put a single Vivillon (evolves from Spewpa) into the deck so the outcome is deterministic.
+    state.decks[0].cards = vec![get_card_by_enum(CardId::B2013Vivillon)];
+
+    let hand_size_before = state.hands[0].len();
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.hands[0].len(), hand_size_before + 1);
+    assert!(matches!(&state.hands[0].last(), Some(Card::Pokemon(card)) if card.name == "Vivillon"));
+    assert!(state.decks[0].cards.is_empty());
+}
+
+#[test]
+fn test_spewpa_signs_of_evolution_no_matching_card_just_shuffles() {
+    let mut game = get_initialized_game(0);
+    game.play_until_stable();
+
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2012Spewpa).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+
+    // No Vivillon in the deck.
+    state.decks[0].cards = vec![get_card_by_enum(CardId::A1033Charmander)];
+
+    let hand_size_before = state.hands[0].len();
+    let deck_size_before = state.decks[0].cards.len();
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.hands[0].len(), hand_size_before);
+    assert_eq!(state.decks[0].cards.len(), deck_size_before);
+}


### PR DESCRIPTION
## Summary
Implements support for card search mechanics that find evolution cards by their pre-evolution name and add them to the player's hand. This enables attacks like Spewpa's "Signs of Evolution" and Rockruff's evolution search.

## Key Changes
- Added new `SearchToHandByEvolvesFrom` mechanic variant that takes a Pokémon name and searches the deck for cards that evolve from it
- Implemented `search_to_hand_by_evolves_from()` helper function in `shared_mutations.rs` that filters cards by their `evolves_from` field
- Integrated the new mechanic into attack effect forecasting in `apply_attack_action.rs`
- Mapped two card text descriptions to the new mechanic:
  - Spewpa's "Put a random card that evolves from Spewpa from your deck into your hand."
  - Rockruff's "Put a random card that evolves from Rockruff from your deck into your hand."
- Added comprehensive test coverage with two test cases:
  - Verifies successful search and hand addition when matching evolution card exists in deck
  - Verifies deck is shuffled without adding cards when no matching evolution exists

## Implementation Details
The mechanic reuses the existing `card_search_outcomes_with_filter()` infrastructure, filtering cards where the `evolves_from` field matches the specified Pokémon name. This maintains consistency with other search mechanics and properly handles the random selection and deck shuffling.

https://claude.ai/code/session_01K6a4wvh3h5UJfiodnjJif2