### PR TITLE
Add Cynthia trainer card implementation

### DIFF
--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -65,6 +65,7 @@ pub fn forecast_trainer_action(
         }
         CardId::A1220Misty | CardId::A1267Misty => misty_outcomes(),
         CardId::A1221Blaine | CardId::A1268Blaine => Outcomes::single_fn(blaine_effect),
+        CardId::A2152Cynthia | CardId::A2192Cynthia => Outcomes::single_fn(cynthia_effect),
         CardId::A1224Brock | CardId::A1271Brock => Outcomes::single_fn(brock_effect),
         CardId::A2a072Irida | CardId::A2a087Irida | CardId::A4b330Irida | CardId::A4b331Irida => {
             Outcomes::single_fn(irida_effect)
@@ -742,6 +743,17 @@ fn blaine_effect(_: &mut StdRng, state: &mut State, _: &Action) {
                 "Rapidash".to_string(),
                 "Magmar".to_string(),
             ],
+        },
+        0,
+    );
+}
+
+fn cynthia_effect(_: &mut StdRng, state: &mut State, _: &Action) {
+    // During this turn, attacks used by your Garchomp or Togekiss do +50 damage to your opponent's Active Pokemon.
+    state.add_turn_effect(
+        TurnEffect::IncreasedDamageForSpecificPokemon {
+            amount: 50,
+            pokemon_names: vec!["Garchomp".to_string(), "Togekiss".to_string()],
         },
         0,
     );

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -88,6 +88,7 @@ pub fn trainer_move_generation_implementation(
         }
         CardId::A1220Misty | CardId::A1267Misty => can_play_misty(state, trainer_card),
         CardId::A1221Blaine | CardId::A1268Blaine => can_play_trainer(state, trainer_card),
+        CardId::A2152Cynthia | CardId::A2192Cynthia => can_play_trainer(state, trainer_card),
         CardId::A1224Brock | CardId::A1271Brock => can_play_trainer(state, trainer_card),
         CardId::A2a072Irida | CardId::A2a087Irida | CardId::A4b330Irida | CardId::A4b331Irida => {
             can_play_irida(state, trainer_card)

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -1,5 +1,7 @@
 #[path = "trainers/barry_test.rs"]
 mod barry_test;
+#[path = "trainers/cynthia_test.rs"]
+mod cynthia_test;
 #[path = "trainers/field_blower_test.rs"]
 mod field_blower_test;
 #[path = "trainers/iris_trainer_test.rs"]

--- a/tests/trainers/cynthia_test.rs
+++ b/tests/trainers/cynthia_test.rs
@@ -1,0 +1,47 @@
+use deckgym::{
+    actions::SimpleAction,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+#[test]
+fn test_cynthia_boosts_garchomp_dragon_claw_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    // Garchomp with energy for Dragon Claw (100 base damage)
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A2123Garchomp)
+            .with_energy(vec![EnergyType::Water, EnergyType::Fighting])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur).with_remaining_hp(150)],
+    );
+    state.hands[0] = vec![get_card_by_enum(CardId::A2152Cynthia)];
+    game.set_state(state);
+
+    // Play Cynthia
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    let play_cynthia = actions
+        .iter()
+        .find(|a| matches!(&a.action, SimpleAction::Play { trainer_card } if trainer_card.name == "Cynthia"))
+        .expect("Cynthia should be playable");
+    game.apply_action(play_cynthia);
+
+    // Attack with Garchomp (Dragon Claw)
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    let attack = actions
+        .iter()
+        .find(|a| matches!(a.action, SimpleAction::Attack(_)))
+        .expect("Garchomp should be able to attack");
+    game.apply_action(attack);
+
+    // Dragon Claw does 100 base damage, +50 from Cynthia = 150, exactly KOing the 150 HP Bulbasaur
+    assert_eq!(
+        game.get_state_clone().points[0],
+        1,
+        "Opponent's Bulbasaur should be KO'd by 150 damage (100 + 50 from Cynthia), scoring a point"
+    );
+}


### PR DESCRIPTION
## Summary
Implements the Cynthia trainer card, which boosts attack damage for Garchomp and Togekiss during the turn it's played.

## Changes
- Added `cynthia_effect()` function to apply a +50 damage turn effect for Garchomp and Togekiss attacks
- Registered Cynthia card IDs (A2152Cynthia and A2192Cynthia) in trainer action forecasting
- Registered Cynthia card IDs in trainer move generation to allow playing the card
- Added comprehensive test (`test_cynthia_boosts_garchomp_dragon_claw_damage`) verifying the damage boost works correctly with Garchomp's Dragon Claw attack

## Implementation Details
The Cynthia effect uses the existing `TurnEffect::IncreasedDamageForSpecificPokemon` mechanism to apply +50 damage to attacks used by Garchomp or Togekiss against the opponent's Active Pokémon during the current turn.

https://claude.ai/code/session_01B2YwpgYzPzSqyzfPdV9iUb