### PR TITLE
Fix Carefree Steps: keep additional effects on heads, support per-target flips

### DIFF
--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::rc::Rc;
 
 use log::debug;
 use rand::rngs::StdRng;
@@ -29,6 +30,12 @@ pub(crate) type Probabilities = Vec<f64>;
 pub(crate) type FnMutation = Box<dyn Fn(&mut StdRng, &mut State, &Action)>;
 pub(crate) type Mutation = Box<dyn FnOnce(&mut StdRng, &mut State, &Action)>;
 pub(crate) type Mutations = Vec<Mutation>;
+
+/// A shareable effect (beyond the core damage application) attached to an
+/// attack outcome, e.g. inflicting a status condition. Shared via `Rc` so the
+/// same effect can be reused across the sub-branches produced when splitting
+/// an outcome for per-target coin flips (e.g. Carefree Steps).
+pub(crate) type AdditionalEffect = Rc<dyn Fn(&mut StdRng, &mut State, &Action)>;
 
 #[derive(Clone)]
 struct CheckupTargets {

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -29,7 +29,7 @@ use super::{
         active_damage_doutcome, active_damage_effect_doutcome, active_damage_effect_mutation,
         active_damage_mutation, build_status_effect, damage_effect_doutcome,
     },
-    outcomes::{CoinSeq, Outcomes},
+    outcomes::{CoinSeq, DamageTarget, Outcomes},
     shared_mutations::{
         pokemon_search_outcomes, pokemon_search_outcomes_by_type, search_and_bench_basic,
         search_and_bench_by_name, search_to_hand_by_evolves_from, supporter_search_outcomes,
@@ -126,7 +126,21 @@ fn apply_defender_damage_prevention_if_needed(
     attack: &Attack,
     outcomes: Outcomes,
 ) -> Outcomes {
-    // Check if DEFENDING Pokemon has CoinFlipToPreventDamage ability (only if attack does damage)
+    // Outcomes that report explicit damage targets (e.g. built via
+    // `damage_effect_doutcome`) get a per-target Carefree Steps coin flip:
+    // every Pokemon being damaged (on either side, active or benched) that
+    // has CoinFlipToPreventDamage gets its own independent 50/50 chance to
+    // have just its damage reduced to 0, while any additional effects
+    // (status conditions, etc.) still apply.
+    if outcomes.has_damage_targets() {
+        return outcomes.apply_coin_flip_damage_prevention(|target| {
+            target_has_coin_flip_prevent_damage(state, acting_player, target)
+        });
+    }
+
+    // Legacy fallback for mechanics that don't report explicit damage
+    // targets: only the opponent's active Pokemon is checked, and the whole
+    // outcome (including any additional effects) is gated behind one coin flip.
     if attack.fixed_damage > 0 {
         let opponent = (acting_player + 1) % 2;
         let defender = state.get_active(opponent);
@@ -143,6 +157,27 @@ fn apply_defender_damage_prevention_if_needed(
     }
 
     outcomes
+}
+
+/// Whether the Pokemon being damaged by `target` has the Carefree Steps
+/// (CoinFlipToPreventDamage) ability.
+fn target_has_coin_flip_prevent_damage(
+    state: &State,
+    acting_player: usize,
+    target: &DamageTarget,
+) -> bool {
+    let target_player = if target.is_opponent_target {
+        (acting_player + 1) % 2
+    } else {
+        acting_player
+    };
+    state.in_play_pokemon[target_player]
+        .get(target.in_play_idx)
+        .and_then(|slot| slot.as_ref())
+        .and_then(|card| card.card.get_ability())
+        .and_then(|a| ability_mechanic_from_effect(&a.effect))
+        .map(|m| matches!(m, AbilityMechanic::CoinFlipToPreventDamage))
+        .unwrap_or(false)
 }
 
 fn forecast_attack_inner(state: &State, card: &Card, attack: &Attack, _index: usize) -> Outcomes {

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -25,11 +25,12 @@ use crate::{
 
 use super::{
     apply_action_helpers::{Mutation, Mutations},
+    attack_outcomes::{AttackOutcomes, DamageTarget},
     mutations::{
         active_damage_doutcome, active_damage_effect_doutcome, active_damage_effect_mutation,
         active_damage_mutation, build_status_effect, damage_effect_doutcome,
     },
-    outcomes::{CoinSeq, DamageTarget, Outcomes},
+    outcomes::{CoinSeq, Outcomes},
     shared_mutations::{
         pokemon_search_outcomes, pokemon_search_outcomes_by_type, search_and_bench_basic,
         search_and_bench_by_name, search_to_hand_by_evolves_from, supporter_search_outcomes,
@@ -88,7 +89,7 @@ fn apply_attack_common_modifiers(
     acting_player: usize,
     state: &State,
     attack: &Attack,
-    base_outcomes: Outcomes,
+    base_outcomes: AttackOutcomes,
 ) -> Outcomes {
     let active = state.get_active(acting_player);
     let has_block_effect = active
@@ -100,32 +101,34 @@ fn apply_attack_common_modifiers(
 
     // Handle confusion: 50% chance the attack fails (coin flip)
     if active.is_confused() {
-        outcomes = apply_confusion_coin_flip(outcomes);
+        outcomes = AttackOutcomes::opaque(apply_confusion_coin_flip(outcomes.into_outcomes()));
     }
 
     // Handle CoinFlipToBlockAttack: 50% chance attack is blocked
     if has_block_effect {
-        outcomes = apply_block_attack_coin_flip(outcomes);
+        outcomes = AttackOutcomes::opaque(apply_block_attack_coin_flip(outcomes.into_outcomes()));
     }
 
     apply_defender_damage_prevention_if_needed(acting_player, state, attack, outcomes)
+        .into_outcomes()
 }
 
 fn apply_copied_attack_modifiers(
     acting_player: usize,
     state: &State,
     attack: &Attack,
-    base_outcomes: Outcomes,
+    base_outcomes: AttackOutcomes,
 ) -> Outcomes {
     apply_defender_damage_prevention_if_needed(acting_player, state, attack, base_outcomes)
+        .into_outcomes()
 }
 
 fn apply_defender_damage_prevention_if_needed(
     acting_player: usize,
     state: &State,
     attack: &Attack,
-    outcomes: Outcomes,
-) -> Outcomes {
+    outcomes: AttackOutcomes,
+) -> AttackOutcomes {
     // Outcomes that report explicit damage targets (e.g. built via
     // `damage_effect_doutcome`) get a per-target Carefree Steps coin flip:
     // every Pokemon being damaged (on either side, active or benched) that
@@ -152,7 +155,9 @@ fn apply_defender_damage_prevention_if_needed(
             .unwrap_or(false);
 
         if defender_has_coin_flip_prevent {
-            return apply_defender_coin_flip_prevent_damage(outcomes);
+            return AttackOutcomes::opaque(apply_defender_coin_flip_prevent_damage(
+                outcomes.into_outcomes(),
+            ));
         }
     }
 
@@ -180,7 +185,12 @@ fn target_has_coin_flip_prevent_damage(
         .unwrap_or(false)
 }
 
-fn forecast_attack_inner(state: &State, card: &Card, attack: &Attack, _index: usize) -> Outcomes {
+fn forecast_attack_inner(
+    state: &State,
+    card: &Card,
+    attack: &Attack,
+    _index: usize,
+) -> AttackOutcomes {
     let Some(effect_text) = &attack.effect else {
         return active_damage_doutcome(attack.fixed_damage);
     };
@@ -232,7 +242,7 @@ fn forecast_effect_attack_by_mechanic(
     state: &State,
     attack: &Attack,
     mechanic: &Mechanic,
-) -> Outcomes {
+) -> AttackOutcomes {
     match mechanic {
         Mechanic::CelebiExPowerfulBloom => celebi_powerful_bloom(state),
         Mechanic::CoinFlipPerSpecificEnergyType {
@@ -286,19 +296,21 @@ fn forecast_effect_attack_by_mechanic(
         } => energy_bench_attack(energies.clone(), *target_benched_type, state, attack),
         Mechanic::VaporeonHyperWhirlpool => vaporeon_hyper_whirlpool(state, attack.fixed_damage),
         Mechanic::SearchToHandByEnergy { energy_type } => {
-            pokemon_search_outcomes_by_type(state, false, *energy_type)
+            AttackOutcomes::opaque(pokemon_search_outcomes_by_type(state, false, *energy_type))
         }
         Mechanic::SearchRandomPokemonToHand => {
-            pokemon_search_outcomes(state.current_player, state, false)
+            AttackOutcomes::opaque(pokemon_search_outcomes(state.current_player, state, false))
         }
         Mechanic::SearchToHandByEvolvesFrom { name } => {
-            search_to_hand_by_evolves_from(state, name.clone())
+            AttackOutcomes::opaque(search_to_hand_by_evolves_from(state, name.clone()))
         }
         Mechanic::SearchToHandSupporterCard => {
-            supporter_search_outcomes(state.current_player, state)
+            AttackOutcomes::opaque(supporter_search_outcomes(state.current_player, state))
         }
-        Mechanic::SearchToBenchByName { name } => search_and_bench_by_name(state, name.clone()),
-        Mechanic::SearchToBenchBasic => search_and_bench_basic(state),
+        Mechanic::SearchToBenchByName { name } => {
+            AttackOutcomes::opaque(search_and_bench_by_name(state, name.clone()))
+        }
+        Mechanic::SearchToBenchBasic => AttackOutcomes::opaque(search_and_bench_basic(state)),
         Mechanic::InflictStatusConditions {
             conditions,
             target_opponent,
@@ -765,7 +777,7 @@ fn copy_attack(
     _state: &State,
     source: &CopyAttackSource,
     require_attacker_energy_match: bool,
-) -> Outcomes {
+) -> AttackOutcomes {
     let source = source.clone();
     active_damage_effect_doutcome(0, move |_, state, action| {
         let choices =
@@ -847,8 +859,8 @@ fn is_copy_attack(attack: &Attack) -> bool {
         .is_some_and(|mechanic| matches!(mechanic, Mechanic::CopyAttack { .. }))
 }
 
-fn recoil_if_ko_attack(damage: u32, self_damage: u32) -> Outcomes {
-    Outcomes::single(Box::new(move |_, state, action| {
+fn recoil_if_ko_attack(damage: u32, self_damage: u32) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::single(Box::new(move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         let attacking_ref = (action.actor, 0);
 
@@ -869,32 +881,32 @@ fn recoil_if_ko_attack(damage: u32, self_damage: u32) -> Outcomes {
         }
 
         handle_knockouts(state, attacking_ref, true);
-    }))
+    })))
 }
 
-fn coinflip_no_effect(fixed_damage: u32) -> Outcomes {
-    Outcomes::binary_coin(
+fn coinflip_no_effect(fixed_damage: u32) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_mutation(fixed_damage),
         active_damage_mutation(0),
-    )
+    ))
 }
 
-fn coinflip_extra_damage_attack(base_damage: u32, extra_damage: u32) -> Outcomes {
-    Outcomes::binary_coin(
+fn coinflip_extra_damage_attack(base_damage: u32, extra_damage: u32) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_mutation(base_damage + extra_damage),
         active_damage_mutation(base_damage),
-    )
+    ))
 }
 
 /// Used for attacks that deal damage and damage themselves only on tails.
-fn coinflip_self_damage_attack(base_damage: u32, self_damage: u32) -> Outcomes {
-    Outcomes::binary_coin(
+fn coinflip_self_damage_attack(base_damage: u32, self_damage: u32) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_mutation(base_damage),
         active_damage_effect_mutation(base_damage, move |_, state, action| {
             let active = state.get_active_mut(action.actor);
             active.apply_damage(self_damage);
         }),
-    )
+    ))
 }
 
 fn discard_self_energy_per_heads_extra_damage_attack(
@@ -902,8 +914,8 @@ fn discard_self_energy_per_heads_extra_damage_attack(
     num_coins: usize,
     energy_type: EnergyType,
     damage_per_discarded_energy: u32,
-) -> Outcomes {
-    Outcomes::binomial_by_heads(num_coins, move |heads| {
+) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binomial_by_heads(num_coins, move |heads| {
         Box::new(move |_, state, action| {
             let requested = vec![energy_type; heads];
             let actual = {
@@ -921,41 +933,43 @@ fn discard_self_energy_per_heads_extra_damage_attack(
             handle_damage_only(state, attacking_ref, &[(damage, opponent, 0)], true, None);
             handle_knockouts(state, attacking_ref, true);
         })
-    })
+    }))
 }
 
-fn both_heads_bonus_damage_attack(base_damage: u32, extra_damage: u32) -> Outcomes {
-    Outcomes::from_coin_branches(vec![
-        (
-            0.25,
-            active_damage_mutation(base_damage + extra_damage),
-            vec![CoinSeq(vec![true, true])],
-        ),
-        (
-            0.75,
-            active_damage_mutation(base_damage),
-            vec![
-                CoinSeq(vec![true, false]),
-                CoinSeq(vec![false, true]),
-                CoinSeq(vec![false, false]),
-            ],
-        ),
-    ])
-    .expect("ExtraDamageIfBothHeads branches should be valid")
+fn both_heads_bonus_damage_attack(base_damage: u32, extra_damage: u32) -> AttackOutcomes {
+    AttackOutcomes::opaque(
+        Outcomes::from_coin_branches(vec![
+            (
+                0.25,
+                active_damage_mutation(base_damage + extra_damage),
+                vec![CoinSeq(vec![true, true])],
+            ),
+            (
+                0.75,
+                active_damage_mutation(base_damage),
+                vec![
+                    CoinSeq(vec![true, false]),
+                    CoinSeq(vec![false, true]),
+                    CoinSeq(vec![false, false]),
+                ],
+            ),
+        ])
+        .expect("ExtraDamageIfBothHeads branches should be valid"),
+    )
 }
 
-fn celebi_powerful_bloom(state: &State) -> Outcomes {
+fn celebi_powerful_bloom(state: &State) -> AttackOutcomes {
     let active_pokemon = state.get_active(state.current_player);
     let total_energy = active_pokemon.attached_energy.len();
 
     if total_energy == 0 {
         // No energy attached, no coins to flip
-        return Outcomes::single(active_damage_mutation(0));
+        return AttackOutcomes::opaque(Outcomes::single(active_damage_mutation(0)));
     }
 
-    Outcomes::binomial_by_heads(total_energy, move |heads| {
+    AttackOutcomes::opaque(Outcomes::binomial_by_heads(total_energy, move |heads| {
         active_damage_mutation((heads as u32) * 50)
-    })
+    }))
 }
 
 fn coin_flip_per_specific_energy_type(
@@ -964,7 +978,7 @@ fn coin_flip_per_specific_energy_type(
     energy_type: EnergyType,
     include_fixed_damage: bool,
     damage_per_heads: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let active_pokemon = state.get_active(state.current_player);
     let energy_count = active_pokemon
         .attached_energy
@@ -974,12 +988,12 @@ fn coin_flip_per_specific_energy_type(
 
     let base_damage = if include_fixed_damage { base_damage } else { 0 };
 
-    Outcomes::binomial_by_heads(energy_count, move |heads| {
+    AttackOutcomes::opaque(Outcomes::binomial_by_heads(energy_count, move |heads| {
         active_damage_mutation(base_damage + (heads as u32) * damage_per_heads)
-    })
+    }))
 }
 
-fn mega_kangaskhan_ex_double_punching_family(attack: &Attack) -> Outcomes {
+fn mega_kangaskhan_ex_double_punching_family(attack: &Attack) -> AttackOutcomes {
     active_damage_effect_doutcome(attack.fixed_damage, |_, state, action| {
         // Force Handle K.O., to maybe .insert(0 promotions to the move_generation_stack
         let attacking_ref = (action.actor, 0);
@@ -1004,7 +1018,7 @@ fn mega_kangaskhan_ex_double_punching_family(attack: &Attack) -> Outcomes {
 }
 
 /// For Magikarp's Waterfall Evolution: Put a random card from your deck that evolves from this Pokémon onto this Pokémon to evolve it.
-fn waterfall_evolution(state: &State) -> Outcomes {
+fn waterfall_evolution(state: &State) -> AttackOutcomes {
     let active_pokemon = state.get_active(state.current_player);
 
     // Find all cards in deck that can evolve from the active Pokemon
@@ -1016,9 +1030,9 @@ fn waterfall_evolution(state: &State) -> Outcomes {
         .collect();
     if evolution_cards.is_empty() {
         // No evolution cards in deck, just shuffle
-        return Outcomes::single_fn(|rng, state, action| {
+        return AttackOutcomes::opaque(Outcomes::single_fn(|rng, state, action| {
             state.decks[action.actor].shuffle(false, rng);
-        });
+        }));
     }
 
     // Generate outcomes for each possible evolution card
@@ -1035,11 +1049,11 @@ fn waterfall_evolution(state: &State) -> Outcomes {
         }));
     }
 
-    Outcomes::from_parts(probabilities, outcomes)
+    AttackOutcomes::opaque(Outcomes::from_parts(probabilities, outcomes))
 }
 
 /// For Manaphy's Oceanic attack: Choose 2 benched Pokémon and attach Water Energy to each
-fn manaphy_oceanic() -> Outcomes {
+fn manaphy_oceanic() -> AttackOutcomes {
     active_damage_effect_doutcome(0, move |_, state, action| {
         let benched_pokemon: Vec<usize> = state
             .enumerate_bench_pokemon(action.actor)
@@ -1074,7 +1088,7 @@ fn manaphy_oceanic() -> Outcomes {
     })
 }
 
-fn palkia_dimensional_storm(state: &State) -> Outcomes {
+fn palkia_dimensional_storm(state: &State) -> AttackOutcomes {
     // This attack does 150 damage to Active, and 20 to every bench pokemon
     // it then also discards 3 energies. This is deterministic
     let targets: Vec<(u32, bool, usize)> = state
@@ -1091,8 +1105,8 @@ fn palkia_dimensional_storm(state: &State) -> Outcomes {
     })
 }
 
-fn moltres_inferno_dance() -> Outcomes {
-    Outcomes::binomial_by_heads(3, move |heads| {
+fn moltres_inferno_dance() -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binomial_by_heads(3, move |heads| {
         active_damage_effect_mutation(0, move |_, state, action| {
             if heads == 0 {
                 return;
@@ -1117,10 +1131,14 @@ fn moltres_inferno_dance() -> Outcomes {
                     .push((action.actor, all_choices));
             }
         })
-    })
+    }))
 }
 
-fn charge_energy_any_way_to_type(damage: u32, energy_type: EnergyType, count: usize) -> Outcomes {
+fn charge_energy_any_way_to_type(
+    damage: u32,
+    energy_type: EnergyType,
+    count: usize,
+) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let target_indices = collect_in_play_indices_by_type(state, action.actor, energy_type);
         let choices = energy_any_way_choices(&target_indices, energy_type, count);
@@ -1134,7 +1152,7 @@ fn move_all_energy_type_to_bench(
     state: &State,
     attack: &Attack,
     energy_type: EnergyType,
-) -> Outcomes {
+) -> AttackOutcomes {
     // Count how many of the specified energy type the active Pokemon has
     let active = state.get_active(state.current_player);
     let energy_count = active
@@ -1201,7 +1219,7 @@ fn move_fixed_energy_type_to_bench(
     attack: &Attack,
     energy_type: EnergyType,
     amount: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let active = state.get_active(state.current_player);
     let energy_count = active
         .attached_energy
@@ -1283,15 +1301,15 @@ fn damage_for_each_heads_attack(
     damage_per_head: u32,
     num_coins: usize,
     attack: &Attack,
-) -> Outcomes {
+) -> AttackOutcomes {
     let fixed_damage = if include_fixed_damage {
         attack.fixed_damage
     } else {
         0
     };
-    Outcomes::binomial_by_heads(num_coins, move |heads_count| {
+    AttackOutcomes::opaque(Outcomes::binomial_by_heads(num_coins, move |heads_count| {
         active_damage_mutation(fixed_damage + damage_per_head * heads_count as u32)
-    })
+    }))
 }
 
 /// Deal damage and attach energy to a pokemon of choice in the bench.
@@ -1300,7 +1318,7 @@ pub(crate) fn energy_bench_attack(
     target_benched_type: Option<EnergyType>,
     state: &State,
     attack: &Attack,
-) -> Outcomes {
+) -> AttackOutcomes {
     let choices = state
         .enumerate_bench_pokemon(state.current_player)
         .filter(|(_, played_card)| {
@@ -1325,21 +1343,25 @@ pub(crate) fn energy_bench_attack(
 }
 
 /// Used for attacks that on heads deal extra damage, on tails deal self damage.
-fn extra_or_self_damage_attack(base_damage: u32, extra_damage: u32, self_damage: u32) -> Outcomes {
-    Outcomes::binary_coin(
+fn extra_or_self_damage_attack(
+    base_damage: u32,
+    extra_damage: u32,
+    self_damage: u32,
+) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_mutation(base_damage + extra_damage),
         active_damage_effect_mutation(base_damage, move |_, state, action| {
             let active = state.get_active_mut(action.actor);
             active.apply_damage(self_damage);
         }),
-    )
+    ))
 }
 
-fn damage_chance_status_attack(damage: u32, status: StatusCondition) -> Outcomes {
-    Outcomes::binary_coin(
+fn damage_chance_status_attack(damage: u32, status: StatusCondition) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_effect_mutation(damage, build_status_effect(status)),
         active_damage_mutation(damage),
-    )
+    ))
 }
 
 /// For attacks that do damage based on benched Pokemon count (new Mechanic-based approach).
@@ -1350,7 +1372,7 @@ fn bench_count_damage_attack(
     damage_per: u32,
     energy_type: Option<EnergyType>,
     bench_side: &BenchSide,
-) -> Outcomes {
+) -> AttackOutcomes {
     let current_player = state.current_player;
     let opponent = (current_player + 1) % 2;
 
@@ -1381,7 +1403,7 @@ fn evolution_bench_count_damage_attack(
     base_damage: u32,
     include_base_damage: bool,
     damage_per: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let current_player = state.current_player;
     let evolution_count = state
         .enumerate_bench_pokemon(current_player)
@@ -1407,7 +1429,7 @@ fn also_choice_bench_damage(
     opponent: bool,
     active_damage: u32,
     bench_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let opponent_player = (state.current_player + 1) % 2;
     let bench_target = if opponent {
         opponent_player
@@ -1428,16 +1450,16 @@ fn also_choice_bench_damage(
             }
         })
         .collect();
-    Outcomes::single(Box::new(
+    AttackOutcomes::opaque(Outcomes::single(Box::new(
         move |_: &mut StdRng, state: &mut State, action: &Action| {
             if !choices.is_empty() {
                 state.move_generation_stack.push((action.actor, choices));
             }
         },
-    ))
+    )))
 }
 
-fn self_charge_active_from_energies(damage: u32, energies: Vec<EnergyType>) -> Outcomes {
+fn self_charge_active_from_energies(damage: u32, energies: Vec<EnergyType>) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         for energy in &energies {
             if state.in_play_pokemon[action.actor][0].is_none() {
@@ -1449,8 +1471,8 @@ fn self_charge_active_from_energies(damage: u32, energies: Vec<EnergyType>) -> O
     })
 }
 
-fn coin_flip_self_charge_active(damage: u32, energies: Vec<EnergyType>) -> Outcomes {
-    Outcomes::binary_coin(
+fn coin_flip_self_charge_active(damage: u32, energies: Vec<EnergyType>) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_effect_mutation(damage, move |_, state, action| {
             for energy in &energies {
                 if state.in_play_pokemon[action.actor][0].is_none() {
@@ -1461,12 +1483,12 @@ fn coin_flip_self_charge_active(damage: u32, energies: Vec<EnergyType>) -> Outco
             }
         }),
         active_damage_mutation(damage),
-    )
+    ))
 }
 
 /// Used for attacks that can go directly to bench.
 /// It will queue (via move_generation_stack) for the user to choose a pokemon to damage.
-fn direct_damage(damage: u32, bench_only: bool) -> Outcomes {
+fn direct_damage(damage: u32, bench_only: bool) -> AttackOutcomes {
     active_damage_effect_doutcome(0, move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         let mut choices = Vec::new();
@@ -1494,7 +1516,7 @@ fn direct_damage(damage: u32, bench_only: bool) -> Outcomes {
     })
 }
 
-fn delayed_spot_damage(damage: u32) -> Outcomes {
+fn delayed_spot_damage(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(0, move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         let mut choices = Vec::new();
@@ -1514,7 +1536,7 @@ fn delayed_spot_damage(damage: u32) -> Outcomes {
 
 /// For attacks that can target opponent's Pokémon that have damage on them.
 /// e.g. Decidueye ex's Pierce the Pain
-fn direct_damage_if_damaged(damage: u32) -> Outcomes {
+fn direct_damage_if_damaged(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(0, move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         let mut choices = Vec::new();
@@ -1538,7 +1560,7 @@ fn direct_damage_if_damaged(damage: u32) -> Outcomes {
 fn discard_all_energy_of_type_then_damage_any_opponent_pokemon(
     energy_type: EnergyType,
     damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     active_damage_effect_doutcome(0, move |_, state, action| {
         // Count and discard all matching energy from the attacking Pokémon.
         let active = state.get_active(action.actor);
@@ -1596,7 +1618,7 @@ fn discard_requested_energy_from_active_best_effort(
 }
 
 /// Discard energy from the active (attacking) Pokémon.
-fn self_energy_discard_attack(fixed_damage: u32, to_discard: Vec<EnergyType>) -> Outcomes {
+fn self_energy_discard_attack(fixed_damage: u32, to_discard: Vec<EnergyType>) -> AttackOutcomes {
     active_damage_effect_doutcome(fixed_damage, move |_, state, action| {
         discard_requested_energy_from_active_best_effort(state, action.actor, &to_discard);
     })
@@ -1606,7 +1628,7 @@ fn self_discard_energy_and_inflict_status(
     fixed_damage: u32,
     to_discard: Vec<EnergyType>,
     conditions: Vec<StatusCondition>,
-) -> Outcomes {
+) -> AttackOutcomes {
     active_damage_effect_doutcome(fixed_damage, move |_, state, action| {
         discard_requested_energy_from_active_best_effort(state, action.actor, &to_discard);
 
@@ -1622,7 +1644,7 @@ fn self_discard_energy_and_card_effect(
     to_discard: Vec<EnergyType>,
     effect: CardEffect,
     duration: u8,
-) -> Outcomes {
+) -> AttackOutcomes {
     active_damage_effect_doutcome(fixed_damage, move |_, state, action| {
         discard_requested_energy_from_active_best_effort(state, action.actor, &to_discard);
         state
@@ -1632,7 +1654,7 @@ fn self_discard_energy_and_card_effect(
 }
 
 /// For attacks that deal damage and discard random energy from opponent's active Pokémon
-fn damage_and_discard_energy(damage: u32, discard_count: usize) -> Outcomes {
+fn damage_and_discard_energy(damage: u32, discard_count: usize) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |rng, state, action| {
         let opponent = (action.actor + 1) % 2;
         let mut to_discard = Vec::new();
@@ -1654,8 +1676,8 @@ fn damage_and_discard_energy(damage: u32, discard_count: usize) -> Outcomes {
     })
 }
 
-fn discard_opponent_active_tools_before_damage(damage: u32, attack_name: String) -> Outcomes {
-    Outcomes::single(Box::new(move |_, state, action| {
+fn discard_opponent_active_tools_before_damage(damage: u32, attack_name: String) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::single(Box::new(move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         if state.in_play_pokemon[opponent][0]
             .as_ref()
@@ -1673,10 +1695,10 @@ fn discard_opponent_active_tools_before_damage(damage: u32, attack_name: String)
             Some(attack_name.as_str()),
         );
         handle_knockouts(state, attacking_ref, true);
-    }))
+    })))
 }
 
-fn discard_top_self_deck(damage: u32) -> Outcomes {
+fn discard_top_self_deck(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, |_, state, action| {
         if let Some(card) = state.decks[action.actor].draw() {
             state.discard_piles[action.actor].push(card);
@@ -1688,15 +1710,15 @@ fn tiered_coin_flip_damage(
     fixed_damage: u32,
     num_coins: usize,
     extra_damage_by_heads: Vec<u32>,
-) -> Outcomes {
-    Outcomes::binomial_by_heads(num_coins, move |heads| {
+) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binomial_by_heads(num_coins, move |heads| {
         let extra = extra_damage_by_heads.get(heads).copied().unwrap_or(0);
         active_damage_mutation(fixed_damage + extra)
-    })
+    }))
 }
 
 /// For attacks that deal damage and discard cards from the top of opponent's deck
-fn damage_and_discard_opponent_deck(damage: u32, discard_count: usize) -> Outcomes {
+fn damage_and_discard_opponent_deck(damage: u32, discard_count: usize) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
 
@@ -1710,35 +1732,38 @@ fn damage_and_discard_opponent_deck(damage: u32, discard_count: usize) -> Outcom
     })
 }
 
-fn vaporeon_hyper_whirlpool(_state: &State, damage: u32) -> Outcomes {
+fn vaporeon_hyper_whirlpool(_state: &State, damage: u32) -> AttackOutcomes {
     // Flip coins until tails - capped at 5 heads for practicality
-    Outcomes::geometric_until_tails(5, move |energies_to_remove| {
-        active_damage_effect_mutation(damage, move |_, state, action| {
-            let opponent = (action.actor + 1) % 2;
-            let mut to_discard = Vec::new();
-            let mut remaining = state.get_active(opponent).attached_energy.clone();
+    AttackOutcomes::opaque(Outcomes::geometric_until_tails(
+        5,
+        move |energies_to_remove| {
+            active_damage_effect_mutation(damage, move |_, state, action| {
+                let opponent = (action.actor + 1) % 2;
+                let mut to_discard = Vec::new();
+                let mut remaining = state.get_active(opponent).attached_energy.clone();
 
-            // Collect energies to discard
-            for _ in 0..energies_to_remove {
-                if remaining.is_empty() {
-                    break; // No more energy to discard
+                // Collect energies to discard
+                for _ in 0..energies_to_remove {
+                    if remaining.is_empty() {
+                        break; // No more energy to discard
+                    }
+                    // NOTE: Using last energy instead of random selection to avoid expanding the game tree.
+                    // This is a simplification - the card text says "random Energy" but we always
+                    // remove the last one for performance reasons.
+                    to_discard.push(remaining.pop().expect("already checked non-empty"));
                 }
-                // NOTE: Using last energy instead of random selection to avoid expanding the game tree.
-                // This is a simplification - the card text says "random Energy" but we always
-                // remove the last one for performance reasons.
-                to_discard.push(remaining.pop().expect("already checked non-empty"));
-            }
 
-            // Discard collected energies properly (moves to discard pile)
-            if !to_discard.is_empty() {
-                state.discard_from_active(opponent, &to_discard);
-            }
-        })
-    })
+                // Discard collected energies properly (moves to discard pile)
+                if !to_discard.is_empty() {
+                    state.discard_from_active(opponent, &to_discard);
+                }
+            })
+        },
+    ))
 }
 
 /// For attacks that deal damage to opponent and also damage themselves
-fn self_damage_attack(damage: u32, self_damage: u32) -> Outcomes {
+fn self_damage_attack(damage: u32, self_damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let active = state.get_active_mut(action.actor);
         active.apply_damage(self_damage);
@@ -1746,7 +1771,10 @@ fn self_damage_attack(damage: u32, self_damage: u32) -> Outcomes {
 }
 
 /// For attacks that deal damage and apply multiple status effects to opponent (e.g. Mega Venusaur Critical Bloom)
-fn damage_multiple_status_attack(statuses: Vec<StatusCondition>, attack: &Attack) -> Outcomes {
+fn damage_multiple_status_attack(
+    statuses: Vec<StatusCondition>,
+    attack: &Attack,
+) -> AttackOutcomes {
     active_damage_effect_doutcome(attack.fixed_damage, move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         for status in &statuses {
@@ -1756,7 +1784,10 @@ fn damage_multiple_status_attack(statuses: Vec<StatusCondition>, attack: &Attack
 }
 
 /// For attacks that deal damage to opponent and apply multiple status effects to the attacker (e.g. Snorlax Collapse)
-fn damage_and_self_multiple_status_attack(damage: u32, statuses: Vec<StatusCondition>) -> Outcomes {
+fn damage_and_self_multiple_status_attack(
+    damage: u32,
+    statuses: Vec<StatusCondition>,
+) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         for status in &statuses {
             state.apply_status_condition(action.actor, 0, *status);
@@ -1765,7 +1796,7 @@ fn damage_and_self_multiple_status_attack(damage: u32, statuses: Vec<StatusCondi
 }
 
 /// Draw cards and deal damage in the same attack.
-fn draw_and_damage_outcome(damage: u32, amount: u8) -> Outcomes {
+fn draw_and_damage_outcome(damage: u32, amount: u8) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         state
             .move_generation_stack
@@ -1773,8 +1804,8 @@ fn draw_and_damage_outcome(damage: u32, amount: u8) -> Outcomes {
     })
 }
 
-fn heal_one_your_pokemon_attack(amount: u32) -> Outcomes {
-    Outcomes::single_fn(move |_rng, state, action| {
+fn heal_one_your_pokemon_attack(amount: u32) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::single_fn(move |_rng, state, action| {
         let choices = state
             .enumerate_in_play_pokemon(action.actor)
             .filter(|(_, pokemon)| pokemon.is_damaged())
@@ -1787,11 +1818,11 @@ fn heal_one_your_pokemon_attack(amount: u32) -> Outcomes {
         if !choices.is_empty() {
             state.move_generation_stack.push((action.actor, choices));
         }
-    })
+    }))
 }
 
-fn heal_one_your_benched_pokemon_attack(amount: u32) -> Outcomes {
-    Outcomes::single_fn(move |_rng, state, action| {
+fn heal_one_your_benched_pokemon_attack(amount: u32) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::single_fn(move |_rng, state, action| {
         let choices = state
             .enumerate_bench_pokemon(action.actor)
             .filter(|(_, pokemon)| pokemon.is_damaged())
@@ -1804,10 +1835,10 @@ fn heal_one_your_benched_pokemon_attack(amount: u32) -> Outcomes {
         if !choices.is_empty() {
             state.move_generation_stack.push((action.actor, choices));
         }
-    })
+    }))
 }
 
-fn heal_all_your_pokemon_attack(damage: u32, heal: u32) -> Outcomes {
+fn heal_all_your_pokemon_attack(damage: u32, heal: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         heal_all_pokemon(state, action.actor, heal);
     })
@@ -1819,13 +1850,13 @@ fn heal_all_pokemon(state: &mut State, player: usize, amount: u32) {
     }
 }
 
-fn coin_flip_self_heal_attack(damage: u32, heal: u32) -> Outcomes {
-    Outcomes::binary_coin(
+fn coin_flip_self_heal_attack(damage: u32, heal: u32) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_effect_mutation(damage, move |_, state, action| {
             state.get_active_mut(action.actor).heal(heal);
         }),
         active_damage_mutation(damage),
-    )
+    ))
 }
 
 /// Generic attack that deals bonus damage if the Pokémon has enough energy of a specific type attached.
@@ -1835,7 +1866,7 @@ fn extra_energy_attack(
     attack: &Attack,
     required_extra_energy: Vec<EnergyType>,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let pokemon = state.in_play_pokemon[state.current_player][0]
         .as_ref()
         .expect("Active Pokemon should be there if attacking");
@@ -1864,7 +1895,7 @@ fn extra_damage_if_different_energy_types_attack(
     base_damage: u32,
     minimum_types: usize,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let pokemon = state.in_play_pokemon[state.current_player][0]
         .as_ref()
         .expect("Active Pokemon should be there if attacking");
@@ -1885,21 +1916,21 @@ fn extra_damage_if_different_energy_types_attack(
 
 /// For attacks that flip a coin until tails, dealing damage for each heads.
 /// Uses geometric distribution truncated at a reasonable number to avoid infinite outcomes.
-fn flip_until_tails_attack(damage_per_heads: u32) -> Outcomes {
+fn flip_until_tails_attack(damage_per_heads: u32) -> AttackOutcomes {
     // Truncate at 8 heads to keep the probability space manageable.
-    Outcomes::geometric_until_tails(8, move |heads| {
+    AttackOutcomes::opaque(Outcomes::geometric_until_tails(8, move |heads| {
         active_damage_mutation((heads as u32) * damage_per_heads)
-    })
+    }))
 }
 
-fn self_heal_attack(heal: u32, attack: &Attack) -> Outcomes {
+fn self_heal_attack(heal: u32, attack: &Attack) -> AttackOutcomes {
     active_damage_effect_doutcome(attack.fixed_damage, move |_, state, action| {
         let active = state.get_active_mut(action.actor);
         active.heal(heal);
     })
 }
 
-fn self_heal_if_stadium_in_play(state: &State, damage: u32, heal: u32) -> Outcomes {
+fn self_heal_if_stadium_in_play(state: &State, damage: u32, heal: u32) -> AttackOutcomes {
     if state.active_stadium.is_some() {
         active_damage_effect_doutcome(damage, move |_, state, action| {
             state.get_active_mut(action.actor).heal(heal);
@@ -1913,7 +1944,7 @@ fn inflict_status_if_stadium_in_play(
     state: &State,
     damage: u32,
     status: StatusCondition,
-) -> Outcomes {
+) -> AttackOutcomes {
     if state.active_stadium.is_some() {
         active_damage_effect_doutcome(damage, move |_, state, action| {
             let opponent = (action.actor + 1) % 2;
@@ -1925,7 +1956,7 @@ fn inflict_status_if_stadium_in_play(
 }
 
 /// For attacks that put this Pokémon to sleep and heal it (e.g. Slowpoke's Rest).
-fn self_asleep_and_heal_attack(heal: u32, damage: u32) -> Outcomes {
+fn self_asleep_and_heal_attack(heal: u32, damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         state.apply_status_condition(action.actor, 0, StatusCondition::Asleep);
         state.get_active_mut(action.actor).heal(heal);
@@ -1939,13 +1970,13 @@ fn flip_coins_bench_damage_per_head(
     fixed_damage: u32,
     num_coins: usize,
     bench_damage_per_head: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     let bench_indices: Vec<usize> = state
         .enumerate_bench_pokemon(opponent)
         .map(|(idx, _)| idx)
         .collect();
-    Outcomes::binomial_by_heads(num_coins, move |heads| {
+    AttackOutcomes::opaque(Outcomes::binomial_by_heads(num_coins, move |heads| {
         let bench_dmg = heads as u32 * bench_damage_per_head;
         let bench_indices = bench_indices.clone();
         Box::new(move |_: &mut StdRng, state: &mut State, action: &Action| {
@@ -1959,10 +1990,14 @@ fn flip_coins_bench_damage_per_head(
             }
             handle_damage(state, attacking_ref, &targets, true, None);
         })
-    })
+    }))
 }
 
-fn damage_and_turn_effect_attack(damage: u32, effect: TurnEffect, effect_duration: u8) -> Outcomes {
+fn damage_and_turn_effect_attack(
+    damage: u32,
+    effect: TurnEffect,
+    effect_duration: u8,
+) -> AttackOutcomes {
     let effect_clone = effect.clone();
     active_damage_effect_doutcome(damage, move |_, state, _| {
         state.add_turn_effect(effect_clone.clone(), effect_duration);
@@ -1975,7 +2010,7 @@ fn damage_and_card_effect_attack(
     effect: CardEffect,
     effect_duration: u8,
     coin_flip: bool,
-) -> Outcomes {
+) -> AttackOutcomes {
     let effect_on_target = move |_: &mut StdRng, state: &mut State, action: &Action| {
         let player = if opponent {
             (action.actor + 1) % 2
@@ -1988,10 +2023,10 @@ fn damage_and_card_effect_attack(
     };
 
     if coin_flip {
-        Outcomes::binary_coin(
+        AttackOutcomes::opaque(Outcomes::binary_coin(
             active_damage_effect_mutation(damage, effect_on_target),
             active_damage_mutation(damage),
-        )
+        ))
     } else {
         active_damage_effect_doutcome(damage, effect_on_target)
     }
@@ -2002,7 +2037,7 @@ fn coin_flip_no_damage_or_damage_and_card_effect_attack(
     opponent: bool,
     effect: CardEffect,
     effect_duration: u8,
-) -> Outcomes {
+) -> AttackOutcomes {
     let effect_on_target = move |_: &mut StdRng, state: &mut State, action: &Action| {
         let player = if opponent {
             (action.actor + 1) % 2
@@ -2014,21 +2049,21 @@ fn coin_flip_no_damage_or_damage_and_card_effect_attack(
             .add_effect(effect.clone(), effect_duration);
     };
 
-    Outcomes::binary_coin(
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_effect_mutation(damage, effect_on_target),
         active_damage_mutation(0),
-    )
+    ))
 }
 
 /// Discard all energy from this Pokemon
-fn damage_and_discard_all_energy(damage: u32) -> Outcomes {
+fn damage_and_discard_all_energy(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let active = state.get_active_mut(action.actor);
         active.attached_energy.clear(); // Discard all energy
     })
 }
 
-fn damage_and_discard_random_energy(damage: u32) -> Outcomes {
+fn damage_and_discard_random_energy(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |rng, state, action| {
         let active = state.get_active(action.actor);
         if !active.attached_energy.is_empty() {
@@ -2040,7 +2075,7 @@ fn damage_and_discard_random_energy(damage: u32) -> Outcomes {
 }
 
 /// For attacks that discard all energy of a specific type after dealing damage.
-fn discard_all_energy_of_type_attack(damage: u32, energy_type: EnergyType) -> Outcomes {
+fn discard_all_energy_of_type_attack(damage: u32, energy_type: EnergyType) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         // Collect all energy of the specified type from the active Pokémon
         let to_discard: Vec<EnergyType> = state
@@ -2060,7 +2095,7 @@ fn discard_random_global_energy_attack(
     fixed_damage: u32,
     count: usize,
     _state: &State,
-) -> Outcomes {
+) -> AttackOutcomes {
     active_damage_effect_doutcome(fixed_damage, move |rng, state, _action| {
         for _ in 0..count {
             let mut pokemon_with_energy: Vec<(usize, usize, usize)> = Vec::new();
@@ -2115,7 +2150,7 @@ fn also_bench_damage(
     active_damage: u32,
     bench_damage: u32,
     must_have_energy: bool,
-) -> Outcomes {
+) -> AttackOutcomes {
     let player = if opponent {
         (state.current_player + 1) % 2
     } else {
@@ -2137,7 +2172,7 @@ fn also_bench_damage(
 }
 
 /// Deals the same damage to all of opponent's Pokémon (active and bench) - like Spiritomb/Clawitzer
-fn damage_all_opponent_pokemon(state: &State, damage: u32) -> Outcomes {
+fn damage_all_opponent_pokemon(state: &State, damage: u32) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     // Collect all opponent's Pokémon (active at index 0, plus bench)
     let targets: Vec<(u32, bool, usize)> = state
@@ -2152,7 +2187,7 @@ fn extra_damage_if_self_hp_at_most(
     base: u32,
     threshold: u32,
     extra: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let attacker = state.get_active(state.current_player);
     if attacker.get_remaining_hp() <= threshold {
         active_damage_doutcome(base + extra)
@@ -2161,7 +2196,11 @@ fn extra_damage_if_self_hp_at_most(
     }
 }
 
-fn extra_damage_if_opponent_hp_more_than_self(state: &State, base: u32, extra: u32) -> Outcomes {
+fn extra_damage_if_opponent_hp_more_than_self(
+    state: &State,
+    base: u32,
+    extra: u32,
+) -> AttackOutcomes {
     let attacker = state.get_active(state.current_player);
     let opponent = state.get_active((state.current_player + 1) % 2);
     if opponent.get_remaining_hp() > attacker.get_remaining_hp() {
@@ -2171,14 +2210,18 @@ fn extra_damage_if_opponent_hp_more_than_self(state: &State, base: u32, extra: u
     }
 }
 
-fn extra_damage_if_opponent_active_has_ability(state: &State, base: u32, extra: u32) -> Outcomes {
+fn extra_damage_if_opponent_active_has_ability(
+    state: &State,
+    base: u32,
+    extra: u32,
+) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     let opponent_active = state.get_active(opponent);
     let has_ability = opponent_active.card.get_ability().is_some();
     active_damage_doutcome(if has_ability { base + extra } else { base })
 }
 
-fn extra_damage_if_hurt(state: &State, base: u32, extra: u32, opponent: bool) -> Outcomes {
+fn extra_damage_if_hurt(state: &State, base: u32, extra: u32, opponent: bool) -> AttackOutcomes {
     let target = if opponent {
         (state.current_player + 1) % 2
     } else {
@@ -2192,7 +2235,7 @@ fn extra_damage_if_hurt(state: &State, base: u32, extra: u32, opponent: bool) ->
     }
 }
 
-fn extra_damage_if_undamaged(state: &State, base: u32, extra: u32) -> Outcomes {
+fn extra_damage_if_undamaged(state: &State, base: u32, extra: u32) -> AttackOutcomes {
     let attacker = state.get_active(state.current_player);
     if attacker.is_damaged() {
         active_damage_doutcome(base)
@@ -2201,7 +2244,7 @@ fn extra_damage_if_undamaged(state: &State, base: u32, extra: u32) -> Outcomes {
     }
 }
 
-fn extra_damage_if_stage2_on_bench(state: &State, base: u32, extra: u32) -> Outcomes {
+fn extra_damage_if_stage2_on_bench(state: &State, base: u32, extra: u32) -> AttackOutcomes {
     let has_stage2 = state
         .enumerate_bench_pokemon(state.current_player)
         .any(|(_, p)| get_stage(p) == 2);
@@ -2217,7 +2260,7 @@ fn extra_damage_if_pokemon_on_bench(
     base: u32,
     pokemon_name: &str,
     extra: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let has_pokemon_on_bench = state
         .enumerate_bench_pokemon(state.current_player)
         .any(|(_, p)| p.get_name() == pokemon_name);
@@ -2228,19 +2271,23 @@ fn extra_damage_if_pokemon_on_bench(
     }
 }
 
-fn damage_equal_to_self_damage(state: &State) -> Outcomes {
+fn damage_equal_to_self_damage(state: &State) -> AttackOutcomes {
     let attacker = state.get_active(state.current_player);
     let damage = attacker.get_damage_counters();
     active_damage_doutcome(damage)
 }
 
-fn extra_damage_equal_to_self_damage(state: &State, base_damage: u32) -> Outcomes {
+fn extra_damage_equal_to_self_damage(state: &State, base_damage: u32) -> AttackOutcomes {
     let attacker = state.get_active(state.current_player);
     let self_damage = attacker.get_damage_counters();
     active_damage_doutcome(base_damage + self_damage)
 }
 
-fn extra_damage_per_energy_type(state: &State, base_damage: u32, damage_per_type: u32) -> Outcomes {
+fn extra_damage_per_energy_type(
+    state: &State,
+    base_damage: u32,
+    damage_per_type: u32,
+) -> AttackOutcomes {
     let attacker = state.get_active(state.current_player);
     let energies = attacker.get_effective_attached_energy(state, state.current_player);
     let mut seen = std::collections::HashSet::new();
@@ -2256,7 +2303,7 @@ fn extra_damage_per_energy(
     base_damage: u32,
     opponent: bool,
     damage_per_energy: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let target = if opponent {
         (state.current_player + 1) % 2
     } else {
@@ -2275,7 +2322,7 @@ fn extra_damage_per_retreat_cost(
     state: &State,
     base_damage: u32,
     damage_per_energy: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     let opponent_active = state.get_active(opponent);
     let retreat_cost = get_retreat_cost(state, opponent_active);
@@ -2283,7 +2330,7 @@ fn extra_damage_per_retreat_cost(
     active_damage_doutcome(damage)
 }
 
-fn damage_per_energy_all(state: &State, opponent: bool, damage_per_energy: u32) -> Outcomes {
+fn damage_per_energy_all(state: &State, opponent: bool, damage_per_energy: u32) -> AttackOutcomes {
     let target = if opponent {
         (state.current_player + 1) % 2
     } else {
@@ -2299,7 +2346,7 @@ fn damage_per_energy_all(state: &State, opponent: bool, damage_per_energy: u32) 
 }
 
 /// Choose 1 of the opponent's Pokémon; deal damage_per_energy × (energy on that Pokémon).
-fn damage_to_any_opponent_per_target_energy(damage_per_energy: u32) -> Outcomes {
+fn damage_to_any_opponent_per_target_energy(damage_per_energy: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(0, move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         let choices: Vec<SimpleAction> = state
@@ -2326,7 +2373,7 @@ fn extra_damage_per_specific_energy(
     base_damage: u32,
     energy_type: EnergyType,
     damage_per_energy: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let active = state.get_active(state.current_player);
     let matching_energy_count = active
         .attached_energy
@@ -2343,7 +2390,7 @@ fn extra_damage_if_type_energy_in_play_attack(
     energy_type: EnergyType,
     minimum_count: usize,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let total_in_play_type_energy: usize = state
         .enumerate_in_play_pokemon(state.current_player)
         .map(|(_, pokemon)| {
@@ -2362,7 +2409,11 @@ fn extra_damage_if_type_energy_in_play_attack(
     }
 }
 
-fn extra_damage_if_stadium_in_play(state: &State, base_damage: u32, extra_damage: u32) -> Outcomes {
+fn extra_damage_if_stadium_in_play(
+    state: &State,
+    base_damage: u32,
+    extra_damage: u32,
+) -> AttackOutcomes {
     if state.active_stadium.is_some() {
         active_damage_doutcome(base_damage + extra_damage)
     } else {
@@ -2370,7 +2421,11 @@ fn extra_damage_if_stadium_in_play(state: &State, base_damage: u32, extra_damage
     }
 }
 
-fn extra_damage_if_opponent_is_ex(state: &State, base_damage: u32, extra_damage: u32) -> Outcomes {
+fn extra_damage_if_opponent_is_ex(
+    state: &State,
+    base_damage: u32,
+    extra_damage: u32,
+) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     let opponent_active = state.get_active(opponent);
     let damage = if opponent_active.card.is_ex() {
@@ -2381,7 +2436,11 @@ fn extra_damage_if_opponent_is_ex(state: &State, base_damage: u32, extra_damage:
     active_damage_doutcome(damage)
 }
 
-fn extra_damage_if_tool_attached(state: &State, base_damage: u32, extra_damage: u32) -> Outcomes {
+fn extra_damage_if_tool_attached(
+    state: &State,
+    base_damage: u32,
+    extra_damage: u32,
+) -> AttackOutcomes {
     let active = state.get_active(state.current_player);
     let damage = if active.has_tool_attached() {
         base_damage + extra_damage
@@ -2395,7 +2454,7 @@ fn extra_damage_if_knocked_out_last_turn_attack(
     state: &State,
     base_damage: u32,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let damage = if state.knocked_out_by_opponent_attack_last_turn {
         base_damage + extra_damage
     } else {
@@ -2408,7 +2467,7 @@ fn extra_damage_if_moved_from_bench_attack(
     state: &State,
     base_damage: u32,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let moved = state.in_play_pokemon[state.current_player][0]
         .as_ref()
         .map(|p| p.moved_to_active_this_turn)
@@ -2425,7 +2484,7 @@ fn extra_damage_if_evolved_this_turn_attack(
     state: &State,
     base_damage: u32,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let evolved = state.in_play_pokemon[state.current_player][0]
         .as_ref()
         .map(|p| p.played_this_turn)
@@ -2438,7 +2497,7 @@ fn extra_damage_if_evolved_this_turn_attack(
     active_damage_doutcome(damage)
 }
 
-fn knock_back_attack(damage: u32) -> Outcomes {
+fn knock_back_attack(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         let mut choices = Vec::new();
@@ -2456,8 +2515,8 @@ fn knock_back_attack(damage: u32) -> Outcomes {
 }
 
 /// For Mawile's Crunch attack: deals 20 damage, flip a coin, if heads discard a random energy from opponent's active
-fn mawile_crunch() -> Outcomes {
-    Outcomes::binary_coin(
+fn mawile_crunch() -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_effect_mutation(20, move |rng, state, action| {
             // Heads: damage + discard random energy
             let opponent = (action.actor + 1) % 2;
@@ -2470,11 +2529,11 @@ fn mawile_crunch() -> Outcomes {
             }
         }),
         active_damage_mutation(20), // Tails: just damage
-    )
+    ))
 }
 
 /// For baby pokémon attacks: Attach an energy from Energy Zone to a benched Basic pokémon
-fn attach_energy_to_benched_basic(acting_player: usize, energy_type: EnergyType) -> Outcomes {
+fn attach_energy_to_benched_basic(acting_player: usize, energy_type: EnergyType) -> AttackOutcomes {
     active_damage_effect_doutcome(0, move |_, state, _| {
         let possible_moves = state
             .enumerate_bench_pokemon(acting_player)
@@ -2493,7 +2552,7 @@ fn attach_energy_to_benched_basic(acting_player: usize, energy_type: EnergyType)
 }
 
 /// For Silvally's Brave Buddies attack: 50 damage, or 100 damage if a Supporter was played this turn
-fn brave_buddies_attack(state: &State, fixed_damage: u32, extra_damage: u32) -> Outcomes {
+fn brave_buddies_attack(state: &State, fixed_damage: u32, extra_damage: u32) -> AttackOutcomes {
     if state.has_played_support {
         active_damage_doutcome(fixed_damage + extra_damage)
     } else {
@@ -2507,7 +2566,7 @@ fn unseen_claw_attack(
     state: &State,
     extra_damage: u32,
     fixed_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let opponent = (acting_player + 1) % 2;
     let opponent_active = state.get_active(opponent);
     let damage = if opponent_active.has_status_condition() {
@@ -2519,9 +2578,9 @@ fn unseen_claw_attack(
 }
 
 /// For Absol's Ominous Claw (B1 150): Deals 50 damage, flip coin, if heads discard a Supporter from opponent's hand
-fn ominous_claw_attack(acting_player: usize, fixed_damage: u32) -> Outcomes {
+fn ominous_claw_attack(acting_player: usize, fixed_damage: u32) -> AttackOutcomes {
     // 50% chance for heads (discard supporter), 50% for tails (just damage)
-    Outcomes::binary_coin(
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_effect_mutation(fixed_damage, move |_, state, _action| {
             let opponent = (acting_player + 1) % 2;
             let possible_discards: Vec<SimpleAction> = state
@@ -2539,11 +2598,11 @@ fn ominous_claw_attack(acting_player: usize, fixed_damage: u32) -> Outcomes {
         }),
         // Tails: just damage
         active_damage_mutation(fixed_damage),
-    )
+    ))
 }
 
 /// For Mega Absol ex's Darkness Claw: Deals 80 damage and lets player discard a Supporter from opponent's hand
-fn darkness_claw_attack(acting_player: usize, fixed_damage: u32) -> Outcomes {
+fn darkness_claw_attack(acting_player: usize, fixed_damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(fixed_damage, move |_, state, _action| {
         let opponent = (acting_player + 1) % 2;
         let possible_discards: Vec<SimpleAction> = state
@@ -2562,7 +2621,11 @@ fn darkness_claw_attack(acting_player: usize, fixed_damage: u32) -> Outcomes {
 }
 
 /// For Sableye's Dirty Throw (B1 101): Discard a card from hand to deal 70 damage. If can't discard, attack does nothing.
-fn discard_hand_cards_required_attack(state: &State, fixed_damage: u32, count: usize) -> Outcomes {
+fn discard_hand_cards_required_attack(
+    state: &State,
+    fixed_damage: u32,
+    count: usize,
+) -> AttackOutcomes {
     let acting_player = state.current_player;
     if state.hands[acting_player].len() < count {
         return active_damage_doutcome(0);
@@ -2582,7 +2645,7 @@ fn discard_hand_cards_required_attack(state: &State, fixed_damage: u32, count: u
 }
 
 /// For Umbreon's Dark Binding: If the Defending Pokémon is a Basic Pokémon, it can't attack during your opponent's next turn.
-fn block_basic_attack(damage: u32) -> Outcomes {
+fn block_basic_attack(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         let opponent_active = state.get_active_mut(opponent);
@@ -2595,8 +2658,8 @@ fn block_basic_attack(damage: u32) -> Outcomes {
 }
 
 /// For Aerodactyl's Primal Wingbeat: Flip a coin. If heads, opponent shuffles their Active Pokémon into their deck.
-fn shuffle_opponent_active_into_deck() -> Outcomes {
-    Outcomes::binary_coin(
+fn shuffle_opponent_active_into_deck() -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         // Heads: shuffle opponent's active into deck
         active_damage_effect_mutation(0, move |rng, state, action| {
             let opponent = (action.actor + 1) % 2;
@@ -2624,11 +2687,11 @@ fn shuffle_opponent_active_into_deck() -> Outcomes {
         }),
         // Tails: just do nothing
         active_damage_mutation(0),
-    )
+    ))
 }
 
-fn coin_flip_shuffle_random_opponent_hand_card_into_deck() -> Outcomes {
-    Outcomes::binary_coin(
+fn coin_flip_shuffle_random_opponent_hand_card_into_deck() -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         // Heads: shuffle a random card from opponent's hand into their deck
         active_damage_effect_mutation(0, move |rng, state, action| {
             let opponent = (action.actor + 1) % 2;
@@ -2642,7 +2705,7 @@ fn coin_flip_shuffle_random_opponent_hand_card_into_deck() -> Outcomes {
         }),
         // Tails: do nothing
         active_damage_mutation(0),
-    )
+    ))
 }
 
 /// Teal Mask Ogerpon ex – Energized Leaves:
@@ -2652,7 +2715,7 @@ fn extra_damage_if_combined_active_energy_at_least(
     base_damage: u32,
     threshold: usize,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let current_player = state.current_player;
     let opponent = (current_player + 1) % 2;
     let combined = state.get_active(current_player).attached_energy.len()
@@ -2672,7 +2735,7 @@ fn coin_flip_charge_bench(
     base_damage: u32,
     energies: Vec<EnergyType>,
     target_benched_type: Option<EnergyType>,
-) -> Outcomes {
+) -> AttackOutcomes {
     let choices = state
         .enumerate_bench_pokemon(state.current_player)
         .filter(|(_, played_card)| {
@@ -2686,7 +2749,7 @@ fn coin_flip_charge_bench(
             is_turn_energy: false,
         })
         .collect::<Vec<_>>();
-    Outcomes::binary_coin(
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         active_damage_effect_mutation(base_damage, move |_, state, action| {
             if !choices.is_empty() {
                 state
@@ -2695,7 +2758,7 @@ fn coin_flip_charge_bench(
             }
         }),
         active_damage_mutation(base_damage),
-    )
+    ))
 }
 
 /// Wellspring Mask Ogerpon – Wellspring Dance:
@@ -2705,7 +2768,7 @@ fn coin_flip_also_choice_bench_damage(
     opponent: bool,
     active_damage: u32,
     bench_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let opponent_player = (state.current_player + 1) % 2;
     let bench_target = if opponent {
         opponent_player
@@ -2732,21 +2795,21 @@ fn coin_flip_also_choice_bench_damage(
 
     // Heads: defer all damage via ApplyDamage choice (atomic KO resolution).
     // Tails: deal active damage directly (bench untouched).
-    Outcomes::binary_coin(
+    AttackOutcomes::opaque(Outcomes::binary_coin(
         Box::new(move |_: &mut StdRng, state: &mut State, action: &Action| {
             state
                 .move_generation_stack
                 .push((action.actor, choices.clone()));
         }),
         active_damage_mutation(active_damage),
-    )
+    ))
 }
 
 fn extra_damage_if_defender_poisoned(
     state: &State,
     base_damage: u32,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     let damage = if state.get_active(opponent).is_poisoned() {
         base_damage + extra_damage
@@ -2760,7 +2823,7 @@ fn extra_damage_if_defender_confused(
     state: &State,
     base_damage: u32,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     let damage = if state.get_active(opponent).is_confused() {
         base_damage + extra_damage
@@ -2770,10 +2833,10 @@ fn extra_damage_if_defender_confused(
     active_damage_doutcome(damage)
 }
 
-fn mega_ampharos_lightning_lancer() -> Outcomes {
+fn mega_ampharos_lightning_lancer() -> AttackOutcomes {
     // 1 of your opponent's Benched Pokémon is chosen at random 3 times.
     // For each time a Pokémon was chosen, also do 20 damage to it.
-    Outcomes::single_fn(|rng, state, action| {
+    AttackOutcomes::opaque(Outcomes::single_fn(|rng, state, action| {
         let opponent = (action.actor + 1) % 2;
         let targets: Vec<(u32, usize, usize)> =
             generate_random_spread_indices(rng, state, opponent, true, 3)
@@ -2784,14 +2847,14 @@ fn mega_ampharos_lightning_lancer() -> Outcomes {
 
         let attacking_ref = (action.actor, 0);
         handle_damage(state, attacking_ref, &targets, true, None);
-    })
+    }))
 }
 
 fn random_damage_to_opponent_pokemon_per_self_energy(
     state: &State,
     energy_type: EnergyType,
     damage_per_hit: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let energy_count = state
         .get_active(state.current_player)
         .attached_energy
@@ -2803,7 +2866,7 @@ fn random_damage_to_opponent_pokemon_per_self_energy(
         return active_damage_doutcome(0);
     }
 
-    Outcomes::single(Box::new(move |rng, state, action| {
+    AttackOutcomes::opaque(Outcomes::single(Box::new(move |rng, state, action| {
         let opponent = (action.actor + 1) % 2;
         let targets: Vec<(u32, usize, usize)> =
             generate_random_spread_indices(rng, state, opponent, false, energy_count)
@@ -2813,7 +2876,7 @@ fn random_damage_to_opponent_pokemon_per_self_energy(
 
         let attacking_ref = (action.actor, 0);
         handle_damage(state, attacking_ref, &targets, true, None);
-    }))
+    })))
 }
 
 fn generate_random_spread_indices(
@@ -2897,10 +2960,10 @@ pub(crate) fn enumerate_random_damage_outcomes(
         .collect()
 }
 
-/// Converts enumerated damage outcomes into Outcomes struct for forecasting.
-fn random_damage_outcomes_to_outcomes(outcomes: Vec<EnumeratedOutcome>) -> Outcomes {
+/// Converts enumerated damage outcomes into AttackOutcomes for forecasting.
+fn random_damage_outcomes_to_outcomes(outcomes: Vec<EnumeratedOutcome>) -> AttackOutcomes {
     if outcomes.is_empty() {
-        return Outcomes::single_fn(|_, _, _| {});
+        return AttackOutcomes::opaque(Outcomes::single_fn(|_, _, _| {}));
     }
 
     let mut probabilities = Vec::with_capacity(outcomes.len());
@@ -2920,7 +2983,7 @@ fn random_damage_outcomes_to_outcomes(outcomes: Vec<EnumeratedOutcome>) -> Outco
         ));
     }
 
-    Outcomes::from_parts(probabilities, mutations)
+    AttackOutcomes::opaque(Outcomes::from_parts(probabilities, mutations))
 }
 
 /// Random spread damage attack (e.g., Draco Meteor, Spurt Fire).
@@ -2930,7 +2993,7 @@ fn random_spread_damage(
     times: usize,
     damage_per_hit: u32,
     include_own_bench: bool,
-) -> Outcomes {
+) -> AttackOutcomes {
     let actor = state.current_player;
     let opponent = (actor + 1) % 2;
 
@@ -2951,7 +3014,7 @@ fn random_spread_damage(
     random_damage_outcomes_to_outcomes(outcomes)
 }
 
-fn switch_self_with_bench(state: &State, damage: u32, optional: bool) -> Outcomes {
+fn switch_self_with_bench(state: &State, damage: u32, optional: bool) -> AttackOutcomes {
     let mut choices: Vec<_> = state
         .enumerate_bench_pokemon(state.current_player)
         .map(|(in_play_idx, _)| SimpleAction::Activate {
@@ -2963,7 +3026,7 @@ fn switch_self_with_bench(state: &State, damage: u32, optional: bool) -> Outcome
         choices.push(SimpleAction::Noop);
     }
 
-    Outcomes::single(Box::new(
+    AttackOutcomes::opaque(Outcomes::single(Box::new(
         move |_: &mut StdRng, state: &mut State, action: &Action| {
             let opponent = (action.actor + 1) % 2;
             let attacking_ref = (action.actor, 0);
@@ -2977,7 +3040,7 @@ fn switch_self_with_bench(state: &State, damage: u32, optional: bool) -> Outcome
                 state.move_generation_stack.push((action.actor, choices));
             }
         },
-    ))
+    )))
 }
 
 /// Mega Steelix ex - Adamantine Rolling: Deals damage and applies multiple card effects
@@ -2986,7 +3049,7 @@ fn damage_and_multiple_card_effects_attack(
     opponent: bool,
     effects: Vec<CardEffect>,
     effect_duration: u8,
-) -> Outcomes {
+) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let player = if opponent {
             (action.actor + 1) % 2
@@ -3007,15 +3070,15 @@ fn damage_for_each_heads_with_status_attack(
     num_coins: usize,
     attack: &Attack,
     status: StatusCondition,
-) -> Outcomes {
-    Outcomes::binomial_by_heads(num_coins, move |heads| {
+) -> AttackOutcomes {
+    AttackOutcomes::opaque(Outcomes::binomial_by_heads(num_coins, move |heads| {
         let damage = if include_fixed_damage {
             attack.fixed_damage + (heads as u32 * damage_per_head)
         } else {
             heads as u32 * damage_per_head
         };
         active_damage_effect_mutation(damage, build_status_effect(status))
-    })
+    }))
 }
 
 /// Mega Blastoise ex - Triple Bombardment: Conditional bench damage based on extra energy
@@ -3026,7 +3089,7 @@ fn conditional_bench_damage_attack(
     bench_damage: u32,
     num_bench_targets: usize,
     opponent: bool,
-) -> Outcomes {
+) -> AttackOutcomes {
     let pokemon = state.get_active(state.current_player);
     let cost_with_extra_energy = attack
         .energy_required
@@ -3093,13 +3156,13 @@ fn conditional_bench_damage_attack(
                 vec![]
             };
 
-            Outcomes::single(Box::new(
+            AttackOutcomes::opaque(Outcomes::single(Box::new(
                 move |_: &mut StdRng, state: &mut State, action: &Action| {
                     if !choices.is_empty() {
                         state.move_generation_stack.push((action.actor, choices));
                     }
                 },
-            ))
+            )))
         } else {
             // Not enough bench targets, just apply damage to active without creating choices
             active_damage_doutcome(attack.fixed_damage)
@@ -3110,7 +3173,7 @@ fn conditional_bench_damage_attack(
 }
 
 /// Xerneas - Geoburst: Damage reduced by self damage
-fn damage_reduced_by_self_damage_attack(state: &State, attack: &Attack) -> Outcomes {
+fn damage_reduced_by_self_damage_attack(state: &State, attack: &Attack) -> AttackOutcomes {
     let active = state.get_active(state.current_player);
     let damage_taken = active.get_damage_counters();
     let actual_damage = attack.fixed_damage.saturating_sub(damage_taken);
@@ -3157,7 +3220,9 @@ mod tests {
             is_stack: false,
         };
 
-        let (_probs, mut muts) = extra_or_self_damage_attack(40, 40, 20).into_branches();
+        let (_probs, mut muts) = extra_or_self_damage_attack(40, 40, 20)
+            .into_outcomes()
+            .into_branches();
         // Tails outcome: base damage + self damage
         let mutation = muts.remove(1);
         mutation(&mut rng, &mut state, &action);
@@ -3210,7 +3275,9 @@ mod tests {
             is_stack: false,
         };
 
-        let (_probs, mut muts) = extra_or_self_damage_attack(40, 40, 20).into_branches();
+        let (_probs, mut muts) = extra_or_self_damage_attack(40, 40, 20)
+            .into_outcomes()
+            .into_branches();
         // Tails outcome: base damage + self damage
         let mutation = muts.remove(1);
         mutation(&mut rng, &mut state, &action);
@@ -3242,7 +3309,7 @@ fn extra_damage_per_trainer_in_opponent_deck_attack(
     state: &State,
     base_damage: u32,
     damage_per_trainer: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     let trainer_count = state.decks[opponent]
         .cards
@@ -3258,7 +3325,7 @@ fn extra_damage_per_supporter_in_discard_attack(
     state: &State,
     base_damage: u32,
     damage_per_supporter: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let supporter_count = state.discard_piles[state.current_player]
         .iter()
         .filter(|card| {
@@ -3277,7 +3344,7 @@ fn extra_damage_per_pokemon_type_in_discard_attack(
     base_damage: u32,
     energy_type: EnergyType,
     damage_per_pokemon: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let pokemon_count = state.discard_piles[state.current_player]
         .iter()
         .filter(|card| matches!(card, Card::Pokemon(pokemon) if pokemon.energy_type == energy_type))
@@ -3291,7 +3358,7 @@ fn extra_damage_per_own_point_attack(
     state: &State,
     base_damage: u32,
     damage_per_point: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let points = state.points[state.current_player] as u32;
     let total_damage = base_damage + (points * damage_per_point);
     active_damage_doutcome(total_damage)
@@ -3303,7 +3370,7 @@ fn extra_damage_if_card_in_discard_attack(
     base_damage: u32,
     card_name: String,
     extra_damage: u32,
-) -> Outcomes {
+) -> AttackOutcomes {
     let has_card_in_discard = state.discard_piles[state.current_player]
         .iter()
         .any(|card| {
@@ -3322,7 +3389,7 @@ fn extra_damage_if_card_in_discard_attack(
 }
 
 /// Magnezone - Mirror Shot: Coin flip to block opponent attack next turn
-fn coin_flip_to_block_attack_next_turn(damage: u32) -> Outcomes {
+fn coin_flip_to_block_attack_next_turn(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let opponent = (action.actor + 1) % 2;
         state
@@ -3336,7 +3403,7 @@ fn first_attack_bonus_turn_effect(
     base_damage: u32,
     effect: TurnEffect,
     duration: u8,
-) -> Outcomes {
+) -> AttackOutcomes {
     let is_first = state.in_play_pokemon[state.current_player][0]
         .as_ref()
         .map(|p| !p.has_attacked_since_play)
@@ -3356,7 +3423,7 @@ fn first_attack_bonus_damage_and_status(
     base_damage: u32,
     extra_damage: u32,
     conditions: Vec<StatusCondition>,
-) -> Outcomes {
+) -> AttackOutcomes {
     let is_first = state.in_play_pokemon[state.current_player][0]
         .as_ref()
         .map(|p| !p.has_attacked_since_play)
@@ -3408,6 +3475,7 @@ mod test {
 
         let (_, mut lazy_mutations) =
             bench_count_damage_attack(&state, 70, true, 20, None, &BenchSide::YourBench)
+                .into_outcomes()
                 .into_branches();
         lazy_mutations.remove(0)(&mut rng, &mut state, &action);
 
@@ -3493,7 +3561,8 @@ mod test {
     #[test]
     fn test_flip_until_tails_probabilities() {
         // Test that flip_until_tails_attack generates correct probabilities
-        let (probabilities, _mutations) = flip_until_tails_attack(20).into_branches();
+        let (probabilities, _mutations) =
+            flip_until_tails_attack(20).into_outcomes().into_branches();
 
         // Check that we have 9 outcomes (0 to 8 heads)
         assert_eq!(probabilities.len(), 9);
@@ -3539,7 +3608,9 @@ mod test {
         state.attach_energy_from_zone(0, 0, EnergyType::Grass, 1, false);
         state.attach_energy_from_zone(0, 0, EnergyType::Fire, 1, false);
 
-        let (probabilities, _mutations) = celebi_powerful_bloom(&state).into_branches();
+        let (probabilities, _mutations) = celebi_powerful_bloom(&state)
+            .into_outcomes()
+            .into_branches();
 
         // Should have 3 outcomes (0, 1, 2 heads)
         assert_eq!(probabilities.len(), 3);
@@ -3552,7 +3623,9 @@ mod test {
         // Test with no energy attached
         let mut state_no_energy = State::default();
         state_no_energy.in_play_pokemon[0][0] = Some(to_playable_card(&celebi, false));
-        let (probabilities_no_energy, _) = celebi_powerful_bloom(&state_no_energy).into_branches();
+        let (probabilities_no_energy, _) = celebi_powerful_bloom(&state_no_energy)
+            .into_outcomes()
+            .into_branches();
 
         // Should have 1 outcome (0 damage)
         assert_eq!(probabilities_no_energy.len(), 1);
@@ -3629,7 +3702,9 @@ mod test {
             .get(effect.as_str())
             .expect("Guzzlord ex effect should be mapped");
         let (_probabilities, mut mutations) =
-            forecast_effect_attack_by_mechanic(&state, &attack, mechanic).into_branches();
+            forecast_effect_attack_by_mechanic(&state, &attack, mechanic)
+                .into_outcomes()
+                .into_branches();
 
         // Apply the first outcome mutation and ensure Oricorio's Safeguard still blocks ex damage.
         mutations.remove(0)(&mut rng, &mut state, &action);
@@ -3665,6 +3740,7 @@ mod test {
             4,
             70,
         )
+        .into_outcomes()
         .into_branches();
         below_mutations.remove(0)(&mut rng, &mut below_threshold, &action);
         assert_eq!(below_threshold.get_active(1).get_remaining_hp(), 90);
@@ -3683,6 +3759,7 @@ mod test {
             4,
             70,
         )
+        .into_outcomes()
         .into_branches();
         threshold_mutations.remove(0)(&mut rng, &mut at_threshold, &action);
         assert_eq!(at_threshold.get_active(1).get_remaining_hp(), 20);
@@ -3707,7 +3784,9 @@ mod test {
                 .with_energy(vec![EnergyType::Water, EnergyType::Lightning]),
         );
 
-        let (_probs, mut mutations) = vaporeon_hyper_whirlpool(&state, 60).into_branches();
+        let (_probs, mut mutations) = vaporeon_hyper_whirlpool(&state, 60)
+            .into_outcomes()
+            .into_branches();
         mutations.remove(2)(&mut rng, &mut state, &action);
 
         assert_eq!(state.get_active(1).attached_energy.len(), 0);

--- a/src/actions/attack_outcomes.rs
+++ b/src/actions/attack_outcomes.rs
@@ -1,0 +1,175 @@
+use super::apply_action_helpers::{AdditionalEffect, Mutation};
+use super::mutations::build_attack_mutation;
+use super::outcomes::{CoinPaths, OutcomeBranch, Outcomes};
+
+/// A single damage target produced by an attack, before any per-target
+/// modifications (e.g. weakness, Carefree Steps prevention) are applied.
+///
+/// `is_opponent_target` indicates whether `in_play_idx` refers to a slot on
+/// the attacker's opponent's side (true) or the attacker's own side (false).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct DamageTarget {
+    pub amount: u32,
+    pub is_opponent_target: bool,
+    pub in_play_idx: usize,
+}
+
+/// The payload of an `AttackOutcomeBranch`: either an opaque mutation (for
+/// mechanics that don't report damage targets) or an explicit set of damage
+/// targets plus an additional effect, from which the mutation can be built
+/// once any per-target damage prevention has been applied.
+pub(crate) enum AttackPayload {
+    Opaque(Mutation),
+    Damage {
+        targets: Vec<DamageTarget>,
+        additional_effect: AdditionalEffect,
+    },
+}
+
+pub(crate) struct AttackOutcomeBranch {
+    pub probability: f64,
+    pub coin_paths: CoinPaths,
+    pub payload: AttackPayload,
+}
+
+/// Dedicated outcome type for the attack-forecast pipeline. Unlike the
+/// generic `Outcomes` type, branches can carry explicit `DamageTarget`
+/// metadata so that per-target effects (e.g. Carefree Steps' independent
+/// coin-flip damage prevention) can be applied without losing track of any
+/// additional effects (status conditions, etc.) tied to the same branch.
+pub(crate) struct AttackOutcomes {
+    branches: Vec<AttackOutcomeBranch>,
+}
+
+impl AttackOutcomes {
+    /// Wraps a plain `Outcomes` value, treating every branch's mutation as
+    /// opaque (no damage-target metadata available).
+    pub(crate) fn opaque(outcomes: Outcomes) -> Self {
+        let branches = outcomes
+            .into_raw_branches()
+            .into_iter()
+            .map(|b| AttackOutcomeBranch {
+                probability: b.probability,
+                coin_paths: b.coin_paths,
+                payload: AttackPayload::Opaque(b.mutation),
+            })
+            .collect();
+        Self { branches }
+    }
+
+    /// Builds a single-branch outcome reporting the given damage targets and
+    /// additional effect.
+    pub(crate) fn from_damage_targets(
+        targets: Vec<DamageTarget>,
+        additional_effect: AdditionalEffect,
+    ) -> Self {
+        Self {
+            branches: vec![AttackOutcomeBranch {
+                probability: 1.0,
+                coin_paths: CoinPaths::None,
+                payload: AttackPayload::Damage {
+                    targets,
+                    additional_effect,
+                },
+            }],
+        }
+    }
+
+    pub(crate) fn has_damage_targets(&self) -> bool {
+        self.branches.iter().any(|b| match &b.payload {
+            AttackPayload::Damage { targets, .. } => !targets.is_empty(),
+            AttackPayload::Opaque(_) => false,
+        })
+    }
+
+    /// Splits each branch that has damage targets matching `can_prevent` into
+    /// sub-branches covering every combination of "prevented" (heads) vs
+    /// "not prevented" (tails) for those targets, each with independent 50/50
+    /// probability. Targets with zero damage, or not matching `can_prevent`,
+    /// are left untouched. Opaque branches, and branches without any matching
+    /// targets, are passed through unchanged.
+    pub(crate) fn apply_coin_flip_damage_prevention(
+        self,
+        can_prevent: impl Fn(&DamageTarget) -> bool,
+    ) -> Self {
+        let mut branches = Vec::with_capacity(self.branches.len());
+        for branch in self.branches {
+            let (targets, additional_effect) = match branch.payload {
+                AttackPayload::Opaque(mutation) => {
+                    branches.push(AttackOutcomeBranch {
+                        probability: branch.probability,
+                        coin_paths: branch.coin_paths,
+                        payload: AttackPayload::Opaque(mutation),
+                    });
+                    continue;
+                }
+                AttackPayload::Damage {
+                    targets,
+                    additional_effect,
+                } => (targets, additional_effect),
+            };
+
+            let preventable: Vec<usize> = targets
+                .iter()
+                .enumerate()
+                .filter(|(_, target)| target.amount > 0 && can_prevent(target))
+                .map(|(idx, _)| idx)
+                .collect();
+
+            if preventable.is_empty() {
+                branches.push(AttackOutcomeBranch {
+                    probability: branch.probability,
+                    coin_paths: branch.coin_paths,
+                    payload: AttackPayload::Damage {
+                        targets,
+                        additional_effect,
+                    },
+                });
+                continue;
+            }
+
+            let sub_probability = branch.probability / (1u32 << preventable.len()) as f64;
+            for mask in 0..(1usize << preventable.len()) {
+                let mut targets = targets.clone();
+                for (bit, &idx) in preventable.iter().enumerate() {
+                    if (mask >> bit) & 1 == 1 {
+                        targets[idx].amount = 0;
+                    }
+                }
+                branches.push(AttackOutcomeBranch {
+                    probability: sub_probability,
+                    coin_paths: branch.coin_paths.clone(),
+                    payload: AttackPayload::Damage {
+                        targets,
+                        additional_effect: additional_effect.clone(),
+                    },
+                });
+            }
+        }
+        Self { branches }
+    }
+
+    /// Converts back to a plain `Outcomes`, building the mutation for any
+    /// `Damage` branches via `build_attack_mutation`.
+    pub(crate) fn into_outcomes(self) -> Outcomes {
+        let branches = self
+            .branches
+            .into_iter()
+            .map(|branch| {
+                let mutation = match branch.payload {
+                    AttackPayload::Opaque(mutation) => mutation,
+                    AttackPayload::Damage {
+                        targets,
+                        additional_effect,
+                    } => build_attack_mutation(targets, additional_effect),
+                };
+                OutcomeBranch {
+                    probability: branch.probability,
+                    mutation,
+                    coin_paths: branch.coin_paths,
+                }
+            })
+            .collect();
+        Outcomes::from_raw_branches(branches)
+    }
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -5,6 +5,7 @@ mod apply_action_helpers;
 mod apply_attack_action;
 mod apply_trainer_action;
 pub(crate) mod attack_helpers;
+mod attack_outcomes;
 mod attacks;
 mod effect_ability_mechanic_map;
 mod effect_mechanic_map;

--- a/src/actions/mutations.rs
+++ b/src/actions/mutations.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use rand::rngs::StdRng;
 
 use crate::{
@@ -7,8 +9,8 @@ use crate::{
 };
 
 use super::{
-    apply_action_helpers::{FnMutation, Mutation},
-    outcomes::Outcomes,
+    apply_action_helpers::{AdditionalEffect, FnMutation, Mutation},
+    outcomes::{DamageTarget, Outcomes},
     Action, SimpleAction,
 };
 
@@ -38,7 +40,10 @@ pub(crate) fn damage_effect_doutcome<F>(
 where
     F: Fn(&mut StdRng, &mut State, &Action) + 'static,
 {
-    Outcomes::single(damage_effect_mutation(targets, additional_effect))
+    let damage_targets = to_damage_targets(&targets);
+    let additional_effect: AdditionalEffect = Rc::new(additional_effect);
+    let mutation = build_attack_mutation(damage_targets.clone(), additional_effect.clone());
+    Outcomes::single(mutation).with_damage_info(damage_targets, additional_effect)
 }
 
 // ===== Helper functions for building Mutations
@@ -63,18 +68,39 @@ pub(crate) fn damage_effect_mutation<F>(
 where
     F: Fn(&mut StdRng, &mut State, &Action) + 'static,
 {
+    build_attack_mutation(to_damage_targets(&targets), Rc::new(additional_effect))
+}
+
+fn to_damage_targets(targets: &[(u32, bool, usize)]) -> Vec<DamageTarget> {
+    targets
+        .iter()
+        .map(|&(amount, is_opponent_target, in_play_idx)| DamageTarget {
+            amount,
+            is_opponent_target,
+            in_play_idx,
+        })
+        .collect()
+}
+
+/// Builds the `Mutation` shared by attack-damage outcomes: resolves each
+/// `DamageTarget` against the acting player, applies the damage, runs the
+/// `additional_effect`, then handles any resulting knockouts.
+pub(crate) fn build_attack_mutation(
+    targets: Vec<DamageTarget>,
+    additional_effect: AdditionalEffect,
+) -> Mutation {
     Box::new({
         move |rng, state, action| {
             let opponent = (action.actor + 1) % 2;
             let targets: Vec<(u32, usize, usize)> = targets
                 .iter()
-                .map(|(damage, is_opponent_target, in_play_idx)| {
-                    let target_player = if *is_opponent_target {
+                .map(|target| {
+                    let target_player = if target.is_opponent_target {
                         opponent
                     } else {
                         action.actor
                     };
-                    (*damage, target_player, *in_play_idx)
+                    (target.amount, target_player, target.in_play_idx)
                 })
                 .collect();
 

--- a/src/actions/mutations.rs
+++ b/src/actions/mutations.rs
@@ -10,7 +10,7 @@ use crate::{
 
 use super::{
     apply_action_helpers::{AdditionalEffect, FnMutation, Mutation},
-    outcomes::{DamageTarget, Outcomes},
+    attack_outcomes::{AttackOutcomes, DamageTarget},
     Action, SimpleAction,
 };
 
@@ -19,14 +19,14 @@ use super::{
 // to promote pokemon after knockout, etc... apply to all attacks.
 
 // Useful for deterministic attacks
-pub(crate) fn active_damage_doutcome(damage: u32) -> Outcomes {
+pub(crate) fn active_damage_doutcome(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, |_, _, _| {})
 }
 
 pub(crate) fn active_damage_effect_doutcome(
     damage: u32,
     additional_effect: impl Fn(&mut StdRng, &mut State, &Action) + 'static,
-) -> Outcomes {
+) -> AttackOutcomes {
     damage_effect_doutcome(vec![(damage, true, 0)], additional_effect)
 }
 
@@ -36,14 +36,13 @@ pub(crate) fn active_damage_effect_doutcome(
 pub(crate) fn damage_effect_doutcome<F>(
     targets: Vec<(u32, bool, usize)>,
     additional_effect: F,
-) -> Outcomes
+) -> AttackOutcomes
 where
     F: Fn(&mut StdRng, &mut State, &Action) + 'static,
 {
     let damage_targets = to_damage_targets(&targets);
     let additional_effect: AdditionalEffect = Rc::new(additional_effect);
-    let mutation = build_attack_mutation(damage_targets.clone(), additional_effect.clone());
-    Outcomes::single(mutation).with_damage_info(damage_targets, additional_effect)
+    AttackOutcomes::from_damage_targets(damage_targets, additional_effect)
 }
 
 // ===== Helper functions for building Mutations

--- a/src/actions/outcomes.rs
+++ b/src/actions/outcomes.rs
@@ -1,6 +1,9 @@
+use std::rc::Rc;
+
 use rand::rngs::StdRng;
 
-use super::apply_action_helpers::{Mutation, Mutations, Probabilities};
+use super::apply_action_helpers::{AdditionalEffect, Mutation, Mutations, Probabilities};
+use super::mutations::build_attack_mutation;
 use super::Action;
 use crate::State;
 
@@ -12,6 +15,24 @@ pub struct OutcomeBranch {
     pub probability: f64,
     pub mutation: Mutation,
     pub coin_paths: CoinPaths,
+    pub damage_targets: Vec<DamageTarget>,
+    pub additional_effect: AdditionalEffect,
+}
+
+/// A single damage target produced by an attack, before any per-target
+/// modifications (e.g. weakness, Carefree Steps prevention) are applied.
+///
+/// `is_opponent_target` indicates whether `in_play_idx` refers to a slot on
+/// the attacker's opponent's side (true) or the attacker's own side (false).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DamageTarget {
+    pub amount: u32,
+    pub is_opponent_target: bool,
+    pub in_play_idx: usize,
+}
+
+fn no_additional_effect() -> AdditionalEffect {
+    Rc::new(|_, _, _| {})
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -38,6 +59,8 @@ impl Outcomes {
                 probability: 1.0,
                 mutation,
                 coin_paths: CoinPaths::None,
+                damage_targets: vec![],
+                additional_effect: no_additional_effect(),
             }],
         }
     }
@@ -47,6 +70,72 @@ impl Outcomes {
         F: Fn(&mut StdRng, &mut State, &Action) + 'static,
     {
         Self::single(Box::new(f))
+    }
+
+    /// Tags every branch with the given damage targets and additional effect,
+    /// so that downstream consumers (e.g. Carefree Steps) can reason about the
+    /// damage an outcome will produce without inspecting its mutation closure.
+    pub fn with_damage_info(
+        mut self,
+        damage_targets: Vec<DamageTarget>,
+        additional_effect: AdditionalEffect,
+    ) -> Self {
+        for branch in &mut self.branches {
+            branch.damage_targets = damage_targets.clone();
+            branch.additional_effect = additional_effect.clone();
+        }
+        self
+    }
+
+    pub fn has_damage_targets(&self) -> bool {
+        self.branches.iter().any(|b| !b.damage_targets.is_empty())
+    }
+
+    /// Splits each branch that has damage targets matching `can_prevent` into
+    /// sub-branches covering every combination of "prevented" (heads) vs
+    /// "not prevented" (tails) for those targets, each with independent 50/50
+    /// probability. Targets with zero damage, or not matching `can_prevent`,
+    /// are left untouched. Branches without any matching targets are passed
+    /// through unchanged.
+    pub fn apply_coin_flip_damage_prevention(
+        self,
+        can_prevent: impl Fn(&DamageTarget) -> bool,
+    ) -> Self {
+        let mut branches = Vec::with_capacity(self.branches.len());
+        for branch in self.branches {
+            let preventable: Vec<usize> = branch
+                .damage_targets
+                .iter()
+                .enumerate()
+                .filter(|(_, target)| target.amount > 0 && can_prevent(target))
+                .map(|(idx, _)| idx)
+                .collect();
+
+            if preventable.is_empty() {
+                branches.push(branch);
+                continue;
+            }
+
+            let sub_probability = branch.probability / (1u32 << preventable.len()) as f64;
+            for mask in 0..(1usize << preventable.len()) {
+                let mut targets = branch.damage_targets.clone();
+                for (bit, &idx) in preventable.iter().enumerate() {
+                    if (mask >> bit) & 1 == 1 {
+                        targets[idx].amount = 0;
+                    }
+                }
+                let additional_effect = branch.additional_effect.clone();
+                let mutation = build_attack_mutation(targets.clone(), additional_effect.clone());
+                branches.push(OutcomeBranch {
+                    probability: sub_probability,
+                    mutation,
+                    coin_paths: branch.coin_paths.clone(),
+                    damage_targets: targets,
+                    additional_effect,
+                });
+            }
+        }
+        Self { branches }
     }
 
     // Useful for constructing outcomes that are not based on coin flips, or when coin flip metadata is not needed.
@@ -65,6 +154,8 @@ impl Outcomes {
                 probability,
                 mutation,
                 coin_paths: CoinPaths::None,
+                damage_targets: vec![],
+                additional_effect: no_additional_effect(),
             })
             .collect();
         let outcomes = Self { branches: built };
@@ -81,11 +172,15 @@ impl Outcomes {
                     probability: 0.5,
                     mutation: heads_mutation,
                     coin_paths: CoinPaths::Exact(vec![CoinSeq(vec![true])]),
+                    damage_targets: vec![],
+                    additional_effect: no_additional_effect(),
                 },
                 OutcomeBranch {
                     probability: 0.5,
                     mutation: tails_mutation,
                     coin_paths: CoinPaths::Exact(vec![CoinSeq(vec![false])]),
+                    damage_targets: vec![],
+                    additional_effect: no_additional_effect(),
                 },
             ],
         }
@@ -100,6 +195,8 @@ impl Outcomes {
                 probability,
                 mutation,
                 coin_paths: CoinPaths::Exact(sequences),
+                damage_targets: vec![],
+                additional_effect: no_additional_effect(),
             })
             .collect();
         let outcomes = Self { branches: built };
@@ -162,6 +259,8 @@ impl Outcomes {
                 probability: branch.probability,
                 mutation: f(branch.mutation),
                 coin_paths: branch.coin_paths,
+                damage_targets: branch.damage_targets,
+                additional_effect: branch.additional_effect,
             })
             .collect();
         Self { branches }
@@ -204,6 +303,8 @@ impl Outcomes {
                         probability: scaled_probability,
                         mutation: branch.mutation,
                         coin_paths: CoinPaths::Exact(kept),
+                        damage_targets: branch.damage_targets,
+                        additional_effect: branch.additional_effect,
                     });
                 }
             }

--- a/src/actions/outcomes.rs
+++ b/src/actions/outcomes.rs
@@ -1,9 +1,6 @@
-use std::rc::Rc;
-
 use rand::rngs::StdRng;
 
-use super::apply_action_helpers::{AdditionalEffect, Mutation, Mutations, Probabilities};
-use super::mutations::build_attack_mutation;
+use super::apply_action_helpers::{Mutation, Mutations, Probabilities};
 use super::Action;
 use crate::State;
 
@@ -11,28 +8,10 @@ pub struct Outcomes {
     branches: Vec<OutcomeBranch>,
 }
 
-pub struct OutcomeBranch {
+pub(crate) struct OutcomeBranch {
     pub probability: f64,
     pub mutation: Mutation,
     pub coin_paths: CoinPaths,
-    pub damage_targets: Vec<DamageTarget>,
-    pub additional_effect: AdditionalEffect,
-}
-
-/// A single damage target produced by an attack, before any per-target
-/// modifications (e.g. weakness, Carefree Steps prevention) are applied.
-///
-/// `is_opponent_target` indicates whether `in_play_idx` refers to a slot on
-/// the attacker's opponent's side (true) or the attacker's own side (false).
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub struct DamageTarget {
-    pub amount: u32,
-    pub is_opponent_target: bool,
-    pub in_play_idx: usize,
-}
-
-fn no_additional_effect() -> AdditionalEffect {
-    Rc::new(|_, _, _| {})
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -59,8 +38,6 @@ impl Outcomes {
                 probability: 1.0,
                 mutation,
                 coin_paths: CoinPaths::None,
-                damage_targets: vec![],
-                additional_effect: no_additional_effect(),
             }],
         }
     }
@@ -72,69 +49,17 @@ impl Outcomes {
         Self::single(Box::new(f))
     }
 
-    /// Tags every branch with the given damage targets and additional effect,
-    /// so that downstream consumers (e.g. Carefree Steps) can reason about the
-    /// damage an outcome will produce without inspecting its mutation closure.
-    pub fn with_damage_info(
-        mut self,
-        damage_targets: Vec<DamageTarget>,
-        additional_effect: AdditionalEffect,
-    ) -> Self {
-        for branch in &mut self.branches {
-            branch.damage_targets = damage_targets.clone();
-            branch.additional_effect = additional_effect.clone();
-        }
-        self
+    /// Converts into the raw list of branches, discarding no information.
+    /// Used by the attack-forecast pipeline to move branches into/out of
+    /// the dedicated `AttackOutcomes` type.
+    pub(crate) fn into_raw_branches(self) -> Vec<OutcomeBranch> {
+        self.branches
     }
 
-    pub fn has_damage_targets(&self) -> bool {
-        self.branches.iter().any(|b| !b.damage_targets.is_empty())
-    }
-
-    /// Splits each branch that has damage targets matching `can_prevent` into
-    /// sub-branches covering every combination of "prevented" (heads) vs
-    /// "not prevented" (tails) for those targets, each with independent 50/50
-    /// probability. Targets with zero damage, or not matching `can_prevent`,
-    /// are left untouched. Branches without any matching targets are passed
-    /// through unchanged.
-    pub fn apply_coin_flip_damage_prevention(
-        self,
-        can_prevent: impl Fn(&DamageTarget) -> bool,
-    ) -> Self {
-        let mut branches = Vec::with_capacity(self.branches.len());
-        for branch in self.branches {
-            let preventable: Vec<usize> = branch
-                .damage_targets
-                .iter()
-                .enumerate()
-                .filter(|(_, target)| target.amount > 0 && can_prevent(target))
-                .map(|(idx, _)| idx)
-                .collect();
-
-            if preventable.is_empty() {
-                branches.push(branch);
-                continue;
-            }
-
-            let sub_probability = branch.probability / (1u32 << preventable.len()) as f64;
-            for mask in 0..(1usize << preventable.len()) {
-                let mut targets = branch.damage_targets.clone();
-                for (bit, &idx) in preventable.iter().enumerate() {
-                    if (mask >> bit) & 1 == 1 {
-                        targets[idx].amount = 0;
-                    }
-                }
-                let additional_effect = branch.additional_effect.clone();
-                let mutation = build_attack_mutation(targets.clone(), additional_effect.clone());
-                branches.push(OutcomeBranch {
-                    probability: sub_probability,
-                    mutation,
-                    coin_paths: branch.coin_paths.clone(),
-                    damage_targets: targets,
-                    additional_effect,
-                });
-            }
-        }
+    /// Rebuilds an `Outcomes` from raw branches, e.g. after the
+    /// attack-forecast pipeline has finished resolving an `AttackOutcomes`
+    /// back into plain mutations.
+    pub(crate) fn from_raw_branches(branches: Vec<OutcomeBranch>) -> Self {
         Self { branches }
     }
 
@@ -154,8 +79,6 @@ impl Outcomes {
                 probability,
                 mutation,
                 coin_paths: CoinPaths::None,
-                damage_targets: vec![],
-                additional_effect: no_additional_effect(),
             })
             .collect();
         let outcomes = Self { branches: built };
@@ -172,15 +95,11 @@ impl Outcomes {
                     probability: 0.5,
                     mutation: heads_mutation,
                     coin_paths: CoinPaths::Exact(vec![CoinSeq(vec![true])]),
-                    damage_targets: vec![],
-                    additional_effect: no_additional_effect(),
                 },
                 OutcomeBranch {
                     probability: 0.5,
                     mutation: tails_mutation,
                     coin_paths: CoinPaths::Exact(vec![CoinSeq(vec![false])]),
-                    damage_targets: vec![],
-                    additional_effect: no_additional_effect(),
                 },
             ],
         }
@@ -195,8 +114,6 @@ impl Outcomes {
                 probability,
                 mutation,
                 coin_paths: CoinPaths::Exact(sequences),
-                damage_targets: vec![],
-                additional_effect: no_additional_effect(),
             })
             .collect();
         let outcomes = Self { branches: built };
@@ -259,8 +176,6 @@ impl Outcomes {
                 probability: branch.probability,
                 mutation: f(branch.mutation),
                 coin_paths: branch.coin_paths,
-                damage_targets: branch.damage_targets,
-                additional_effect: branch.additional_effect,
             })
             .collect();
         Self { branches }
@@ -303,8 +218,6 @@ impl Outcomes {
                         probability: scaled_probability,
                         mutation: branch.mutation,
                         coin_paths: CoinPaths::Exact(kept),
-                        damage_targets: branch.damage_targets,
-                        additional_effect: branch.additional_effect,
                     });
                 }
             }

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -90,6 +90,8 @@ mod mega_sceptile_terminating_tail_test;
 mod mega_steelix_adamantine_rolling_test;
 #[path = "pokemon/meowstic_test.rs"]
 mod meowstic_test;
+#[path = "pokemon/meowth_carefree_steps_test.rs"]
+mod meowth_carefree_steps_test;
 #[path = "pokemon/miraidon_ex_test.rs"]
 mod miraidon_ex_test;
 #[path = "pokemon/morpeko_test.rs"]

--- a/tests/pokemon/meowth_carefree_steps_test.rs
+++ b/tests/pokemon/meowth_carefree_steps_test.rs
@@ -1,0 +1,126 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game_with_board,
+};
+
+#[test]
+fn test_carefree_steps_meowth_still_poisoned_when_damage_prevented() {
+    // Venomoth's Poison Powder deals 30 damage and Poisons the opponent's
+    // Active Pokemon. Meowth's Carefree Steps may prevent the 30 damage on a
+    // coin flip, but the Poison status should be applied either way.
+    let mut prevented_count = 0;
+    let mut damaged_count = 0;
+
+    for seed in 0..100 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            1,
+            vec![PlayedCard::from_id(CardId::A1017Venomoth).with_energy(vec![EnergyType::Grass])],
+            vec![PlayedCard::from_id(CardId::B2124Meowth)],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::Attack(0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let meowth = state.get_active(1);
+        assert!(
+            meowth.is_poisoned(),
+            "Seed {seed}: Meowth should be Poisoned by Poison Powder regardless of Carefree Steps"
+        );
+
+        match meowth.get_remaining_hp() {
+            50 => prevented_count += 1,
+            20 => damaged_count += 1,
+            hp => panic!("Seed {seed}: unexpected Meowth HP after attack: {hp}"),
+        }
+    }
+
+    assert!(
+        prevented_count > 0,
+        "Expected some seeds where Carefree Steps prevents the damage"
+    );
+    assert!(
+        damaged_count > 0,
+        "Expected some seeds where Carefree Steps doesn't prevent the damage"
+    );
+}
+
+#[test]
+fn test_palkia_ex_dimensional_storm_each_benched_meowth_flips_independently() {
+    // Palkia ex's Dimensional Storm does 150 damage to the opponent's Active
+    // Pokemon and 20 damage to each of their Benched Pokemon. Each Benched
+    // Meowth's Carefree Steps coin flip should be independent of the other.
+    let mut both_prevented = 0;
+    let mut only_first_prevented = 0;
+    let mut only_second_prevented = 0;
+    let mut neither_prevented = 0;
+
+    for seed in 0..200 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            1,
+            vec![PlayedCard::from_id(CardId::A2049PalkiaEx).with_energy(vec![
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Colorless,
+            ])],
+            vec![
+                PlayedCard::from_id(CardId::A1004VenusaurEx),
+                PlayedCard::from_id(CardId::B2124Meowth),
+                PlayedCard::from_id(CardId::B2124Meowth),
+            ],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::Attack(1),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        assert_eq!(
+            state.get_remaining_hp(1, 0),
+            40,
+            "Seed {seed}: opponent's Active should take the full 150 damage from Dimensional Storm"
+        );
+
+        let bench_1_hp = state.get_remaining_hp(1, 1);
+        let bench_2_hp = state.get_remaining_hp(1, 2);
+
+        match (bench_1_hp, bench_2_hp) {
+            (50, 50) => both_prevented += 1,
+            (50, 30) => only_first_prevented += 1,
+            (30, 50) => only_second_prevented += 1,
+            (30, 30) => neither_prevented += 1,
+            (hp1, hp2) => panic!("Seed {seed}: unexpected Benched Meowth HPs: {hp1}, {hp2}"),
+        }
+    }
+
+    assert!(
+        both_prevented > 0,
+        "Expected some seeds where both Meowths prevent their damage"
+    );
+    assert!(
+        only_first_prevented > 0,
+        "Expected some seeds where only the first Meowth prevents its damage"
+    );
+    assert!(
+        only_second_prevented > 0,
+        "Expected some seeds where only the second Meowth prevents its damage"
+    );
+    assert!(
+        neither_prevented > 0,
+        "Expected some seeds where neither Meowth prevents its damage"
+    );
+}


### PR DESCRIPTION
Attaches DamageTarget/additional-effect metadata to Outcomes/OutcomeBranch
so Carefree Steps no longer relies on an opaque whole-outcome coin gate.
Each damaged target that has the ability now flips its own independent
coin; on heads only that target's damage is zeroed, while side-effects
like Poison still apply. Mechanics without explicit damage targets keep
the old whole-outcome behavior as a fallback.

https://claude.ai/code/session_015GLCdEAy8BtovbzJZv4XAD