### PR TITLE
Implement Typhlosion's Fire Breath ability

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -100,6 +100,7 @@ pub enum AbilityMechanic {
     },
     PoisonOpponentActive,
     ConfuseOpponentActive,
+    BurnOpponentActive,
     RemoveRandomSpecialConditionFromActive,
     HealActiveYourPokemon {
         amount: u32,

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -169,6 +169,7 @@ fn forecast_ability_by_mechanic(
         } => discard_energy_to_increase_type_damage(*discard_energy, *attack_type, *amount),
         AbilityMechanic::PoisonOpponentActive => poison_opponent_active(),
         AbilityMechanic::ConfuseOpponentActive => confuse_opponent_active(),
+        AbilityMechanic::BurnOpponentActive => burn_opponent_active(),
         AbilityMechanic::RemoveRandomSpecialConditionFromActive => {
             remove_random_special_condition_from_active()
         }
@@ -501,6 +502,13 @@ fn confuse_opponent_active() -> Outcomes {
     Outcomes::single_fn(|_rng, state, action| {
         let opponent = (action.actor + 1) % 2;
         state.apply_status_condition(opponent, 0, StatusCondition::Confused);
+    })
+}
+
+fn burn_opponent_active() -> Outcomes {
+    Outcomes::single_fn(|_rng, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        state.apply_status_condition(opponent, 0, StatusCondition::Burned);
     })
 }
 

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -246,7 +246,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
         );
         // map.insert("Once during your turn, you may heal 30 damage from each of your [W] Pokémon.", todo_implementation);
         // map.insert("Once during your turn, you may look at the top card of your deck.", todo_implementation);
-        // map.insert("Once during your turn, you may make your opponent's Active Pokémon Burned.", todo_implementation);
+        map.insert(
+            "Once during your turn, you may make your opponent's Active Pokémon Burned.",
+            AbilityMechanic::BurnOpponentActive,
+        );
         // map.insert("Once during your turn, you may move all [D] Energy from each of your Pokémon to this Pokémon.", todo_implementation);
         // map.insert("Once during your turn, you may move all [P] Energy from 1 of your Benched [P] Pokémon to your Active Pokémon.", todo_implementation);
         // map.insert("Once during your turn, you may put a random Pokémon Tool card from your deck into your hand.", todo_implementation);

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -125,6 +125,7 @@ fn can_use_ability_by_mechanic(
         }
         AbilityMechanic::PoisonOpponentActive => _in_play_index == 0 && !card.ability_used,
         AbilityMechanic::ConfuseOpponentActive => _in_play_index == 0 && !card.ability_used,
+        AbilityMechanic::BurnOpponentActive => !card.ability_used,
         AbilityMechanic::RemoveRandomSpecialConditionFromActive => {
             can_use_remove_random_special_condition_from_active(state, card)
         }

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -138,6 +138,8 @@ mod tapu_lele_energy_arrow_test;
 mod tepig_stoke_test;
 #[path = "pokemon/terapagos_ex_test.rs"]
 mod terapagos_ex_test;
+#[path = "pokemon/typhlosion_fire_breath_test.rs"]
+mod typhlosion_fire_breath_test;
 #[path = "pokemon/vanilluxe_test.rs"]
 mod vanilluxe_test;
 #[path = "pokemon/vaporeon_ex_test.rs"]

--- a/tests/pokemon/typhlosion_fire_breath_test.rs
+++ b/tests/pokemon/typhlosion_fire_breath_test.rs
@@ -1,0 +1,56 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::PlayedCard,
+    test_support::get_test_game_with_board,
+};
+
+/// Fire Breath: "Once during your turn, you may make your opponent's Active Pokémon Burned."
+/// Typhlosion doesn't need to be in the Active Spot to use it.
+#[test]
+fn test_typhlosion_fire_breath_burns_opponent_active_from_bench() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A4029Typhlosion),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let ability_action = Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 1 },
+        is_stack: false,
+    };
+    game.apply_action(&ability_action);
+
+    let state = game.get_state_clone();
+    assert!(
+        state.get_active(1).is_burned(),
+        "Opponent's Active Pokémon should be Burned after Fire Breath"
+    );
+}
+
+#[test]
+fn test_typhlosion_fire_breath_only_once_per_turn() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A4029Typhlosion)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let ability_action = Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 0 },
+        is_stack: false,
+    };
+    game.apply_action(&ability_action);
+
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    let can_use_ability_again = actions
+        .iter()
+        .any(|a| matches!(a.action, SimpleAction::UseAbility { in_play_idx: 0 }));
+    assert!(
+        !can_use_ability_again,
+        "Fire Breath should only be usable once per turn"
+    );
+}


### PR DESCRIPTION
Adds the BurnOpponentActive mechanic for "Once during your turn, you
may make your opponent's Active Pokémon Burned," usable regardless of
whether the Pokémon is active or benched.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018vBFAE1QLFzBM4FcRgXsWd