### PR TITLE
Implement counterattack effects for Spike Armor abilities

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -354,9 +354,33 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("During your opponent's next turn, if the Defending Pokémon tries to use an attack, your opponent flips a coin. If tails, that attack doesn't happen.", todo_implementation);
     // map.insert("During your opponent's next turn, if they attach Energy from their Energy Zone to the Defending Pokémon, that Pokémon will be Asleep.", todo_implementation);
-    // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 20 damage to the Attacking Pokémon.", todo_implementation);
-    // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 30 damage to the Attacking Pokémon.", todo_implementation);
-    // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 40 damage to the Attacking Pokémon.", todo_implementation);
+    map.insert(
+        "During your opponent's next turn, if this Pokémon is damaged by an attack, do 20 damage to the Attacking Pokémon.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::Counterattack { amount: 20 },
+            duration: 1,
+            coin_flip: false,
+        },
+    );
+    map.insert(
+        "During your opponent's next turn, if this Pokémon is damaged by an attack, do 30 damage to the Attacking Pokémon.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::Counterattack { amount: 30 },
+            duration: 1,
+            coin_flip: false,
+        },
+    );
+    map.insert(
+        "During your opponent's next turn, if this Pokémon is damaged by an attack, do 40 damage to the Attacking Pokémon.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::Counterattack { amount: 40 },
+            duration: 1,
+            coin_flip: false,
+        },
+    );
     map.insert(
         "During your opponent's next turn, prevent all damage done to this Pokémon by attacks if that damage is 40 or less.",
         Mechanic::DamageAndCardEffect {
@@ -1699,7 +1723,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("Discard Water2 [W] Energy from this Pokémon. Your opponent's Active Pokémon is now Paralyzed.", todo_implementation);
     // map.insert("Discard a Stadium in play.", todo_implementation);
     // map.insert("During your next turn, attacks used by your Pokémon do +20 damage to your opponent's Active Pokémon.", todo_implementation);
-    // map.insert("During your opponent's next turn, if this Pokémon is damaged by an attack, do 80 damage to the Attacking Pokémon.", todo_implementation);
+    map.insert(
+        "During your opponent's next turn, if this Pokémon is damaged by an attack, do 80 damage to the Attacking Pokémon.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::Counterattack { amount: 80 },
+            duration: 1,
+            coin_flip: false,
+        },
+    );
     // map.insert("During your opponent's next turn, if this Pokémon is in the Active Spot when your opponent's Active Pokémon retreats, this attack does 40 damage to the new Active Pokémon.", todo_implementation);
     // map.insert("During your opponent's next turn, this Pokémon takes -80 damage from attacks from your opponent's Pokémon ex.", todo_implementation);
     // map.insert("Flip 2 coins. If both of them are heads, this attack does 20 more damage.", todo_implementation);

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -33,6 +33,12 @@ pub enum CardEffect {
     DelayedDamage {
         amount: u32,
     },
+    /// If this Pokémon is damaged by an attack while in the Active Spot, deal `amount`
+    /// damage to the Attacking Pokémon (e.g. Alolan Sandslash's Spike Armor). Temporary
+    /// counterpart to RockyHelmet's always-on recoil.
+    Counterattack {
+        amount: u32,
+    },
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/hooks/counterattack.rs
+++ b/src/hooks/counterattack.rs
@@ -1,4 +1,4 @@
-use crate::{card_ids::CardId, models::PlayedCard, tools::has_tool};
+use crate::{card_ids::CardId, effects::CardEffect, models::PlayedCard, tools::has_tool};
 
 /// Some cards counterattack either because of RockyHelmet or because of their own ability.
 pub(crate) fn get_counterattack_damage(card: &PlayedCard) -> u32 {
@@ -6,6 +6,16 @@ pub(crate) fn get_counterattack_damage(card: &PlayedCard) -> u32 {
     if has_tool(card, CardId::A2148RockyHelmet) {
         total_damage += 20;
     }
+
+    // Temporary counterattack effects (e.g. Alolan Sandslash's Spike Armor).
+    total_damage += card
+        .get_active_effects()
+        .iter()
+        .filter_map(|effect| match effect {
+            CardEffect::Counterattack { amount } => Some(*amount),
+            _ => None,
+        })
+        .sum::<u32>();
 
     // Some cards have it as an ability
     let card_id = CardId::from_card_id(&card.card.get_id());

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -1,5 +1,7 @@
 #[path = "pokemon/additional_ability_logic_test.rs"]
 mod additional_ability_logic_test;
+#[path = "pokemon/alolan_sandslash_spike_armor_test.rs"]
+mod alolan_sandslash_spike_armor_test;
 #[path = "pokemon/altaria_dragon_arcana_test.rs"]
 mod altaria_dragon_arcana_test;
 #[path = "pokemon/applin_share_test.rs"]

--- a/tests/pokemon/alolan_sandslash_spike_armor_test.rs
+++ b/tests/pokemon/alolan_sandslash_spike_armor_test.rs
@@ -1,0 +1,125 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+/// Alolan Sandslash's Spike Armor: "During your opponent's next turn, if this
+/// Pokémon is damaged by an attack, do 40 damage to the Attacking Pokémon."
+/// This counterattack is applied at the same place RockyHelmet does its recoil.
+#[test]
+fn test_alolan_sandslash_spike_armor_counters_attacker() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Alolan Sandslash (100 HP, Spike Armor = 20 dmg) vs Bulbasaur (70 HP, Vine Whip = 40 dmg)
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A3039AlolanSandslash)
+            .with_energy(vec![EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    // Sandslash uses Spike Armor: 20 damage to Bulbasaur + arm counterattack effect.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3039AlolanSandslash, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        50,
+        "Bulbasaur should take 20 damage from Spike Armor (70 - 20 = 50)"
+    );
+
+    // End Sandslash's turn.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    // Bulbasaur attacks Sandslash with Vine Whip (40 damage).
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(CardId::A1001Bulbasaur, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // Sandslash: 100 - 40 = 60.
+    assert_eq!(
+        state.get_active(0).get_remaining_hp(),
+        60,
+        "Alolan Sandslash should take 40 damage from Vine Whip"
+    );
+    // Spike Armor counters for 40: Bulbasaur 50 - 40 = 10.
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        10,
+        "Bulbasaur should take 40 counterattack damage from Spike Armor (50 - 40 = 10)"
+    );
+}
+
+/// Spike Armor only lasts during the opponent's next turn: once that turn passes,
+/// a later attack should not trigger the counterattack.
+#[test]
+fn test_alolan_sandslash_spike_armor_expires_after_one_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A3039AlolanSandslash)
+            .with_energy(vec![EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    // Sandslash uses Spike Armor.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3039AlolanSandslash, 0),
+        is_stack: false,
+    });
+    // End Sandslash's turn (opponent's "next turn" begins).
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    // Opponent's next turn passes without attacking.
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    // Sandslash's turn passes.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    let bulbasaur_hp_before = game.get_state_clone().get_active(1).get_remaining_hp();
+
+    // Now Bulbasaur attacks; the Spike Armor effect should already have expired.
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(CardId::A1001Bulbasaur, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        bulbasaur_hp_before,
+        "Spike Armor should have expired; Bulbasaur should take no counterattack damage"
+    );
+}


### PR DESCRIPTION
## Summary
Adds support for temporary counterattack effects that trigger when a Pokémon with the effect is damaged by an attack. This enables implementation of abilities like Alolan Sandslash's Spike Armor, which deals damage back to the attacking Pokémon during the opponent's next turn.

## Key Changes
- **New `CardEffect::Counterattack`**: Added a new effect variant to represent temporary counterattack mechanics (distinct from RockyHelmet's permanent recoil)
- **Effect mechanic mappings**: Implemented four counterattack effect text mappings in `effect_mechanic_map.rs`:
  - 20 damage counterattack (e.g., Alolan Sandslash)
  - 30 damage counterattack
  - 40 damage counterattack
  - 80 damage counterattack
- **Counterattack damage calculation**: Updated `get_counterattack_damage()` to include temporary counterattack effects alongside RockyHelmet's permanent recoil
- **Comprehensive test coverage**: Added `alolan_sandslash_spike_armor_test.rs` with two test cases:
  - Verifies counterattack damage is applied when the protected Pokémon is attacked
  - Verifies the effect expires after one opponent turn (duration: 1)

## Implementation Details
- Counterattack effects use `duration: 1` to ensure they only apply during the opponent's immediate next turn
- The counterattack damage is applied at the same point in the damage calculation as RockyHelmet recoil, maintaining consistency with existing recoil mechanics
- All counterattack variants use `opponent: false` and `coin_flip: false` since they apply to the defending player's Pokémon without randomness

https://claude.ai/code/session_01V5jRRHDVsw7PC73b23oq7g