### PR TITLE
Implement Honchkrow Evil Admonition attack mechanic

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -672,6 +672,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfOpponentActiveHasAbility { extra_damage } => {
             extra_damage_if_opponent_active_has_ability(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::ExtraDamagePerOpponentPokemonWithAbility { damage_per } => {
+            extra_damage_per_opponent_pokemon_with_ability(state, attack.fixed_damage, *damage_per)
+        }
         Mechanic::CoinFlipShuffleRandomOpponentHandCardIntoDeck => {
             coin_flip_shuffle_random_opponent_hand_card_into_deck()
         }
@@ -2141,6 +2144,19 @@ fn extra_damage_if_opponent_active_has_ability(state: &State, base: u32, extra: 
     let opponent_active = state.get_active(opponent);
     let has_ability = opponent_active.card.get_ability().is_some();
     active_damage_doutcome(if has_ability { base + extra } else { base })
+}
+
+fn extra_damage_per_opponent_pokemon_with_ability(
+    state: &State,
+    base: u32,
+    damage_per: u32,
+) -> Outcomes {
+    let opponent = (state.current_player + 1) % 2;
+    let ability_count = state
+        .enumerate_in_play_pokemon(opponent)
+        .filter(|(_, pokemon)| pokemon.card.get_ability().is_some())
+        .count() as u32;
+    active_damage_doutcome(base + damage_per * ability_count)
 }
 
 fn extra_damage_if_hurt(state: &State, base: u32, extra: u32, opponent: bool) -> Outcomes {

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -365,6 +365,11 @@ pub enum Mechanic {
     ExtraDamageIfOpponentActiveHasAbility {
         extra_damage: u32,
     },
+    /// Honchkrow – Evil Admonition: extra damage for each of the opponent's
+    /// Pokémon in play (active and bench) that has an Ability.
+    ExtraDamagePerOpponentPokemonWithAbility {
+        damage_per: u32,
+    },
     CoinFlipShuffleRandomOpponentHandCardIntoDeck,
     /// Teal Mask Ogerpon ex – Energized Leaves:
     /// If total energy on both Active Pokémon ≥ threshold, deal extra_damage more.

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1495,7 +1495,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("This attack does 40 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost.", todo_implementation);
     // map.insert("This attack does 40 more damage for each of your Benched Wishiwashi and Wishiwashi ex.", todo_implementation);
-    // map.insert("This attack does 40 more damage for each of your opponent's Pokémon in play that has an Ability.", todo_implementation);
+    map.insert(
+        "This attack does 40 more damage for each of your opponent's Pokémon in play that has an Ability.",
+        Mechanic::ExtraDamagePerOpponentPokemonWithAbility { damage_per: 40 },
+    );
     map.insert(
         "This attack does 50 damage to 1 of your opponent's Benched Pokémon.",
         Mechanic::DirectDamage {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -50,6 +50,8 @@ mod grovyle_slicing_snipe_test;
 mod hatterene_test;
 #[path = "pokemon/heracross_test.rs"]
 mod heracross_test;
+#[path = "pokemon/honchkrow_evil_admonition_test.rs"]
+mod honchkrow_evil_admonition_test;
 #[path = "pokemon/houndstone_last_respects_test.rs"]
 mod houndstone_last_respects_test;
 #[path = "pokemon/iron_bundle_ex_test.rs"]

--- a/tests/pokemon/honchkrow_evil_admonition_test.rs
+++ b/tests/pokemon/honchkrow_evil_admonition_test.rs
@@ -1,0 +1,69 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+#[test]
+fn test_evil_admonition_base_damage_when_no_opponent_abilities() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1149Honchkrow)
+            .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+        // Both opponent Pokémon lack an Ability.
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax),
+            PlayedCard::from_id(CardId::A1211Snorlax),
+        ],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // Evil Admonition: 40 base + 0 extra (no opponent Pokémon with an Ability).
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        150 - 40
+    );
+}
+
+#[test]
+fn test_evil_admonition_extra_damage_per_opponent_ability() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1149Honchkrow)
+            .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+        // Active Snorlax has no Ability, but two benched Weezing each have one.
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax),
+            PlayedCard::from_id(CardId::A1177Weezing),
+            PlayedCard::from_id(CardId::A1177Weezing),
+        ],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // Evil Admonition: 40 base + 40 * 2 (two opponent Pokémon with an Ability) = 120.
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        150 - 120
+    );
+}


### PR DESCRIPTION
## Summary
Adds support for Honchkrow's Evil Admonition attack, which deals extra damage based on the number of opponent Pokémon in play that have an Ability.

## Changes
- **New Mechanic**: Added `ExtraDamagePerOpponentPokemonWithAbility` variant to the `Mechanic` enum to handle attacks that scale damage based on opponent Pokémon abilities
- **Implementation**: Added `extra_damage_per_opponent_pokemon_with_ability()` function that counts all opponent Pokémon (active and benched) with abilities and multiplies the damage per count
- **Effect Mapping**: Mapped the effect text "This attack does 40 more damage for each of your opponent's Pokémon in play that has an Ability." to the new mechanic with 40 damage per ability
- **Tests**: Added comprehensive test coverage with two test cases:
  - Base damage when no opponent Pokémon have abilities
  - Correct damage scaling when multiple opponent Pokémon have abilities

## Implementation Details
The mechanic correctly iterates through all opponent Pokémon in play (using `enumerate_in_play_pokemon`) and counts those with abilities, then applies the multiplied damage to the active Pokémon.

https://claude.ai/code/session_019NceJx84Dgg4wjZSu3Vusb