### PR TITLE
[codex] Implement Hitmonchan ex Quick Straight

### DIFF
--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -12,7 +12,7 @@ use crate::{
     effects::TurnEffect,
     hooks::{
         get_counterattack_damage, modify_damage, on_attack_knockout, on_end_turn, on_knockout,
-        should_poison_attacker,
+        should_poison_attacker, DamageModifierContext,
     },
     models::{Card, StatusCondition, TrainerType},
     state::GameOutcome,
@@ -403,7 +403,10 @@ pub(crate) fn handle_damage(
         attacking_ref,
         targets,
         is_from_active_attack,
-        attack_name,
+        DamageModifierContext {
+            attack_name,
+            attack_effect: None,
+        },
     );
     handle_knockouts(state, attacking_ref, is_from_active_attack);
 }
@@ -415,7 +418,7 @@ pub(crate) fn handle_damage_only(
     attacking_ref: (usize, usize), // (attacking_player, attacking_pokemon_idx)
     targets: &[(u32, usize, usize)], // damage, target_player, in_play_idx
     is_from_active_attack: bool,
-    attack_name: Option<&str>,
+    context: DamageModifierContext<'_>,
 ) {
     let attacking_player = attacking_ref.0;
 
@@ -438,7 +441,7 @@ pub(crate) fn handle_damage_only(
                 attacking_ref,
                 *target_ref,
                 is_from_active_attack,
-                attack_name,
+                context,
             );
             (modified_damage, target_ref.1, target_ref.2)
         })

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -605,6 +605,7 @@ fn forecast_effect_attack_by_mechanic(
             card_name.clone(),
             *extra_damage,
         ),
+        Mechanic::DamageUnaffectedByWeakness => active_damage_doutcome(attack.fixed_damage),
         Mechanic::CoinFlipToBlockAttackNextTurn => {
             coin_flip_to_block_attack_next_turn(attack.fixed_damage)
         }

--- a/src/actions/attack_outcome.rs
+++ b/src/actions/attack_outcome.rs
@@ -2,7 +2,7 @@ use std::rc::Rc;
 
 use rand::rngs::StdRng;
 
-use crate::hooks::modify_damage;
+use crate::hooks::{modify_damage, DamageModifierContext};
 use crate::State;
 
 use super::apply_action_helpers::{handle_damage_only, handle_knockouts, Mutation, Probabilities};
@@ -117,13 +117,16 @@ impl AttackOutcome {
             }
 
             if !resolved.is_empty() {
-                let attack_name = attack_name_from_action(state, action);
+                let attack_metadata = attack_metadata_from_action(state, action);
                 handle_damage_only(
                     state,
                     attacking_ref,
                     &resolved,
                     true,
-                    attack_name.as_deref(),
+                    DamageModifierContext {
+                        attack_name: attack_metadata.name.as_deref(),
+                        attack_effect: attack_metadata.effect.as_deref(),
+                    },
                 );
             }
 
@@ -380,6 +383,7 @@ impl AttackOutcomes {
         target_player: usize,
         target_idx: usize,
         attack_name: Option<&str>,
+        attack_effect: Option<&str>,
     ) -> f64 {
         let actor = attacking_ref.0;
         let opponent = (actor + 1) % 2;
@@ -400,7 +404,10 @@ impl AttackOutcomes {
                             attacking_ref,
                             (*amount, target_player, *idx),
                             true,
-                            attack_name,
+                            DamageModifierContext {
+                                attack_name,
+                                attack_effect,
+                            },
                         )
                     })
                     .sum();
@@ -416,9 +423,17 @@ impl AttackOutcomes {
         state: &State,
         acting_player: usize,
         attack_name: Option<&str>,
+        attack_effect: Option<&str>,
     ) -> f64 {
         let opponent = (acting_player + 1) % 2;
-        self.expected_damage_to(state, (acting_player, 0), opponent, 0, attack_name)
+        self.expected_damage_to(
+            state,
+            (acting_player, 0),
+            opponent,
+            0,
+            attack_name,
+            attack_effect,
+        )
     }
 
     /// Lower into `Outcomes` and return its `(probabilities, mutations)` branches. Convenience
