### PR TITLE
Implement attack history tracking for conditional damage mechanics

### DIFF
--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -701,6 +701,9 @@ pub(crate) fn wrap_with_common_logic(mutation: Mutation) -> Mutation {
                 .expect("Pokemon should be there if using ability");
             pokemon.ability_used = true;
         }
+        if let SimpleAction::Attack(attack) = &action.action {
+            state.record_attack_used(action.actor, attack.title.clone());
+        }
 
         mutation(rng, state, action); // in the case of attacks, have this be damage + effect.
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -499,6 +499,15 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage } => {
             extra_damage_if_knocked_out_last_turn_attack(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::ExtraDamageIfAttackUsedDuringOwnLastTurn {
+            attack_name,
+            extra_damage,
+        } => extra_damage_if_attack_used_during_own_last_turn(
+            state,
+            attack.fixed_damage,
+            attack_name,
+            *extra_damage,
+        ),
         Mechanic::ExtraDamageIfMovedFromBench { extra_damage } => {
             extra_damage_if_moved_from_bench_attack(state, attack.fixed_damage, *extra_damage)
         }
@@ -2405,6 +2414,20 @@ fn extra_damage_if_knocked_out_last_turn_attack(
     extra_damage: u32,
 ) -> AttackOutcomes {
     let damage = if state.knocked_out_by_opponent_attack_last_turn {
+        base_damage + extra_damage
+    } else {
+        base_damage
+    };
+    active_damage_doutcome(damage)
+}
+
+fn extra_damage_if_attack_used_during_own_last_turn(
+    state: &State,
+    base_damage: u32,
+    attack_name: &str,
+    extra_damage: u32,
+) -> AttackOutcomes {
+    let damage = if state.used_attack_during_own_last_turn(state.current_player, attack_name) {
         base_damage + extra_damage
     } else {
         base_damage

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -269,6 +269,10 @@ pub enum Mechanic {
     ExtraDamageIfKnockedOutLastTurn {
         extra_damage: u32,
     },
+    ExtraDamageIfAttackUsedDuringOwnLastTurn {
+        attack_name: String,
+        extra_damage: u32,
+    },
     ExtraDamageIfMovedFromBench {
         extra_damage: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -769,9 +769,27 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("Heal 50 damage from 1 of your Benched Pokémon.", todo_implementation);
     // map.insert("Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon.", todo_implementation);
-    // map.insert("If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 20 more damage.", todo_implementation);
-    // map.insert("If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 30 more damage.", todo_implementation);
-    // map.insert("If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 60 more damage.", todo_implementation);
+    map.insert(
+        "If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 20 more damage.",
+        Mechanic::ExtraDamageIfAttackUsedDuringOwnLastTurn {
+            attack_name: "Sweets Relay".to_string(),
+            extra_damage: 20,
+        },
+    );
+    map.insert(
+        "If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 30 more damage.",
+        Mechanic::ExtraDamageIfAttackUsedDuringOwnLastTurn {
+            attack_name: "Sweets Relay".to_string(),
+            extra_damage: 30,
+        },
+    );
+    map.insert(
+        "If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 60 more damage.",
+        Mechanic::ExtraDamageIfAttackUsedDuringOwnLastTurn {
+            attack_name: "Sweets Relay".to_string(),
+            extra_damage: 60,
+        },
+    );
     map.insert(
         "If Durant is on your Bench, this attack does 40 more damage.",
         Mechanic::ExtraDamageIfPokemonOnBench {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -69,6 +69,11 @@ pub struct State {
     pub has_used_stadium: [bool; 2], // Tracks if each player has used the stadium this turn
     pub(crate) knocked_out_by_opponent_attack_this_turn: bool,
     pub(crate) knocked_out_by_opponent_attack_last_turn: bool,
+    // Name of the attack (if any) each player used during their current/previous own turn
+    // (e.g. for Vanilluxe's "Sweets Relay": "If 1 of your Pokémon used Sweets Relay during
+    // your last turn, this attack does more damage.").
+    pub(crate) attack_name_used_this_turn: [Option<String>; 2],
+    pub(crate) attack_name_used_last_turn: [Option<String>; 2],
     // Maps turn to a vector of effects (cards) for that turn. Using BTreeMap to keep State hashable.
     turn_effects: BTreeMap<u8, Vec<TurnEffect>>,
 }
@@ -96,6 +101,8 @@ impl State {
 
             knocked_out_by_opponent_attack_this_turn: false,
             knocked_out_by_opponent_attack_last_turn: false,
+            attack_name_used_this_turn: [None, None],
+            attack_name_used_last_turn: [None, None],
             turn_effects: BTreeMap::new(),
         }
     }
@@ -462,6 +469,8 @@ impl State {
             (self.current_player + 1) % 2
         );
         self.end_turn_pending = false;
+        self.attack_name_used_last_turn[self.current_player] =
+            self.attack_name_used_this_turn[self.current_player].take();
         self.current_player = (self.current_player + 1) % 2;
         self.turn_count += 1;
         if self.turn_count > 30 {
@@ -606,6 +615,22 @@ impl State {
     /// Get the flag indicating a Pokemon was KO'd by opponent's attack last turn.
     pub fn get_knocked_out_by_opponent_attack_last_turn(&self) -> bool {
         self.knocked_out_by_opponent_attack_last_turn
+    }
+
+    pub(crate) fn record_attack_used(&mut self, player: usize, attack_name: String) {
+        self.attack_name_used_this_turn[player] = Some(attack_name);
+    }
+
+    pub(crate) fn used_attack_during_own_last_turn(
+        &self,
+        player: usize,
+        attack_name: &str,
+    ) -> bool {
+        self.attack_name_used_last_turn[player].as_deref() == Some(attack_name)
+    }
+
+    pub fn set_attack_name_used_last_turn(&mut self, player: usize, attack_name: Option<String>) {
+        self.attack_name_used_last_turn[player] = attack_name;
     }
 
     /// Generate all possible actions for the current game state.

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -134,6 +134,8 @@ mod tapu_lele_energy_arrow_test;
 mod tepig_stoke_test;
 #[path = "pokemon/terapagos_ex_test.rs"]
 mod terapagos_ex_test;
+#[path = "pokemon/vanilluxe_test.rs"]
+mod vanilluxe_test;
 #[path = "pokemon/vaporeon_ex_test.rs"]
 mod vaporeon_ex_test;
 #[path = "pokemon/vulpix_tail_whip_test.rs"]

--- a/tests/pokemon/vanilluxe_test.rs
+++ b/tests/pokemon/vanilluxe_test.rs
@@ -1,0 +1,59 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_vanilluxe_sweets_relay_no_bonus_without_prior_use() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2039Vanilluxe)
+            .with_energy(vec![EnergyType::Water, EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2039Vanilluxe, 0),
+        is_stack: false,
+    });
+
+    let final_state = game.get_state_clone();
+    assert_eq!(
+        final_state.get_active(1).get_remaining_hp(),
+        10,
+        "Sweets Relay should only deal its base 60 damage with no prior Sweets Relay use"
+    );
+}
+
+#[test]
+fn test_vanilluxe_sweets_relay_gets_bonus_after_own_last_turn_use() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2039Vanilluxe)
+            .with_energy(vec![EnergyType::Water, EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.set_attack_name_used_last_turn(0, Some("Sweets Relay".to_string()));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2039Vanilluxe, 0),
+        is_stack: false,
+    });
+
+    let final_state = game.get_state_clone();
+    assert_eq!(
+        final_state.get_active(1).get_remaining_hp(),
+        30,
+        "Sweets Relay should deal 60 base + 60 bonus damage after a prior turn's Sweets Relay use"
+    );
+}

--- a/tests/pokemon/vanilluxe_test.rs
+++ b/tests/pokemon/vanilluxe_test.rs
@@ -1,8 +1,9 @@
 use deckgym::{
-    actions::Action,
+    actions::{Action, SimpleAction},
     card_ids::CardId,
     models::{EnergyType, PlayedCard},
     test_support::{attack_action, get_initialized_game},
+    Game,
 };
 
 #[test]
@@ -31,8 +32,44 @@ fn test_vanilluxe_sweets_relay_no_bonus_without_prior_use() {
     );
 }
 
+/// Drives the game forward (auto-ending every other player's turn, and resolving any forced
+/// single-choice actions like the post-turn draw) until it's `target_player`'s turn again with a
+/// clean decision point (no pending move-generation stack).
+fn advance_to_players_next_turn(game: &mut Game, target_player: usize) {
+    loop {
+        let state = game.get_state_clone();
+        let (_actor, actions) = state.generate_possible_actions();
+        let only_forced_end_turn =
+            actions.len() == 1 && matches!(actions[0].action, SimpleAction::EndTurn);
+        if state.current_player == target_player
+            && state.move_generation_stack.is_empty()
+            && !only_forced_end_turn
+        {
+            break;
+        }
+        let action = actions
+            .iter()
+            .find(|action| matches!(action.action, SimpleAction::EndTurn))
+            .unwrap_or(&actions[0])
+            .clone();
+        game.apply_action(&action);
+    }
+}
+
+/// Resets a player's active Pokemon back to full HP, without touching any other state (in
+/// particular, doesn't touch the "attack used during last turn" bookkeeping).
+fn heal_active_to_full(game: &mut Game, player: usize, total_hp: u32) {
+    let mut state = game.get_state_clone();
+    let healed = state.in_play_pokemon[player][0]
+        .take()
+        .expect("active Pokemon should be there")
+        .with_remaining_hp(total_hp);
+    state.in_play_pokemon[player][0] = Some(healed);
+    game.set_state(state);
+}
+
 #[test]
-fn test_vanilluxe_sweets_relay_gets_bonus_after_own_last_turn_use() {
+fn test_vanilluxe_sweets_relay_gets_bonus_after_own_last_turn_use_multi_turn() {
     let mut game = get_initialized_game(0);
     let mut state = game.get_state_clone();
     state.current_player = 0;
@@ -41,19 +78,84 @@ fn test_vanilluxe_sweets_relay_gets_bonus_after_own_last_turn_use() {
             .with_energy(vec![EnergyType::Water, EnergyType::Water])],
         vec![PlayedCard::from_id(CardId::A1211Snorlax)],
     );
-    state.set_attack_name_used_last_turn(0, Some("Sweets Relay".to_string()));
     game.set_state(state);
 
+    // Turn 1: no Sweets Relay used yet, so only the base 60 damage applies.
     game.apply_action(&Action {
         actor: 0,
         action: attack_action(CardId::B2039Vanilluxe, 0),
         is_stack: false,
     });
-
-    let final_state = game.get_state_clone();
     assert_eq!(
-        final_state.get_active(1).get_remaining_hp(),
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        90,
+        "First Sweets Relay use should deal only the base 60 damage"
+    );
+
+    // Play through the opponent's turn (no Sweets Relay use happens for them) and get back to
+    // player 0's turn.
+    advance_to_players_next_turn(&mut game, 0);
+    heal_active_to_full(&mut game, 1, 150);
+
+    // Turn 2 (player 0's next own turn): Sweets Relay was used during their last turn, so this
+    // attack should now deal the base 60 + 60 bonus damage.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2039Vanilluxe, 0),
+        is_stack: false,
+    });
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
         30,
-        "Sweets Relay should deal 60 base + 60 bonus damage after a prior turn's Sweets Relay use"
+        "Sweets Relay should deal 60 base + 60 bonus damage after a prior own-turn use"
+    );
+}
+
+#[test]
+fn test_vanilluxe_sweets_relay_bonus_does_not_stack_across_turns() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2039Vanilluxe)
+            .with_energy(vec![EnergyType::Water, EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    game.set_state(state);
+
+    // Turn 1: base damage only.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2039Vanilluxe, 0),
+        is_stack: false,
+    });
+    advance_to_players_next_turn(&mut game, 0);
+    heal_active_to_full(&mut game, 1, 150);
+
+    // Turn 2: gets the bonus from turn 1's use.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2039Vanilluxe, 0),
+        is_stack: false,
+    });
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        30,
+        "Second consecutive Sweets Relay use should get the bonus"
+    );
+    advance_to_players_next_turn(&mut game, 0);
+    heal_active_to_full(&mut game, 1, 150);
+
+    // Turn 3: still only a single +60 bonus, not a stacked +120, even though Sweets Relay has
+    // now been used on every prior own turn.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2039Vanilluxe, 0),
+        is_stack: false,
+    });
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        30,
+        "Sweets Relay bonus should not stack across repeated own-turn uses"
     );
 }


