### PR TITLE
Implement Whale Pump's water energy scaling damage mechanic

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1355,7 +1355,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "This attack does 20 damage to each of your opponent's Pokémon.",
         Mechanic::DamageAllOpponentPokemon { damage: 20 },
     );
-    // map.insert("This attack does 10 more damage for each [W] Energy attached to this Pokémon.", todo_implementation);
+    map.insert(
+        "This attack does 10 more damage for each [W] Energy attached to this Pokémon.",
+        Mechanic::ExtraDamagePerSpecificEnergy {
+            energy_type: EnergyType::Water,
+            damage_per_energy: 10,
+        },
+    );
     map.insert(
         "This attack does 100 damage to 1 of your opponent's Pokémon that have damage on them.",
         Mechanic::DirectDamageIfDamaged { damage: 100 },

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -138,6 +138,8 @@ mod terapagos_ex_test;
 mod vaporeon_ex_test;
 #[path = "pokemon/vulpix_tail_whip_test.rs"]
 mod vulpix_tail_whip_test;
+#[path = "pokemon/wailord_test.rs"]
+mod wailord_test;
 #[path = "pokemon/xerneas_geoburst_test.rs"]
 mod xerneas_geoburst_test;
 #[path = "pokemon/zekrom_bolt_strike_test.rs"]

--- a/tests/pokemon/wailord_test.rs
+++ b/tests/pokemon/wailord_test.rs
@@ -1,0 +1,79 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Whale Pump does 60 base + 10 more damage for each [W] Energy attached to Wailord.
+#[test]
+fn test_whale_pump_extra_damage_per_water_energy() {
+    // Wailord with 2 [W] energies: 60 + 2*10 = 80 damage
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B1057Wailord)
+            .with_energy(vec![EnergyType::Water, EnergyType::Water])],
+        vec![PlayedCard::new(
+            get_card_by_enum(CardId::A1001Bulbasaur),
+            0,
+            200,
+            vec![],
+            false,
+            vec![],
+        )],
+    );
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1057Wailord, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // 60 + (2 * 10) = 80 damage, opponent had 200 HP -> 120 remaining
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        120,
+        "Whale Pump should deal 80 damage with 2 Water energies (60 + 2*10)"
+    );
+}
+
+/// With no [W] energy attached, Whale Pump should only deal its fixed 60 damage.
+#[test]
+fn test_whale_pump_no_water_energy() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B1057Wailord).with_energy(vec![
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::new(
+            get_card_by_enum(CardId::A1001Bulbasaur),
+            0,
+            200,
+            vec![],
+            false,
+            vec![],
+        )],
+    );
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1057Wailord, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        140,
+        "Whale Pump should deal only 60 fixed damage with no Water energy"
+    );
+}


### PR DESCRIPTION
## Summary
Implements the "Whale Pump" attack mechanic for Wailord, which deals 10 additional damage for each Water energy attached to the Pokémon.

## Changes
- **Effect Mechanic Implementation**: Added support for `ExtraDamagePerSpecificEnergy` mechanic in the effect mechanic map, enabling attacks that scale damage based on a specific energy type attached to the attacking Pokémon
- **Test Coverage**: Added comprehensive tests for Wailord's Whale Pump attack:
  - Test with 2 Water energies: verifies 80 damage (60 base + 2×10 bonus)
  - Test with no Water energies: verifies 60 base damage only

## Implementation Details
The mechanic correctly counts only Water-type energies when calculating bonus damage, allowing other energy types to be attached without contributing to the damage multiplier. This follows the standard Pokémon TCG mechanic pattern where attacks can scale based on specific energy types.

https://claude.ai/code/session_01ThU89GeAPX3HqKLWQthQYC