### PR TITLE
Implement Salamence Dragon Dive coin flip self-damage mechanic

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1765,7 +1765,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::CoinFlipAlsoChoiceBenchDamage { opponent: true, damage: 40 },
     );
     // map.insert("Flip a coin. If heads, this attack does 70 damage to your opponent's Active Pokémon. If tails, heal 30 damage from your opponent's Active Pokémon.", todo_implementation);
-    // map.insert("Flip a coin. If tails, this Pokémon also does 50 damage to itself.", todo_implementation);
+    map.insert(
+        "Flip a coin. If tails, this Pokémon also does 50 damage to itself.",
+        Mechanic::CoinFlipSelfDamage { self_damage: 50 },
+    );
     // map.insert("Heal 20 damage from 1 of your Pokémon.", todo_implementation);
     // map.insert("If Plusle is on your Bench, this attack also does 10 damage to each of your opponent's Benched Pokémon.", todo_implementation);
     // map.insert("If a Stadium is in play, this attack does 40 more damage.", todo_implementation);

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -116,6 +116,8 @@ mod porygonz_cyberjack_test;
 mod rampardos_head_smash_test;
 #[path = "pokemon/roaring_moon_test.rs"]
 mod roaring_moon_test;
+#[path = "pokemon/salamence_test.rs"]
+mod salamence_test;
 #[path = "pokemon/shinx_hide_test.rs"]
 mod shinx_hide_test;
 #[path = "pokemon/slither_wing_test.rs"]

--- a/tests/pokemon/salamence_test.rs
+++ b/tests/pokemon/salamence_test.rs
@@ -1,0 +1,108 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard, TrainerCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+fn played_card_with_base_hp(card_id: CardId, base_hp: u32) -> PlayedCard {
+    PlayedCard::new(get_card_by_enum(card_id), 0, base_hp, vec![], false, vec![])
+}
+
+fn trainer_from_id(card_id: CardId) -> TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+fn use_dragon_dive(seed: u64, force_heads: bool) -> (u32, u32) {
+    let mut game = get_initialized_game(seed);
+    let mut state = game.get_state_clone();
+    let will = trainer_from_id(CardId::A4156Will);
+
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B2123Salamence).with_energy(vec![
+                EnergyType::Fire,
+                EnergyType::Water,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![played_card_with_base_hp(CardId::A1001Bulbasaur, 200)],
+    );
+    state.hands[0] = if force_heads {
+        vec![Card::Trainer(will.clone())]
+    } else {
+        vec![]
+    };
+    game.set_state(state);
+
+    if force_heads {
+        game.apply_action(&Action {
+            actor: 0,
+            action: deckgym::actions::SimpleAction::Play { trainer_card: will },
+            is_stack: false,
+        });
+    }
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2123Salamence, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    (
+        state.get_active(0).get_remaining_hp(),
+        state.get_active(1).get_remaining_hp(),
+    )
+}
+
+#[test]
+fn test_salamence_dragon_dive_heads_has_no_self_damage() {
+    for seed in 0..50 {
+        let (salamence_hp, opponent_hp) = use_dragon_dive(seed, true);
+
+        assert_eq!(
+            opponent_hp, 50,
+            "Seed {seed}: Dragon Dive should deal 150 damage"
+        );
+        assert_eq!(
+            salamence_hp, 150,
+            "Seed {seed}: Will should force heads, so Dragon Dive should not damage Salamence"
+        );
+    }
+}
+
+#[test]
+fn test_salamence_dragon_dive_tails_damages_itself() {
+    let mut saw_tails = false;
+
+    for seed in 0..200 {
+        let (salamence_hp, opponent_hp) = use_dragon_dive(seed, false);
+
+        assert_eq!(
+            opponent_hp, 50,
+            "Seed {seed}: Dragon Dive should deal 150 damage regardless of coin flip"
+        );
+
+        if salamence_hp == 100 {
+            saw_tails = true;
+        } else {
+            assert_eq!(
+                salamence_hp, 150,
+                "Seed {seed}: Dragon Dive should only leave Salamence at 150 HP on heads or 100 HP on tails"
+            );
+        }
+    }
+
+    assert!(
+        saw_tails,
+        "Expected at least one tails outcome where Dragon Dive does 50 damage to Salamence"
+    );
+}


### PR DESCRIPTION
## Summary
Implements the coin flip self-damage mechanic for Salamence's Dragon Dive attack, which deals 50 damage to itself on tails.

## Changes
- Added `CoinFlipSelfDamage` mechanic mapping in `effect_mechanic_map.rs` for the "Flip a coin. If tails, this Pokémon also does 50 damage to itself." effect text
- Added comprehensive test suite for Salamence's Dragon Dive attack in `tests/pokemon/salamence_test.rs` with:
  - Test verifying no self-damage occurs when Will trainer card forces heads
  - Test verifying 50 self-damage occurs on tails outcomes
  - Tests run across multiple random seeds to ensure proper coin flip behavior

## Implementation Details
The mechanic is mapped to handle the conditional self-damage based on coin flip results, allowing Dragon Dive to deal its full 150 damage to the opponent while potentially damaging Salamence itself depending on the flip outcome.

https://claude.ai/code/session_01DzKUvdbNSUj2Xb93RsS6JE