### PR TITLE
Implement Dustox Select Powder and Cascoon Harden mechanics

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -67,6 +67,7 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::DiscardToolFromPokemon { .. }
         | SimpleAction::DiscardActiveStadium
         | SimpleAction::DiscardRandomOpponentActiveEnergy
+        | SimpleAction::ApplyStatusToOpponentActive { .. }
         | SimpleAction::Noop => forecast_deterministic_action(),
         SimpleAction::UseAbility { in_play_idx } => forecast_ability(state, action, *in_play_idx),
         SimpleAction::Attack(index) => forecast_attack(action.actor, state, *index),
@@ -264,6 +265,10 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
             if let Some(energy) = state.get_active(opponent).attached_energy.last().copied() {
                 state.discard_from_active(opponent, &[energy]);
             }
+        }
+        SimpleAction::ApplyStatusToOpponentActive { condition } => {
+            let opponent = (action.actor + 1) % 2;
+            state.apply_status_condition(opponent, 0, *condition);
         }
         SimpleAction::Noop => {}
         _ => panic!("Deterministic Action expected"),

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -277,6 +277,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ChanceStatusAttack { condition } => {
             damage_chance_status_attack(attack.fixed_damage, *condition)
         }
+        Mechanic::ChooseStatusToInflict { options } => {
+            damage_and_choose_status_attack(attack.fixed_damage, options.clone())
+        }
         Mechanic::DamageAllOpponentPokemon { damage } => {
             damage_all_opponent_pokemon(state, *damage)
         }
@@ -1298,6 +1301,22 @@ fn extra_or_self_damage_attack(base_damage: u32, extra_damage: u32, self_damage:
             active.apply_damage(self_damage);
         }),
     )
