### PR TITLE
Implement Carracosta line and Marlon

### DIFF
--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -145,6 +145,7 @@ pub fn forecast_trainer_action(
         CardId::A2b069Iono | CardId::A2b088Iono | CardId::A4b340Iono | CardId::A4b341Iono => {
             Outcomes::single_fn(iono_effect)
         }
+        CardId::B1221Marlon | CardId::B1266Marlon => Outcomes::single_fn(marlon_effect),
         CardId::B1223May | CardId::B1268May => may_effect(acting_player, state),
         CardId::B1224Fantina | CardId::B1269Fantina => Outcomes::single_fn(fantina_effect),
         CardId::B1226Lisia | CardId::B1271Lisia => lisia_effect(acting_player, state),
@@ -287,6 +288,25 @@ fn nasty_notice_effect(_: &mut StdRng, state: &mut State, action: &Action) {
 
 fn erika_effect(rng: &mut StdRng, state: &mut State, action: &Action) {
     inner_healing_effect(rng, state, action, 50, Some(EnergyType::Grass));
+}
+
+fn marlon_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Heal 70 damage from 1 of your Carracosta or Jellicent.
+    let targets = ["Carracosta", "Jellicent"];
+    let possible_moves = state
+        .enumerate_in_play_pokemon(action.actor)
+        .filter(|(_, x)| targets.contains(&x.get_name().as_str()))
+        .map(|(i, _)| SimpleAction::Heal {
+            in_play_idx: i,
+            amount: 70,
+            cure_status: false,
+        })
+        .collect::<Vec<_>>();
+    if !possible_moves.is_empty() {
+        state
+            .move_generation_stack
+            .push((action.actor, possible_moves));
+    }
 }
 
 fn irida_effect(_: &mut StdRng, state: &mut State, action: &Action) {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -995,7 +995,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             energy_type: EnergyType::Psychic,
         },
     );
