### PR TITLE
Implement Breloom (B3 012) Pre-Dawn Strike attack effect

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -678,6 +678,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfDefenderConfused { extra_damage } => {
             extra_damage_if_defender_confused(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::ExtraDamageIfDefenderAsleep { extra_damage } => {
+            extra_damage_if_defender_asleep(state, attack.fixed_damage, *extra_damage)
+        }
         Mechanic::DiscardTopSelfDeck => discard_top_self_deck(attack.fixed_damage),
         Mechanic::TieredCoinFlipDamage {
             num_coins,
@@ -2798,6 +2801,20 @@ fn extra_damage_if_defender_confused(
 ) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     let damage = if state.get_active(opponent).is_confused() {
+        base_damage + extra_damage
+    } else {
+        base_damage
+    };
+    active_damage_doutcome(damage)
+}
+
+fn extra_damage_if_defender_asleep(
+    state: &State,
+    base_damage: u32,
+    extra_damage: u32,
+) -> AttackOutcomes {
+    let opponent = (state.current_player + 1) % 2;
+    let damage = if state.get_active(opponent).is_asleep() {
         base_damage + extra_damage
     } else {
         base_damage

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -409,6 +409,10 @@ pub enum Mechanic {
     ExtraDamageIfDefenderConfused {
         extra_damage: u32,
     },
+    /// Breloom – Pre-Dawn Strike: extra damage if opponent's active is Asleep.
+    ExtraDamageIfDefenderAsleep {
+        extra_damage: u32,
+    },
     /// Discard the top card of the attacker's own deck after dealing damage.
     DiscardTopSelfDeck,
     /// Tiered coin flip damage: flip `num_coins` coins and deal fixed_damage +

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2148,7 +2148,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::ExtraDamageIfStage2OnBench { extra_damage: 50 },
     );
     // map.insert("If your opponent has any [P] Pokémon in play, this attack does 50 more damage.", todo_implementation);
-    // map.insert("If your opponent's Active Pokémon is Asleep, this attack does 60 more damage.", todo_implementation);
+    map.insert(
+        "If your opponent's Active Pokémon is Asleep, this attack does 60 more damage.",
+        Mechanic::ExtraDamageIfDefenderAsleep { extra_damage: 60 },
+    );
     map.insert(
         "If your opponent's Active Pokémon is Confused, this attack does 70 more damage.",
         Mechanic::ExtraDamageIfDefenderConfused { extra_damage: 70 },

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -18,6 +18,8 @@ mod bombirdier_test;
 mod bonsly_teary_attack_test;
 #[path = "pokemon/brambleghast_accept_pain_test.rs"]
 mod brambleghast_accept_pain_test;
+#[path = "pokemon/breloom_test.rs"]
+mod breloom_test;
 #[path = "pokemon/camerupt_eruption_test.rs"]
 mod camerupt_eruption_test;
 #[path = "pokemon/carracosta_blocking_shell_test.rs"]

--- a/tests/pokemon/breloom_test.rs
+++ b/tests/pokemon/breloom_test.rs
@@ -1,0 +1,65 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard, StatusCondition},
+    test_support::{attack_action, get_initialized_game},
+};
+
+/// Breloom's Pre-Dawn Strike deals 30 damage normally, or 30 + 60 = 90 damage
+/// if the opponent's Active Pokémon is Asleep.
+#[test]
+fn test_pre_dawn_strike_extra_damage_when_opponent_asleep() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Player 0: Breloom (Grass) with 1 Grass energy (enough for Pre-Dawn Strike).
+    // Player 1: Snorlax (150 HP, weak to Fighting - no weakness bonus vs Grass).
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3012Breloom).with_energy(vec![EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.current_player = 0;
+    state.apply_status_condition(1, 0, StatusCondition::Asleep);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3012Breloom, 0),
+        is_stack: false,
+    });
+
+    // Snorlax 150 HP - 90 (30 base + 60 asleep bonus) = 60.
+    let hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        hp, 60,
+        "Pre-Dawn Strike should deal 90 damage to an Asleep opponent"
+    );
+}
+
+/// When the opponent's Active Pokémon is not Asleep, Pre-Dawn Strike deals only
+/// its base 30 damage.
+#[test]
+fn test_pre_dawn_strike_base_damage_when_opponent_not_asleep() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3012Breloom).with_energy(vec![EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3012Breloom, 0),
+        is_stack: false,
+    });
+
+    // Snorlax 150 HP - 30 (base damage only) = 120.
+    let hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        hp, 120,
+        "Pre-Dawn Strike should deal only base 30 damage when opponent is not Asleep"
+    );
+}


### PR DESCRIPTION
Add ExtraDamageIfDefenderAsleep mechanic for the "if opponent's Active
is Asleep, this attack does 60 more damage" effect, following the
existing ExtraDamageIfDefenderConfused/Poisoned pattern.