+}
+
+/// Deal damage, then let the player choose which Special Condition to inflict on the
+/// opponent's Active Pokémon (e.g. Dustox's Select Powder).
+fn damage_and_choose_status_attack(damage: u32, options: Vec<StatusCondition>) -> Outcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let choices: Vec<SimpleAction> = options
+            .iter()
+            .map(|condition| SimpleAction::ApplyStatusToOpponentActive {
+                condition: *condition,
+            })
+            .collect();
+        if !choices.is_empty() {
+            state.move_generation_stack.push((action.actor, choices));
+        }
+    })
 }
 
 fn damage_chance_status_attack(damage: u32, status: StatusCondition) -> Outcomes {

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -53,6 +53,11 @@ pub enum Mechanic {
     ChanceStatusAttack {
         condition: StatusCondition,
     },
+    /// Deal damage, then let the player choose one of these Special Conditions to
+    /// inflict on the opponent's Active Pokémon (e.g. Dustox's Select Powder).
+    ChooseStatusToInflict {
+        options: Vec<StatusCondition>,
+    },
     DamageAllOpponentPokemon {
         damage: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -77,7 +77,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     map.insert("Choose 2 of your Benched Pokémon. For each of those Pokémon, take a [W] Energy from your Energy Zone and attach it to that Pokémon.", Mechanic::ManaphyOceanicGift);
-    // map.insert("Choose either Poisoned or Confused. Your opponent's Active Pokémon is now affected by that Special Condition.", todo_implementation);
+    map.insert(
+        "Choose either Poisoned or Confused. Your opponent's Active Pokémon is now affected by that Special Condition.",
+        Mechanic::ChooseStatusToInflict {
+            options: vec![StatusCondition::Poisoned, StatusCondition::Confused],
+        },
+    );
     map.insert(
         "Discard 2 [L] Energy from this Pokémon.",
         Mechanic::SelfDiscardEnergy {
@@ -352,7 +357,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 20 damage to the Attacking Pokémon.", todo_implementation);
     // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 30 damage to the Attacking Pokémon.", todo_implementation);
     // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 40 damage to the Attacking Pokémon.", todo_implementation);
-    // map.insert("During your opponent's next turn, prevent all damage done to this Pokémon by attacks if that damage is 40 or less.", todo_implementation);
+    map.insert(
+        "During your opponent's next turn, prevent all damage done to this Pokémon by attacks if that damage is 40 or less.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::PreventDamageIfLessOrEqual { threshold: 40 },
+            duration: 1,
+            coin_flip: false,
+        },
+    );
     map.insert(
         "During your opponent's next turn, the Defending Pokémon can't attack.",
         Mechanic::DamageAndCardEffect {

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -1,4 +1,4 @@
-use crate::models::{Card, EnergyType, TrainerCard};
+use crate::models::{Card, EnergyType, StatusCondition, TrainerCard};
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -152,6 +152,10 @@ pub enum SimpleAction {
     DiscardActiveStadium,
     /// Crawdaunt's Unruly Claw: discard a random Energy from the opponent's Active Pokémon
     DiscardRandomOpponentActiveEnergy,
+    /// Apply a chosen Special Condition to the opponent's Active Pokémon (e.g. Dustox's Select Powder).
+    ApplyStatusToOpponentActive {
+        condition: StatusCondition,
+    },
     Noop, // No operation, used to have the user say "no" to a question
 }
 
@@ -315,6 +319,9 @@ impl fmt::Display for SimpleAction {
                 write!(f, "DiscardRandomOpponentActiveEnergy")
             }
             SimpleAction::UseStadium => write!(f, "UseStadium"),
+            SimpleAction::ApplyStatusToOpponentActive { condition } => {
+                write!(f, "ApplyStatusToOpponentActive({condition:?})")
+            }
             SimpleAction::Noop => write!(f, "Noop"),
         }
     }

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -6,16 +6,31 @@ use crate::models::EnergyType;
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum CardEffect {
     NoRetreat,
-    ReducedDamage { amount: u32 },
-    IncreasedVulnerability { amount: u32 },
-    IncreasedAttackCost { amount: u8 },
+    ReducedDamage {
+        amount: u32,
+    },
+    IncreasedVulnerability {
+        amount: u32,
+    },
+    IncreasedAttackCost {
+        amount: u8,
+    },
     CannotAttack,
     CannotUseAttack(String),
-    IncreasedDamageForAttack { attack_name: String, amount: u32 },
+    IncreasedDamageForAttack {
+        attack_name: String,
+        amount: u32,
+    },
     PreventAllDamageAndEffects,
+    /// Prevent all damage from attacks if the incoming damage is at most `threshold` (e.g. Cascoon's Harden).
+    PreventDamageIfLessOrEqual {
+        threshold: u32,
+    },
     NoWeakness,
     CoinFlipToBlockAttack,
-    DelayedDamage { amount: u32 },
+    DelayedDamage {
+        amount: u32,
+    },
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -1012,11 +1012,23 @@ pub(crate) fn modify_damage(
                 + intimidating_fang_reduction
                 + ability_damage_reduction,
         );
-    match weakness_application {
+    let final_damage = match weakness_application {
         WeaknessApplication::None => pre_weakness,
         WeaknessApplication::Flat(amount) => pre_weakness + amount,
         WeaknessApplication::Double => pre_weakness * 2,
+    };
+
+    // Threshold-based prevention (e.g. Cascoon's Harden): prevent all damage if it is low enough.
+    let prevented_by_threshold = receiving_pokemon
+        .get_active_effects()
+        .iter()
+        .any(|effect| matches!(effect, CardEffect::PreventDamageIfLessOrEqual { threshold } if final_damage <= *threshold));
+    if prevented_by_threshold {
+        debug!("PreventDamageIfLessOrEqual: Preventing {final_damage} damage");
+        return 0;
     }
+
+    final_damage
 }
 
 /// Calculate type-specific damage boost from abilities like Lucario's Fighting Coach or Aegislash's Royal Command

--- a/src/models/card.rs
+++ b/src/models/card.rs
@@ -272,7 +272,7 @@ impl Card {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum StatusCondition {
     Poisoned,
     Paralyzed,

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -73,6 +73,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::DiscardToolFromPokemon { .. } => 5,
         SimpleAction::DiscardActiveStadium => 5,
         SimpleAction::DiscardRandomOpponentActiveEnergy => 10,
+        SimpleAction::ApplyStatusToOpponentActive { .. } => 10,
         SimpleAction::UseStadium => 5, // Stadium abilities like Mesagoza
         SimpleAction::Noop => 0,       // No operation has no weight
     }

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -18,6 +18,8 @@ mod bonsly_teary_attack_test;
 mod brambleghast_accept_pain_test;
 #[path = "pokemon/camerupt_eruption_test.rs"]
 mod camerupt_eruption_test;
+#[path = "pokemon/cascoon_harden_test.rs"]
+mod cascoon_harden_test;
 #[path = "pokemon/castform_test.rs"]
 mod castform_test;
 #[path = "pokemon/chansey_blissey_test.rs"]
@@ -36,6 +38,8 @@ mod darkrai_ex_test;
 mod durant_test;
 #[path = "pokemon/dusknoir_shadow_void_test.rs"]
 mod dusknoir_shadow_void_test;
+#[path = "pokemon/dustox_select_powder_test.rs"]
+mod dustox_select_powder_test;
 #[path = "pokemon/emboar_flare_storm_test.rs"]
 mod emboar_flare_storm_test;
 #[path = "pokemon/flutter_mane_ex_test.rs"]

--- a/tests/pokemon/cascoon_harden_test.rs
+++ b/tests/pokemon/cascoon_harden_test.rs
@@ -1,0 +1,75 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    effects::CardEffect,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Cascoon's Harden: "During your opponent's next turn, prevent all damage done to
+/// this Pokémon by attacks if that damage is 40 or less."
+#[test]
+fn test_cascoon_harden_prevents_low_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1006Cascoon).with_energy(vec![EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Grass])],
+    );
+    game.set_state(state);
+
+    // Cascoon uses Harden, applying the prevention effect to itself.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    // Opponent's turn: Bulbasaur attacks with Vine Whip (40 damage).
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    assert_eq!(
+        game.get_state_clone().get_active(0).get_remaining_hp(),
+        80,
+        "Harden should prevent the 40-damage Vine Whip entirely"
+    );
+}
+
+#[test]
+fn test_cascoon_harden_does_not_prevent_high_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+
+    // Cascoon already hardened; opponent has a >40 damage attacker (Weezing's Smokescreen, 50).
+    let mut cascoon =
+        PlayedCard::from_id(CardId::B1006Cascoon).with_energy(vec![EnergyType::Grass]);
+    cascoon.add_effect(CardEffect::PreventDamageIfLessOrEqual { threshold: 40 }, 1);
+    state.set_board(
+        vec![cascoon],
+        vec![PlayedCard::from_id(CardId::A1a050Weezing)
+            .with_energy(vec![EnergyType::Darkness, EnergyType::Darkness])],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    assert_eq!(
+        game.get_state_clone().get_active(0).get_remaining_hp(),
+        30,
+        "Harden should not prevent damage above 40 (Weezing's 50-damage Tackle)"
+    );
+}

--- a/tests/pokemon/dustox_select_powder_test.rs
+++ b/tests/pokemon/dustox_select_powder_test.rs
@@ -1,0 +1,115 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard, StatusCondition},
+    test_support::get_initialized_game,
+};
+
+/// Dustox's Select Powder: "Choose either Poisoned or Confused. Your opponent's
+/// Active Pokémon is now affected by that Special Condition." (60 damage).
+#[test]
+fn test_dustox_select_powder_offers_poison_and_confuse_then_poisons() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1007Dustox).with_energy(vec![EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        10,
+        "Select Powder should deal 60 damage (70 HP Bulbasaur -> 10)"
+    );
+
+    let (actor, choices) = state.generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(
+        choices.len(),
+        2,
+        "Player should choose between Poisoned and Confused"
+    );
+    assert!(choices.iter().any(|c| matches!(
+        c.action,
+        SimpleAction::ApplyStatusToOpponentActive {
+            condition: StatusCondition::Poisoned
+        }
+    )));
+    assert!(choices.iter().any(|c| matches!(
+        c.action,
+        SimpleAction::ApplyStatusToOpponentActive {
+            condition: StatusCondition::Confused
+        }
+    )));
+
+    let poison_choice = choices
+        .iter()
+        .find(|c| {
+            matches!(
+                c.action,
+                SimpleAction::ApplyStatusToOpponentActive {
+                    condition: StatusCondition::Poisoned
+                }
+            )
+        })
+        .cloned()
+        .expect("Expected a Poisoned choice");
+    game.apply_action(&poison_choice);
+
+    let state = game.get_state_clone();
+    assert!(
+        state.get_active(1).is_poisoned(),
+        "Choosing Poisoned should poison the opponent's Active Pokémon"
+    );
+    assert!(
+        !state.get_active(1).is_confused(),
+        "The opponent's Active should not also be Confused"
+    );
+}
+
+#[test]
+fn test_dustox_select_powder_can_confuse_opponent_active() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1007Dustox).with_energy(vec![EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    let confuse_choice = choices
+        .iter()
+        .find(|c| {
+            matches!(
+                c.action,
+                SimpleAction::ApplyStatusToOpponentActive {
+                    condition: StatusCondition::Confused
+                }
+            )
+        })
+        .cloned()
+        .expect("Expected a Confused choice");
+    game.apply_action(&confuse_choice);
+
+    assert!(
+        game.get_state_clone().get_active(1).is_confused(),
+        "Choosing Confused should confuse the opponent's Active Pokémon"
+    );
+}


### PR DESCRIPTION
## Summary
This PR implements two Pokémon attack/ability mechanics: Dustox's Select Powder (which lets the player choose between Poisoned or Confused status conditions) and Cascoon's Harden (which prevents damage below a threshold).

## Key Changes

- **New `ChooseStatusToInflict` mechanic**: Added support for attacks that deal damage and then let the player choose which Special Condition to inflict on the opponent's Active Pokémon. This is used by Dustox's Select Powder attack.

- **New `PreventDamageIfLessOrEqual` card effect**: Implements threshold-based damage prevention (e.g., Cascoon's Harden prevents all damage if it's 40 or less). The effect is checked in the `modify_damage` hook after weakness calculation.

- **New `ApplyStatusToOpponentActive` action**: Added a simple action to apply a chosen Special Condition to the opponent's Active Pokémon, with corresponding handling in action forecasting and application.

- **Updated `StatusCondition` derive traits**: Added `Eq` and `Hash` derives to `StatusCondition` to support use in collections and comparisons.

- **Effect mechanic mappings**: Registered both Dustox's Select Powder and Cascoon's Harden in the `EFFECT_MECHANIC_MAP`.

- **Comprehensive test coverage**: Added two test files:
  - `dustox_select_powder_test.rs`: Tests that the attack offers both status condition choices and correctly applies the chosen condition
  - `cascoon_harden_test.rs`: Tests that the effect prevents damage at or below the threshold but allows damage above it

## Implementation Details

The `damage_and_choose_status_attack` function handles the attack flow by dealing damage first, then pushing status condition choices onto the move generation stack for the player to select from. The threshold-based prevention is applied after weakness calculation to ensure it operates on the final damage value.

https://claude.ai/code/session_01CAiLBdaNHYzdgdeg3gpXfF