-    // map.insert("Prevent all damage done to this Pokémon by attacks from Basic Pokémon during your opponent's next turn.", todo_implementation);
+    map.insert(
+        "Prevent all damage done to this Pokémon by attacks from Basic Pokémon during your opponent's next turn.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::PreventDamageFromBasic,
+            duration: 1,
+            coin_flip: false,
+        },
+    );
     map.insert(
         "Put 1 random Basic Pokémon from your deck onto your Bench.",
         Mechanic::SearchToBenchBasic,

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -26,6 +26,8 @@ pub enum CardEffect {
     PreventDamageIfLessOrEqual {
         threshold: u32,
     },
+    /// Prevent all damage done by attacks from Basic Pokémon (e.g. Carracosta's Blocking Shell).
+    PreventDamageFromBasic,
     NoWeakness,
     CoinFlipToBlockAttack,
     DelayedDamage {

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -896,6 +896,17 @@ pub(crate) fn modify_damage(
         return 0;
     }
 
+    // Check for PreventDamageFromBasic (Carracosta's Blocking Shell)
+    if attacking_pokemon.card.is_basic()
+        && receiving_pokemon
+            .get_active_effects()
+            .iter()
+            .any(|effect| matches!(effect, CardEffect::PreventDamageFromBasic))
+    {
+        debug!("PreventDamageFromBasic: Preventing all damage from a Basic Pokémon");
+        return 0;
+    }
+
     // Calculate all modifiers
     let is_active_to_active = target_idx == 0 && attacking_idx == 0 && is_from_active_attack;
     let target_is_ex = receiving_pokemon.card.is_ex();

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -177,6 +177,7 @@ pub fn trainer_move_generation_implementation(
         CardId::A2b069Iono | CardId::A2b088Iono | CardId::A4b340Iono | CardId::A4b341Iono => {
             can_play_trainer(state, trainer_card)
         }
+        CardId::B1221Marlon | CardId::B1266Marlon => can_play_marlon(state, trainer_card),
         CardId::B1223May | CardId::B1268May => can_play_trainer(state, trainer_card),
         CardId::B1224Fantina | CardId::B1269Fantina => can_play_trainer(state, trainer_card),
         CardId::B1226Lisia | CardId::B1271Lisia => can_play_trainer(state, trainer_card),
@@ -323,6 +324,21 @@ fn can_play_erika(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simpl
         .filter(|(_, x)| x.is_damaged() && x.get_energy_type() == Some(EnergyType::Grass))
         .count();
     if damaged_grass_count > 0 {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
+}
+
+/// Names of Pokémon that Marlon can heal.
+const MARLON_TARGETS: [&str; 2] = ["Carracosta", "Jellicent"];
+
+/// Check if Marlon can be played (requires a damaged Carracosta or Jellicent in play)
+fn can_play_marlon(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let has_valid_target = state
+        .enumerate_in_play_pokemon(state.current_player)
+        .any(|(_, x)| x.is_damaged() && MARLON_TARGETS.contains(&x.get_name().as_str()));
+    if has_valid_target {
         can_play_trainer(state, trainer_card)
     } else {
         cannot_play_trainer()

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -18,6 +18,8 @@ mod bonsly_teary_attack_test;
 mod brambleghast_accept_pain_test;
 #[path = "pokemon/camerupt_eruption_test.rs"]
 mod camerupt_eruption_test;
+#[path = "pokemon/carracosta_blocking_shell_test.rs"]
+mod carracosta_blocking_shell_test;
 #[path = "pokemon/cascoon_harden_test.rs"]
 mod cascoon_harden_test;
 #[path = "pokemon/castform_test.rs"]

--- a/tests/pokemon/carracosta_blocking_shell_test.rs
+++ b/tests/pokemon/carracosta_blocking_shell_test.rs
@@ -1,0 +1,83 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    effects::CardEffect,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Carracosta's Blocking Shell: "Prevent all damage done to this Pokémon by attacks
+/// from Basic Pokémon during your opponent's next turn." (100 damage)
+#[test]
+fn test_carracosta_blocking_shell_prevents_basic_attack_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B1067Carracosta).with_energy(vec![
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Colorless,
+            ]),
+        ],
+        // Mewtwo ex is a Basic Pokémon with enough HP to survive the 100 damage.
+        vec![PlayedCard::from_id(CardId::A1129MewtwoEx)
+            .with_energy(vec![EnergyType::Psychic, EnergyType::Colorless])],
+    );
+    game.set_state(state);
+
+    // Carracosta uses Blocking Shell, dealing 100 and shielding itself from Basics.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    // Opponent's turn: the Basic Mewtwo ex attacks with Psychic Sphere (50 damage).
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    assert_eq!(
+        game.get_state_clone().get_active(0).get_remaining_hp(),
+        150,
+        "Blocking Shell should prevent all damage from a Basic Pokémon's attack"
+    );
+}
+
+/// Blocking Shell only blocks Basic Pokémon, so attacks from evolved Pokémon still land.
+#[test]
+fn test_carracosta_blocking_shell_does_not_prevent_evolved_attack_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+
+    // Carracosta has already used Blocking Shell (effect active for the opponent's turn).
+    let mut carracosta = PlayedCard::from_id(CardId::B1067Carracosta);
+    carracosta.add_effect(CardEffect::PreventDamageFromBasic, 1);
+    state.set_board(
+        // Weezing is a Stage 1 (evolved) Pokémon, so its 50-damage Tackle is not blocked.
+        vec![carracosta],
+        vec![PlayedCard::from_id(CardId::A1a050Weezing)
+            .with_energy(vec![EnergyType::Darkness, EnergyType::Darkness])],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(0),
+        is_stack: false,
+    });
+
+    assert_eq!(
+        game.get_state_clone().get_active(0).get_remaining_hp(),
+        100,
+        "Blocking Shell should not prevent damage from an evolved Pokémon's attack"
+    );
+}

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -8,6 +8,8 @@ mod iris_trainer_test;
 mod juliana_test;
 #[path = "trainers/korrina_cabbie_parasol_lady_test.rs"]
 mod korrina_cabbie_parasol_lady_test;
+#[path = "trainers/marlon_test.rs"]
+mod marlon_test;
 #[path = "trainers/professor_sada_test.rs"]
 mod professor_sada_test;
 #[path = "trainers/professor_turo_test.rs"]

--- a/tests/trainers/marlon_test.rs
+++ b/tests/trainers/marlon_test.rs
@@ -1,0 +1,115 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Marlon: "Heal 70 damage from 1 of your Carracosta or Jellicent."
+#[test]
+fn test_marlon_heals_carracosta() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    // A damaged Carracosta should be a valid Marlon target.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1067Carracosta).with_remaining_hp(40)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let marlon = match get_card_by_enum(CardId::B1221Marlon) {
+        Card::Trainer(tc) => tc,
+        _ => panic!("Expected trainer card"),
+    };
+    state.hands[0].push(Card::Trainer(marlon.clone()));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: marlon,
+        },
+        is_stack: false,
+    });
+
+    // Choose to heal Carracosta (index 0).
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    let heal_action = actions
+        .iter()
+        .find(|a| matches!(a.action, SimpleAction::Heal { in_play_idx: 0, .. }))
+        .expect("Should have a heal action for Carracosta");
+    game.apply_action(heal_action);
+
+    assert_eq!(
+        game.get_state_clone().get_active(0).get_remaining_hp(),
+        110,
+        "Marlon should heal Carracosta by 70 (40 + 70)"
+    );
+}
+
+/// Marlon can only target Carracosta or Jellicent, not other Pokémon.
+#[test]
+fn test_marlon_only_targets_carracosta_or_jellicent() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    // Active is a damaged Bulbasaur (not a valid target); bench has a damaged Jellicent.
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_remaining_hp(10),
+            PlayedCard::from_id(CardId::B1069Jellicent).with_remaining_hp(40),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let marlon = match get_card_by_enum(CardId::B1221Marlon) {
+        Card::Trainer(tc) => tc,
+        _ => panic!("Expected trainer card"),
+    };
+    state.hands[0].push(Card::Trainer(marlon.clone()));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: marlon,
+        },
+        is_stack: false,
+    });
+
+    // Only Jellicent (index 1) should be a valid heal target.
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    let heal_targets: Vec<usize> = actions
+        .iter()
+        .filter_map(|a| match a.action {
+            SimpleAction::Heal { in_play_idx, .. } => Some(in_play_idx),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        heal_targets,
+        vec![1],
+        "Only the benched Jellicent should be a valid Marlon target"
+    );
+
+    let heal_action = actions
+        .iter()
+        .find(|a| matches!(a.action, SimpleAction::Heal { in_play_idx: 1, .. }))
+        .expect("Should have a heal action for Jellicent");
+    game.apply_action(heal_action);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .expect("Jellicent should still be in play")
+            .get_remaining_hp(),
+        110,
+        "Marlon should heal Jellicent by 70 (40 + 70)"
+    );
+}


### PR DESCRIPTION
- Carracosta's Blocking Shell: prevent all damage from Basic Pokémon
  during the opponent's next turn via new PreventDamageFromBasic effect.
- Marlon supporter: heal 70 damage from a Carracosta or Jellicent.
- Tirtouga was already complete.

https://claude.ai/code/session_018Bjicm9bRA5CEH5u7DZnok