@@ -449,10 +464,21 @@ impl AttackOutcomes {
 }
 
 /// Look up the title of the attack being resolved, for attack-name-specific damage modifiers.
-fn attack_name_from_action(_state: &State, action: &Action) -> Option<String> {
+struct AttackMetadata {
+    name: Option<String>,
+    effect: Option<String>,
+}
+
+fn attack_metadata_from_action(_state: &State, action: &Action) -> AttackMetadata {
     match &action.action {
-        SimpleAction::Attack(attack) => Some(attack.title.clone()),
-        _ => None,
+        SimpleAction::Attack(attack) => AttackMetadata {
+            name: Some(attack.title.clone()),
+            effect: attack.effect.clone(),
+        },
+        _ => AttackMetadata {
+            name: None,
+            effect: None,
+        },
     }
 }
 
@@ -476,7 +502,7 @@ mod tests {
     fn expected_damage_reads_branch_data_without_running_closures() {
         let state = state_with_grimer_vs_meowth();
         let outcomes = AttackOutcomes::single(AttackOutcome::damage(vec![(20, true, 0)]));
-        let expected = outcomes.expected_damage_to_opponent_active(&state, 0, None);
+        let expected = outcomes.expected_damage_to_opponent_active(&state, 0, None, None);
         assert!(
             (expected - 20.0).abs() < 1e-9,
             "expected 20, got {expected}"
@@ -489,7 +515,7 @@ mod tests {
         let outcomes = AttackOutcomes::single(AttackOutcome::damage(vec![(20, true, 0)]))
             .split_with_damage_prevention(&[0]);
         // Heads branch (0.5) prevents the active damage, tails branch (0.5) deals 20.
-        let expected = outcomes.expected_damage_to_opponent_active(&state, 0, None);
+        let expected = outcomes.expected_damage_to_opponent_active(&state, 0, None, None);
         assert!(
             (expected - 10.0).abs() < 1e-9,
             "expected 10, got {expected}"

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -213,6 +213,7 @@ pub enum Mechanic {
         card_name: String,
         extra_damage: u32,
     },
+    DamageUnaffectedByWeakness,
     DelayedSpotDamage {
         amount: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1554,7 +1554,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "This attack does more damage equal to the damage this Pokémon has on it.",
         Mechanic::ExtraDamageEqualToSelfDamage,
     );
-    // map.insert("This attack's damage isn't affected by Weakness.", todo_implementation);
+    map.insert(
+        "This attack's damage isn't affected by Weakness.",
+        Mechanic::DamageUnaffectedByWeakness,
+    );
     // map.insert("This attack's damage isn't affected by any effects on your opponent's Active Pokémon.", todo_implementation);
     // map.insert("Until this Pokémon leaves the Active Spot, this Pokémon's Rolling Frenzy attack does +30 damage. This effect stacks.", todo_implementation);
     // map.insert("You can use this attack only if you have Uxie and Azelf on your Bench. Discard all Energy from this Pokémon.", todo_implementation);

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -787,13 +787,29 @@ enum WeaknessApplication {
     Double,
 }
 
+const DAMAGE_UNAFFECTED_BY_WEAKNESS_EFFECT: &str =
+    "This attack's damage isn't affected by Weakness.";
+
+#[derive(Clone, Copy, Default)]
+pub(crate) struct DamageModifierContext<'a> {
+    pub(crate) attack_name: Option<&'a str>,
+    pub(crate) attack_effect: Option<&'a str>,
+}
+
+fn attack_effect_ignores_weakness(context: DamageModifierContext<'_>) -> bool {
+    // TODO: If more attack text needs to alter damage-modifier stages, replace this
+    // effect-string check with a typed attack metadata/damage-modifier capability.
+    context.attack_effect == Some(DAMAGE_UNAFFECTED_BY_WEAKNESS_EFFECT)
+}
+
 fn get_weakness_application(
     state: &State,
     is_active_to_active: bool,
     target_player: usize,
     attacking_pokemon: &crate::models::PlayedCard,
+    context: DamageModifierContext<'_>,
 ) -> WeaknessApplication {
-    if !is_active_to_active {
+    if !is_active_to_active || attack_effect_ignores_weakness(context) {
         return WeaknessApplication::None;
     }
     let receiving = state.get_active(target_player);
@@ -843,7 +859,7 @@ pub(crate) fn modify_damage(
     attacking_ref: (usize, usize),
     target_ref: (u32, usize, usize),
     is_from_active_attack: bool,
-    attack_name: Option<&str>,
+    context: DamageModifierContext<'_>,
 ) -> u32 {
     // If attack is 0, not even Giovanni takes it to 10.
     let (attacking_player, attacking_idx) = attacking_ref;
@@ -941,7 +957,7 @@ pub(crate) fn modify_damage(
     let increased_attack_specific_modifiers = get_increased_attack_specific_modifiers(
         attacking_pokemon,
         is_active_to_active,
-        attack_name,
+        context.attack_name,
     );
     let reduced_card_effect_modifiers =
         get_reduced_card_effect_modifiers(state, is_active_to_active, target_player);
@@ -954,8 +970,13 @@ pub(crate) fn modify_damage(
         attacking_player,
         is_from_active_attack,
     );
-    let weakness_application =
-        get_weakness_application(state, is_active_to_active, target_player, attacking_pokemon);
+    let weakness_application = get_weakness_application(
+        state,
+        is_active_to_active,
+        target_player,
+        attacking_pokemon,
+        context,
+    );
 
     // Type-specific damage boost abilities (e.g., Lucario's Fighting Coach, Aegislash's Royal Command)
     // These check if certain ability-holders are in play and boost damage for specific energy types
@@ -1435,14 +1456,25 @@ mod tests {
 
         // Get base damage without Giovanni effect
         let attack = attacker.get_attacks()[0].clone();
-        let base_damage = modify_damage(&state, (0, 0), (attack.fixed_damage, 1, 0), true, None);
+        let base_damage = modify_damage(
+            &state,
+            (0, 0),
+            (attack.fixed_damage, 1, 0),
+            true,
+            DamageModifierContext::default(),
+        );
 
         // Add Giovanni effect
         state.add_turn_effect(TurnEffect::IncreasedDamage { amount: 10 }, 0);
 
         // Get damage with Giovanni effect
-        let damage_with_giovanni =
-            modify_damage(&state, (0, 0), (attack.fixed_damage, 1, 0), true, None);
+        let damage_with_giovanni = modify_damage(
+            &state,
+            (0, 0),
+            (attack.fixed_damage, 1, 0),
+            true,
+            DamageModifierContext::default(),
+        );
 
         // Verify Giovanni adds exactly 10 damage
         assert_eq!(
@@ -1461,10 +1493,21 @@ mod tests {
         non_ex_state.in_play_pokemon[0][0] = Some(to_playable_card(&attacker_card, false));
         let non_ex_defender = get_card_by_enum(CardId::A1033Charmander);
         non_ex_state.in_play_pokemon[1][0] = Some(to_playable_card(&non_ex_defender, false));
-        let base_damage_non_ex = modify_damage(&non_ex_state, (0, 0), (40, 1, 0), true, None);
+        let base_damage_non_ex = modify_damage(
+            &non_ex_state,
+            (0, 0),
+            (40, 1, 0),
+            true,
+            DamageModifierContext::default(),
+        );
         non_ex_state.add_turn_effect(TurnEffect::IncreasedDamageAgainstEx { amount: 20 }, 0);
-        let damage_with_red_vs_non_ex =
-            modify_damage(&non_ex_state, (0, 0), (40, 1, 0), true, None);
+        let damage_with_red_vs_non_ex = modify_damage(
+            &non_ex_state,
+            (0, 0),
+            (40, 1, 0),
+            true,
+            DamageModifierContext::default(),
+        );
         assert_eq!(
             damage_with_red_vs_non_ex, base_damage_non_ex,
             "Red should not increase damage against non-EX Pokémon"
@@ -1475,9 +1518,21 @@ mod tests {
         ex_state.in_play_pokemon[0][0] = Some(to_playable_card(&attacker_card, false));
         let ex_defender = get_card_by_enum(CardId::A3122SolgaleoEx);
         ex_state.in_play_pokemon[1][0] = Some(to_playable_card(&ex_defender, false));
-        let base_damage_ex = modify_damage(&ex_state, (0, 0), (40, 1, 0), true, None);
+        let base_damage_ex = modify_damage(
+            &ex_state,
+            (0, 0),
+            (40, 1, 0),
+            true,
+            DamageModifierContext::default(),
+        );
         ex_state.add_turn_effect(TurnEffect::IncreasedDamageAgainstEx { amount: 20 }, 0);
-        let damage_with_red_vs_ex = modify_damage(&ex_state, (0, 0), (40, 1, 0), true, None);
+        let damage_with_red_vs_ex = modify_damage(
+            &ex_state,
+            (0, 0),
+            (40, 1, 0),
+            true,
+            DamageModifierContext::default(),
+        );
         assert_eq!(
             damage_with_red_vs_ex,
             base_damage_ex + 20,
@@ -1501,7 +1556,13 @@ mod tests {
             .add_effect(crate::effects::CardEffect::ReducedDamage { amount: 50 }, 1);
 
         // Act
-        let damage_with_stiffen = modify_damage(&state, (0, 0), (120, 1, 0), true, None);
+        let damage_with_stiffen = modify_damage(
+            &state,
+            (0, 0),
+            (120, 1, 0),
+            true,
+            DamageModifierContext::default(),
+        );
 
         // Assert
         assert_eq!(

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -22,6 +22,7 @@ pub(crate) use core::on_end_turn;
 pub(crate) use core::on_evolve;
 pub(crate) use core::on_knockout;
 pub use core::to_playable_card;
+pub(crate) use core::DamageModifierContext;
 pub(crate) use counterattack::get_counterattack_damage;
 pub(crate) use counterattack::should_poison_attacker;
 pub(crate) use retreat::can_retreat;

--- a/src/state/energy.rs
+++ b/src/state/energy.rs
@@ -4,6 +4,7 @@ use crate::{
         handle_damage_only, handle_knockouts,
     },
     effects::TurnEffect,
+    hooks::DamageModifierContext,
     models::{EnergyType, StatusCondition},
     State,
 };
@@ -116,7 +117,7 @@ impl State {
                         (opponent, 0),
                         &[(20, actor, in_play_idx)],
                         false,
-                        None,
+                        DamageModifierContext::default(),
                     );
                 }
             }
@@ -141,7 +142,7 @@ impl State {
                     (actor, in_play_idx),
                     &[(20, opponent, 0)],
                     false,
-                    None,
+                    DamageModifierContext::default(),
                 );
             }
 

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -58,6 +58,8 @@ mod grovyle_slicing_snipe_test;
 mod hatterene_test;
 #[path = "pokemon/heracross_test.rs"]
 mod heracross_test;
+#[path = "pokemon/hitmonchan_ex_test.rs"]
+mod hitmonchan_ex_test;
 #[path = "pokemon/honchkrow_evil_admonition_test.rs"]
 mod honchkrow_evil_admonition_test;
 #[path = "pokemon/houndstone_last_respects_test.rs"]

--- a/tests/pokemon/hitmonchan_ex_test.rs
+++ b/tests/pokemon/hitmonchan_ex_test.rs
@@ -1,0 +1,31 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_hitmonchan_ex_quick_straight_ignores_weakness() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1124HitmonchanEx)
+            .with_energy(vec![EnergyType::Fighting])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1124HitmonchanEx, 0),
+        is_stack: false,
+    });
+
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        100,
+        "Quick Straight should deal 50 damage without applying Fighting weakness"
+    );
+}


### PR DESCRIPTION
## Summary

- Implement Hitmonchan ex's Quick Straight attack effect by mapping its shared effect text to a new attack mechanic.
- Add a damage path that preserves normal attack damage modifiers while skipping Weakness for attacks whose text says damage is not affected by Weakness.
- Add a Game-level regression test proving Hitmonchan ex deals 50, not 70, into a Fighting-weak Snorlax.

## Root Cause

The effect text 'This attack's damage isn't affected by Weakness.' was still unmapped, so Hitmonchan ex panicked when attacking instead of resolving Quick Straight.

## Validation

- cargo test --features test-utils --test pokemon
- cargo test --features test-utils --test stadiums
- cargo run --bin card_test -- "B1 124"
- cargo clippy --all-targets --all-features -- -D warnings
- git diff --check