### PR TITLE
Implement Alcremie's Sweets Overload attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -508,6 +508,10 @@ fn forecast_effect_attack_by_mechanic(
             attack_name,
             *extra_damage,
         ),
+        Mechanic::DamagePerAttackUsedThisGame {
+            attack_name,
+            damage_per_use,
+        } => damage_per_attack_used_this_game(state, attack_name, *damage_per_use),
         Mechanic::ExtraDamageIfMovedFromBench { extra_damage } => {
             extra_damage_if_moved_from_bench_attack(state, attack.fixed_damage, *extra_damage)
         }
@@ -2433,6 +2437,15 @@ fn extra_damage_if_attack_used_during_own_last_turn(
         base_damage
     };
     active_damage_doutcome(damage)
+}
+
+fn damage_per_attack_used_this_game(
+    state: &State,
+    attack_name: &str,
+    damage_per_use: u32,
+) -> AttackOutcomes {
+    let uses = state.count_attack_used_this_game(state.current_player, attack_name);
+    active_damage_doutcome(damage_per_use * uses)
 }
 
 fn extra_damage_if_moved_from_bench_attack(

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -273,6 +273,10 @@ pub enum Mechanic {
         attack_name: String,
         extra_damage: u32,
     },
+    DamagePerAttackUsedThisGame {
+        attack_name: String,
+        damage_per_use: u32,
+    },
     ExtraDamageIfMovedFromBench {
         extra_damage: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1554,7 +1554,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             bench_side: BenchSide::YourBench,
         },
     );
