### PR TITLE
Implement Volkner trainer card effect

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -101,6 +101,11 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
             *in_play_idx,
             *num_random_energies,
         ),
+        SimpleAction::AttachTypedFromDiscard {
+            in_play_idx,
+            energy_type,
+            count,
+        } => forecast_attach_typed_from_discard(*in_play_idx, *energy_type, *count),
         SimpleAction::SadaAttach { assignments } => forecast_sada_attach(assignments),
         SimpleAction::UseStadium => forecast_use_stadium(state, action.actor),
         // acting_player is not passed here, because there is only 1 turn to end. The current turn.
@@ -716,6 +721,22 @@ fn forecast_attach_from_discard(
     }
 
     Outcomes::from_parts(probabilities, mutations)
+}
+
+/// Volkner: deterministically attach up to `count` energies of `energy_type` from discard.
+fn forecast_attach_typed_from_discard(
+    in_play_idx: usize,
+    energy_type: EnergyType,
+    count: usize,
+) -> Outcomes {
+    Outcomes::single_fn(move |_rng, state, action| {
+        let available = state.discard_energies[action.actor]
+            .iter()
+            .filter(|e| **e == energy_type)
+            .count();
+        let energies = vec![energy_type; std::cmp::min(count, available)];
+        state.attach_energy_from_discard(action.actor, in_play_idx, &energies);
+    })
 }
 
 /// Generate all unique 2-energy combinations from a list of energies in discard pile.

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -141,6 +141,7 @@ pub fn forecast_trainer_action(
         CardId::B1217FlamePatch | CardId::B1331FlamePatch => {
             Outcomes::single_fn(flame_patch_effect)
         }
+        CardId::A2153Volkner | CardId::A2193Volkner => Outcomes::single_fn(volkner_effect),
         CardId::B1225Copycat | CardId::B1270Copycat => Outcomes::single_fn(copycat_effect),
         CardId::A2b069Iono | CardId::A2b088Iono | CardId::A4b340Iono | CardId::A4b341Iono => {
             Outcomes::single_fn(iono_effect)
@@ -1101,6 +1102,34 @@ fn lusamine_effect(_: &mut StdRng, state: &mut State, action: &Action) {
         .map(|(idx, _)| SimpleAction::AttachFromDiscard {
             in_play_idx: idx,
             num_random_energies: num_energies_to_attach,
+        })
+        .collect();
+
+    if !possible_attachments.is_empty() {
+        state
+            .move_generation_stack
+            .push((player, possible_attachments));
+    }
+}
+
+/// Queue the decision for user to select Electivire or Luxray to attach Lightning energy to
+fn volkner_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    let player = action.actor;
+    let num_lightning_to_attach = std::cmp::min(
+        2,
+        state.discard_energies[player]
+            .iter()
+            .filter(|e| **e == EnergyType::Lightning)
+            .count(),
+    );
+
+    let possible_attachments: Vec<SimpleAction> = state
+        .enumerate_in_play_pokemon(player)
+        .filter(|(_, pokemon)| matches!(pokemon.get_name().as_str(), "Electivire" | "Luxray"))
+        .map(|(idx, _)| SimpleAction::AttachTypedFromDiscard {
+            in_play_idx: idx,
+            energy_type: EnergyType::Lightning,
+            count: num_lightning_to_attach,
         })
         .collect();
 

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -115,6 +115,12 @@ pub enum SimpleAction {
         in_play_idx: usize,
         num_random_energies: usize,
     },
+    /// Volkner: attach a fixed number of a specific energy type from discard to a Pokemon
+    AttachTypedFromDiscard {
+        in_play_idx: usize,
+        energy_type: EnergyType,
+        count: usize,
+    },
     /// Professor Sada: attach 3 specific different-typed energies from discard to Ancient Pokémon
     SadaAttach {
         assignments: Vec<(EnergyType, usize)>, // (energy_type, in_play_idx) × 3
@@ -272,6 +278,13 @@ impl fmt::Display for SimpleAction {
                 num_random_energies,
             } => {
                 write!(f, "AttachFromDiscard({in_play_idx}, {num_random_energies})")
+            }
+            SimpleAction::AttachTypedFromDiscard {
+                in_play_idx,
+                energy_type,
+                count,
+            } => {
+                write!(f, "AttachTypedFromDiscard({in_play_idx}, {energy_type:?}, {count})")
             }
             SimpleAction::SadaAttach { assignments } => {
                 let s = assignments

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -132,6 +132,7 @@ pub fn trainer_move_generation_implementation(
         | CardId::A4b350Lusamine
         | CardId::A4b351Lusamine
         | CardId::A4b375Lusamine => can_play_lusamine(state, trainer_card),
+        CardId::A2153Volkner | CardId::A2193Volkner => can_play_volkner(state, trainer_card),
         CardId::A3149Ilima | CardId::A3191Ilima => can_play_ilima(state, trainer_card),
         CardId::A3150Kiawe | CardId::A3192Kiawe => can_play_kiawe(state, trainer_card),
         CardId::A4157Lyra | CardId::A4197Lyra | CardId::A4b332Lyra | CardId::A4b333Lyra => {
@@ -613,6 +614,26 @@ fn can_play_lusamine(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Si
 
     // Check if player has at least 1 energy in discard
     if state.discard_energies[player].is_empty() {
+        return cannot_play_trainer();
+    }
+
+    can_play_trainer(state, trainer_card)
+}
+
+/// Check if Volkner can be played (requires an Electivire or Luxray in play and
+/// at least 1 Lightning Energy in discard)
+fn can_play_volkner(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let player = state.current_player;
+
+    let has_valid_target = state
+        .enumerate_in_play_pokemon(player)
+        .any(|(_, pokemon)| matches!(pokemon.get_name().as_str(), "Electivire" | "Luxray"));
+    if !has_valid_target {
+        return cannot_play_trainer();
+    }
+
+    let has_lightning_in_discard = state.discard_energies[player].contains(&EnergyType::Lightning);
+    if !has_lightning_in_discard {
         return cannot_play_trainer();
     }
 

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -63,6 +63,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::DiscardOpponentSupporter { .. } => 5,
         SimpleAction::DiscardOwnCards { .. } => 5,
         SimpleAction::AttachFromDiscard { .. } => 10,
+        SimpleAction::AttachTypedFromDiscard { .. } => 10,
         SimpleAction::SadaAttach { .. } => 10,
         SimpleAction::ApplyEeveeBagDamageBoost => 5,
         SimpleAction::HealAllEeveeEvolutions => 5,

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -14,3 +14,5 @@ mod marlon_test;
 mod professor_sada_test;
 #[path = "trainers/professor_turo_test.rs"]
 mod professor_turo_test;
+#[path = "trainers/volkner_test.rs"]
+mod volkner_test;

--- a/tests/trainers/volkner_test.rs
+++ b/tests/trainers/volkner_test.rs
@@ -1,0 +1,112 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard, TrainerCard},
+    test_support::get_initialized_game,
+};
+
+fn make_volkner_trainer_card() -> TrainerCard {
+    match get_card_by_enum(CardId::A2153Volkner) {
+        Card::Trainer(tc) => tc,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+fn play_volkner(game: &mut deckgym::Game) {
+    let trainer_card = make_volkner_trainer_card();
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+}
+
+/// Volkner cannot be played without an Electivire or Luxray in play.
+#[test]
+fn test_cannot_play_volkner_without_target() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_volkner_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card));
+    state.discard_energies[0] = vec![EnergyType::Lightning, EnergyType::Lightning];
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    let can_play = actions
+        .iter()
+        .any(|a| matches!(&a.action, SimpleAction::Play { .. }));
+    assert!(
+        !can_play,
+        "Should not be able to play Volkner without Electivire or Luxray, actions: {actions:?}"
+    );
+}
+
+/// Playing Volkner lets the player choose Electivire or Luxray, then attaches
+/// 2 Lightning Energy from the discard pile to the chosen Pokemon.
+#[test]
+fn test_volkner_attaches_two_lightning_energy_to_chosen_target() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A2057Electivire),
+            PlayedCard::from_id(CardId::A2060Luxray),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    state.hands[0].clear();
+    let trainer_card = make_volkner_trainer_card();
+    state.hands[0].push(Card::Trainer(trainer_card));
+    state.discard_energies[0] = vec![
+        EnergyType::Lightning,
+        EnergyType::Lightning,
+        EnergyType::Fire,
+    ];
+    game.set_state(state);
+
+    play_volkner(&mut game);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(
+        choices.len(),
+        2,
+        "Should be able to choose either Electivire (slot 0) or Luxray (slot 1); got: {choices:?}"
+    );
+
+    // Choose Luxray, the benched target (slot 1).
+    let luxray_choice = choices
+        .iter()
+        .find(|a| matches!(&a.action, SimpleAction::AttachTypedFromDiscard { in_play_idx, .. } if *in_play_idx == 1))
+        .expect("Should have a choice targeting Luxray");
+    game.apply_action(luxray_choice);
+
+    let state = game.get_state_clone();
+    let luxray = state.in_play_pokemon[0][1]
+        .as_ref()
+        .expect("Luxray should still be in play");
+    assert_eq!(luxray.attached_energy.len(), 2);
+    assert!(luxray
+        .attached_energy
+        .iter()
+        .all(|e| *e == EnergyType::Lightning));
+
+    assert_eq!(
+        state.discard_energies[0],
+        vec![EnergyType::Fire],
+        "Both Lightning energies should be removed from discard, Fire should remain"
+    );
+}


### PR DESCRIPTION
## Summary
Adds support for the Volkner trainer card, which allows a player to attach up to 2 Lightning Energy from their discard pile to either Electivire or Luxray in play.

## Key Changes
- **New action type**: Added `AttachTypedFromDiscard` to `SimpleAction` enum to support attaching a specific energy type in a fixed quantity from discard
- **Volkner effect implementation**: 
  - Added `volkner_effect()` function that generates choices for the player to select either Electivire or Luxray as the attachment target
  - Automatically determines the number of Lightning Energy available in discard (up to 2) and attaches them
- **Play validation**: Added `can_play_volkner()` check to ensure Volkner can only be played when:
  - At least one Electivire or Luxray is in play
  - At least one Lightning Energy is in the discard pile
- **Action forecasting**: Implemented `forecast_attach_typed_from_discard()` to deterministically apply the energy attachment
- **Weighted random player**: Added weight for the new action type in AI decision-making
- **Comprehensive tests**: Added test suite covering:
  - Cannot play Volkner without valid targets
  - Correct energy attachment to chosen Pokémon
  - Proper discard pile cleanup after attachment

## Implementation Details
The implementation follows the existing pattern for conditional trainer cards like Lusamine and Kiawe, using the move generation stack to queue player choices after the card is played.

https://claude.ai/code/session_01P7D5tVFHnX3Kph6spFuen4