### PR DESCRIPTION
## Summary
This PR adds support for attack mechanics that deal bonus damage based on whether a specific attack was used during the player's previous turn. This enables implementation of cards like Vanilluxe with the "Sweets Relay" attack effect.

## Key Changes
- **State tracking**: Added `attack_name_used_this_turn` and `attack_name_used_last_turn` arrays to track which attacks each player has used, with automatic rotation at end of turn
- **New mechanic**: Introduced `ExtraDamageIfAttackUsedDuringOwnLastTurn` variant to the `Mechanic` enum to support conditional damage bonuses
- **Attack recording**: Modified `wrap_with_common_logic` to automatically record the attack name whenever an attack action is executed
- **Effect mapping**: Implemented three variants of the Sweets Relay bonus damage effect (20, 30, and 60 extra damage) in the effect mechanic map
- **Helper methods**: Added `record_attack_used()`, `used_attack_during_own_last_turn()`, and `set_attack_name_used_last_turn()` to the State API
- **Tests**: Added comprehensive test coverage for Vanilluxe's Sweets Relay attack, verifying both the base damage case and the bonus damage case when the attack was used on the previous turn

## Implementation Details
The attack history is managed at the state level and automatically transitions from "this turn" to "last turn" during the `end_turn()` method, ensuring the history is always available for damage calculation during the next player's turn.

https://claude.ai/code/session_017YNdgcZyhmbZdY2ZNwomsv