-    // map.insert("This attack does 40 damage for each time your Pokémon used Sweets Relay during this game.", todo_implementation);
+    map.insert(
+        "This attack does 40 damage for each time your Pokémon used Sweets Relay during this game.",
+        Mechanic::DamagePerAttackUsedThisGame {
+            attack_name: "Sweets Relay".to_string(),
+            damage_per_use: 40,
+        },
+    );
     map.insert(
         "This attack does 40 damage to 1 of your opponent's Pokémon.",
         Mechanic::DirectDamage {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -74,6 +74,10 @@ pub struct State {
     // your last turn, this attack does more damage.").
     pub(crate) attack_name_used_this_turn: [Option<String>; 2],
     pub(crate) attack_name_used_last_turn: [Option<String>; 2],
+    // Number of times each player has used each named attack during the entire game (e.g. for
+    // Alcremie's "Sweets Overload": "This attack does 40 damage for each time your Pokémon used
+    // Sweets Relay during this game."). Using BTreeMap to keep State hashable.
+    pub(crate) attack_name_used_count: [BTreeMap<String, u32>; 2],
     // Maps turn to a vector of effects (cards) for that turn. Using BTreeMap to keep State hashable.
     turn_effects: BTreeMap<u8, Vec<TurnEffect>>,
 }
@@ -103,6 +107,7 @@ impl State {
             knocked_out_by_opponent_attack_last_turn: false,
             attack_name_used_this_turn: [None, None],
             attack_name_used_last_turn: [None, None],
+            attack_name_used_count: [BTreeMap::new(), BTreeMap::new()],
             turn_effects: BTreeMap::new(),
         }
     }
@@ -618,6 +623,9 @@ impl State {
     }
 
     pub(crate) fn record_attack_used(&mut self, player: usize, attack_name: String) {
+        *self.attack_name_used_count[player]
+            .entry(attack_name.clone())
+            .or_insert(0) += 1;
         self.attack_name_used_this_turn[player] = Some(attack_name);
     }
 
@@ -627,6 +635,13 @@ impl State {
         attack_name: &str,
     ) -> bool {
         self.attack_name_used_last_turn[player].as_deref() == Some(attack_name)
+    }
+
+    pub(crate) fn count_attack_used_this_game(&self, player: usize, attack_name: &str) -> u32 {
+        self.attack_name_used_count[player]
+            .get(attack_name)
+            .copied()
+            .unwrap_or(0)
     }
 
     pub fn set_attack_name_used_last_turn(&mut self, player: usize, attack_name: Option<String>) {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -1,5 +1,7 @@
 #[path = "pokemon/additional_ability_logic_test.rs"]
 mod additional_ability_logic_test;
+#[path = "pokemon/alcremie_test.rs"]
+mod alcremie_test;
 #[path = "pokemon/alolan_sandslash_spike_armor_test.rs"]
 mod alolan_sandslash_spike_armor_test;
 #[path = "pokemon/altaria_dragon_arcana_test.rs"]

--- a/tests/pokemon/alcremie_test.rs
+++ b/tests/pokemon/alcremie_test.rs
@@ -1,0 +1,117 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+    Game,
+};
+
+#[test]
+fn test_alcremie_sweets_overload_deals_no_damage_without_prior_sweets_relay_use() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A3b037Alcremie).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3b037Alcremie, 0),
+        is_stack: false,
+    });
+
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        70,
+        "Sweets Overload should deal no damage when Sweets Relay was never used this game"
+    );
+}
+
+/// Drives the game forward (auto-ending every other player's turn, and resolving any forced
+/// single-choice actions like the post-turn draw) until it's `target_player`'s turn again with a
+/// clean decision point (no pending move-generation stack).
+fn advance_to_players_next_turn(game: &mut Game, target_player: usize) {
+    loop {
+        let state = game.get_state_clone();
+        let (_actor, actions) = state.generate_possible_actions();
+        let only_forced_end_turn =
+            actions.len() == 1 && matches!(actions[0].action, SimpleAction::EndTurn);
+        if state.current_player == target_player
+            && state.move_generation_stack.is_empty()
+            && !only_forced_end_turn
+        {
+            break;
+        }
+        let action = actions
+            .iter()
+            .find(|action| matches!(action.action, SimpleAction::EndTurn))
+            .unwrap_or(&actions[0])
+            .clone();
+        game.apply_action(&action);
+    }
+}
+
+/// Resets a player's active Pokemon back to full HP, without touching any other state (in
+/// particular, doesn't touch the Sweets Relay usage count tracked on state).
+fn heal_active_to_full(game: &mut Game, player: usize, total_hp: u32) {
+    let mut state = game.get_state_clone();
+    let healed = state.in_play_pokemon[player][0]
+        .take()
+        .expect("active Pokemon should be there")
+        .with_remaining_hp(total_hp);
+    state.in_play_pokemon[player][0] = Some(healed);
+    game.set_state(state);
+}
+
+#[test]
+fn test_alcremie_sweets_overload_scales_with_sweets_relay_uses_this_game() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2039Vanilluxe)
+            .with_energy(vec![EnergyType::Water, EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    game.set_state(state);
+
+    // Use Sweets Relay on two separate own-turns, so it has been used twice this game.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2039Vanilluxe, 0),
+        is_stack: false,
+    });
+    advance_to_players_next_turn(&mut game, 0);
+    heal_active_to_full(&mut game, 1, 150);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2039Vanilluxe, 0),
+        is_stack: false,
+    });
+    advance_to_players_next_turn(&mut game, 0);
+
+    // Swap Alcremie into the active slot (preserving the Sweets Relay usage count tracked on
+    // state) and use Sweets Overload.
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A3b037Alcremie).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3b037Alcremie, 0),
+        is_stack: false,
+    });
+
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        70,
+        "Sweets Overload should deal 40 damage for each of the 2 prior Sweets Relay uses this game"
+    );
+}


### PR DESCRIPTION
Sweets Overload deals 40 damage for each time the player's Pokémon
used Sweets Relay during the game, so add a per-player, per-attack
usage counter on State (distinct from the existing last-turn-only
tracking used by Sweets Relay itself) and a new DamagePerAttackUsedThisGame
mechanic to read it.