### PR TITLE
Implement Gardevoir Psychic Turbo attack energy attachment

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1797,7 +1797,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             name: "Spewpa".to_string(),
         },
     );
-    // map.insert("Take 2 [P] Energy from your Energy Zone and attach it to 1 of your Benched [P] Pokémon.", todo_implementation);
+    map.insert(
+        "Take 2 [P] Energy from your Energy Zone and attach it to 1 of your Benched [P] Pokémon.",
+        Mechanic::ChargeBench {
+            energies: vec![EnergyType::Psychic, EnergyType::Psychic],
+            target_benched_type: Some(EnergyType::Psychic),
+        },
+    );
     map.insert(
         "Take 3 [P] Energy from your Energy Zone and attach it to your [P] Pokémon in any way you like.",
         Mechanic::ChargeYourTypeAnyWay {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -54,6 +54,8 @@ mod flutter_mane_ex_test;
 mod flygon_ex_test;
 #[path = "pokemon/gallade_test.rs"]
 mod gallade_test;
+#[path = "pokemon/gardevoir_psy_turbo_test.rs"]
+mod gardevoir_psy_turbo_test;
 #[path = "pokemon/grovyle_slicing_snipe_test.rs"]
 mod grovyle_slicing_snipe_test;
 #[path = "pokemon/hatterene_test.rs"]

--- a/tests/pokemon/gardevoir_psy_turbo_test.rs
+++ b/tests/pokemon/gardevoir_psy_turbo_test.rs
@@ -1,0 +1,47 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+#[test]
+fn test_gardevoir_psy_turbo_attaches_energy_to_benched_psychic_pokemon() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B2065Gardevoir)
+                .with_energy(vec![EnergyType::Psychic, EnergyType::Psychic]),
+            PlayedCard::from_id(CardId::A1130Ralts),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2065Gardevoir, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    // Only the Psychic-type Ralts on the bench should be a valid attach target,
+    // not the Colorless/Fire Charmander.
+    assert!(!choices.is_empty());
+    assert!(choices.iter().all(|choice| {
+        matches!(
+            &choice.action,
+            SimpleAction::Attach { attachments, .. }
+                if attachments.iter().all(|(_, _, in_play_idx)| *in_play_idx == 1)
+        )
+    }));
+
+    let chosen = choices[0].clone();
+    game.apply_action(&chosen);
+
+    let state = game.get_state_clone();
+    let ralts = state.in_play_pokemon[0][1]
+        .as_ref()
+        .expect("Ralts should still be on the bench");
+    assert_eq!(ralts.attached_energy.len(), 2);
+}


### PR DESCRIPTION
## Summary
Implements the energy attachment mechanic for Gardevoir's Psychic Turbo attack, which attaches 2 Psychic energy from the Energy Zone to a benched Psychic-type Pokémon.

## Changes
- **Effect mechanic implementation**: Added `ChargeBench` mechanic mapping for Gardevoir's attack text that attaches 2 Psychic energy to benched Psychic-type Pokémon only
- **Test coverage**: Added comprehensive test (`test_gardevoir_psy_turbo_attaches_energy_to_benched_psychic_pokemon`) that verifies:
  - The attack correctly identifies valid targets (benched Psychic-type Pokémon)
  - Non-Psychic benched Pokémon are excluded from valid targets
  - Energy is properly attached to the selected benched Pokémon

## Implementation Details
The mechanic uses the existing `ChargeBench` variant with:
- `energies`: Vector containing two Psychic energy types
- `target_benched_type`: Set to `Some(EnergyType::Psychic)` to restrict valid targets to Psychic-type Pokémon only

https://claude.ai/code/session_01Vehj7wyCCwiczuGLSEgcTD