### PR TITLE
Implement Lilligant's Toughness Aroma ability (+20 HP to your Grass Pokemon)

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -76,6 +76,12 @@ pub enum AbilityMechanic {
         energy_type_b: EnergyType,
         amount: u32,
     },
+    /// Passive: each of your Pokémon of the given type gets +`amount` HP for as long as
+    /// this Pokémon (the ability holder) is in play. Stacks if multiple sources are in play.
+    IncreaseHpForTypeInPlay {
+        energy_type: EnergyType,
+        amount: u32,
+    },
     StartTurnRandomPokemonToHand {
         energy_type: EnergyType,
     },

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -124,6 +124,9 @@ fn forecast_ability_by_mechanic(
         | AbilityMechanic::IncreaseDamageForTwoTypesInPlay { .. } => {
             panic!("Type damage bonus mechanics are passive abilities")
         }
+        AbilityMechanic::IncreaseHpForTypeInPlay { .. } => {
+            panic!("IncreaseHpForTypeInPlay is a passive ability")
+        }
         AbilityMechanic::StartTurnRandomPokemonToHand { .. } => {
             panic!("StartTurnRandomPokemonToHand is a passive ability")
         }

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -719,6 +719,12 @@ pub(crate) fn wrap_with_common_logic(mutation: Mutation) -> Mutation {
             handle_knockouts(state, (action.actor, 0), false);
         }
 
+        // Catch-all refresh: any action could have changed a player's board composition
+        // (e.g. a Pokemon entering, leaving, or being knocked out of play), which may add
+        // or remove team-wide ability bonuses like Lilligant's Toughness Aroma. Cheap
+        // enough to always run rather than tracking every mutation site that could matter.
+        state.refresh_ability_team_hp_bonus_all();
+
         if let SimpleAction::Attack(_) = &action.action {
             // We use a flag instead of .move_generation_stack to reduce
             // stack surgery to make sure things happen in order.

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -113,7 +113,13 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
                 energy_type: Some(EnergyType::Psychic),
             },
         );
-        // map.insert("Each of your [G] Pokémon gets +20 HP.", todo_implementation);
+        map.insert(
+            "Each of your [G] Pokémon gets +20 HP.",
+            AbilityMechanic::IncreaseHpForTypeInPlay {
+                energy_type: EnergyType::Grass,
+                amount: 20,
+            },
+        );
         // map.insert("If a Stadium is in play, this Pokémon has no Retreat Cost.", todo_implementation);
         map.insert(
             "If any damage is done to this Pokémon by attacks, flip a coin. If heads, prevent that damage.",

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -95,6 +95,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::IncreaseDamageWhenRemainingHpAtMost { .. } => false,
         AbilityMechanic::IncreaseDamageForTypeInPlay { .. } => false,
         AbilityMechanic::IncreaseDamageForTwoTypesInPlay { .. } => false,
+        AbilityMechanic::IncreaseHpForTypeInPlay { .. } => false,
         AbilityMechanic::StartTurnRandomPokemonToHand { .. } => false,
         AbilityMechanic::SearchRandomPokemonFromDeck => {
             !card.ability_used

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -8,9 +8,11 @@ use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::hash::Hash;
 
+use std::collections::HashMap;
+
 use crate::{
     actions::abilities::AbilityMechanic,
-    actions::{has_ability_mechanic, SimpleAction},
+    actions::{get_ability_mechanic, has_ability_mechanic, SimpleAction},
     deck::Deck,
     effects::TurnEffect,
     models::{Card, EnergyType, StatusCondition},
@@ -143,6 +145,35 @@ impl State {
         let starting_plains_active = is_starting_plains_active(self);
         if let Some(pokemon) = self.in_play_pokemon[player][index].as_mut() {
             pokemon.refresh_starting_plains_bonus(starting_plains_active);
+        }
+    }
+
+    /// Recomputes the team-wide HP bonus (e.g. Lilligant's Toughness Aroma) for both
+    /// players' boards. Cheap enough to call after every action, so callers don't need to
+    /// track which specific board mutation might have added or removed a bonus source.
+    pub(crate) fn refresh_ability_team_hp_bonus_all(&mut self) {
+        self.refresh_ability_team_hp_bonus_for_player(0);
+        self.refresh_ability_team_hp_bonus_for_player(1);
+    }
+
+    fn refresh_ability_team_hp_bonus_for_player(&mut self, player: usize) {
+        let mut bonus_by_type: HashMap<EnergyType, u32> = HashMap::new();
+        for pokemon in self.in_play_pokemon[player].iter().flatten() {
+            if let Some(AbilityMechanic::IncreaseHpForTypeInPlay {
+                energy_type,
+                amount,
+            }) = get_ability_mechanic(&pokemon.card)
+            {
+                *bonus_by_type.entry(*energy_type).or_insert(0) += amount;
+            }
+        }
+        for pokemon in self.in_play_pokemon[player].iter_mut().flatten() {
+            let bonus = pokemon
+                .get_energy_type()
+                .and_then(|energy_type| bonus_by_type.get(&energy_type))
+                .copied()
+                .unwrap_or(0);
+            pokemon.set_ability_team_hp_bonus(bonus);
         }
     }
 
@@ -604,6 +635,7 @@ impl State {
         for (i, card) in player_1.into_iter().enumerate() {
             self.in_play_pokemon[1][i] = Some(card);
         }
+        self.refresh_ability_team_hp_bonus_all();
     }
 
     /// Set the flag indicating a Pokemon was KO'd by opponent's attack last turn.

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -20,6 +20,7 @@ pub struct PlayedCard {
     damage_counters: u32,
     base_hp: u32,
     stadium_hp_bonus: u32,
+    ability_team_hp_bonus: u32,
     pub attached_energy: Vec<EnergyType>,
     pub attached_tool: Option<Card>,
     pub played_this_turn: bool,
@@ -52,6 +53,7 @@ impl PlayedCard {
             damage_counters,
             base_hp,
             stadium_hp_bonus: 0,
+            ability_team_hp_bonus: 0,
             attached_energy,
             played_this_turn,
             moved_to_active_this_turn: false,
@@ -187,6 +189,13 @@ impl PlayedCard {
         };
     }
 
+    /// Sets the cached team-wide HP bonus granted by abilities like Lilligant's Toughness
+    /// Aroma. Recomputed by `State::refresh_ability_team_hp_bonus_for_player` whenever a
+    /// player's board composition changes.
+    pub(crate) fn set_ability_team_hp_bonus(&mut self, bonus: u32) {
+        self.ability_team_hp_bonus = bonus;
+    }
+
     pub fn get_remaining_hp(&self) -> u32 {
         self.get_effective_total_hp()
             .saturating_sub(self.damage_counters)
@@ -216,6 +225,7 @@ impl PlayedCard {
         }
 
         effective_hp += self.stadium_hp_bonus;
+        effective_hp += self.ability_team_hp_bonus;
 
         // Reuniclus Infinite Increase: +30 HP for each Psychic Energy attached
         if has_ability_mechanic(

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -86,6 +86,8 @@ mod jolteon_ex_test;
 mod klefki_dismantling_keys_test;
 #[path = "pokemon/legacy_ability_logic_test.rs"]
 mod legacy_ability_logic_test;
+#[path = "pokemon/lilligant_toughness_aroma_test.rs"]
+mod lilligant_toughness_aroma_test;
 #[path = "pokemon/lucario_b3_test.rs"]
 mod lucario_b3_test;
 #[path = "pokemon/lucario_fighting_coach_test.rs"]

--- a/tests/pokemon/lilligant_toughness_aroma_test.rs
+++ b/tests/pokemon/lilligant_toughness_aroma_test.rs
@@ -1,0 +1,92 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_lilligant_toughness_aroma_boosts_own_grass_pokemon_only() {
+    let mut game = get_initialized_game(0);
+    game.play_until_stable();
+
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B1018Lilligant), // [G], 80 HP -> 100 (self included)
+            PlayedCard::from_id(CardId::A1030Lilligant), // [G], 100 HP -> 120
+            PlayedCard::from_id(CardId::A1033Charmander), // [R], 60 HP -> unaffected
+        ],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.in_play_pokemon[0][0]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        100
+    );
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        120
+    );
+    assert_eq!(
+        state.in_play_pokemon[0][2]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        60
+    );
+}
+
+#[test]
+fn test_lilligant_toughness_aroma_bonus_disappears_once_lilligant_is_knocked_out() {
+    let mut game = get_initialized_game(0);
+    game.play_until_stable();
+
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B1018Lilligant).with_remaining_hp(30), // KOable by 1 Ember
+            PlayedCard::from_id(CardId::A1001Bulbasaur),                       // [G], 70 HP
+        ],
+        vec![PlayedCard::from_id(CardId::A1033Charmander).with_energy(vec![EnergyType::Fire])],
+    );
+    state.current_player = 1;
+    game.set_state(state);
+
+    // Sanity check: benched Bulbasaur currently benefits from Lilligant's team-wide bonus.
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        90
+    );
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(CardId::A1033Charmander, 0),
+        is_stack: false,
+    });
+
+    // Lilligant was K.O.'d by the attack, so Bulbasaur should lose the team-wide
+    // bonus and be back to its base 70 HP.
+    let state = game.get_state_clone();
+    assert!(state.in_play_pokemon[0][0].is_none());
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        70
+    );
+}

--- a/tests/pokemon/lilligant_toughness_aroma_test.rs
+++ b/tests/pokemon/lilligant_toughness_aroma_test.rs
@@ -1,6 +1,7 @@
 use deckgym::{
-    actions::Action,
+    actions::{Action, SimpleAction},
     card_ids::CardId,
+    database::get_card_by_enum,
     models::{EnergyType, PlayedCard},
     test_support::{attack_action, get_initialized_game},
 };
@@ -88,5 +89,62 @@ fn test_lilligant_toughness_aroma_bonus_disappears_once_lilligant_is_knocked_out
             .unwrap()
             .get_remaining_hp(),
         70
+    );
+}
+
+#[test]
+fn test_lilligant_toughness_aroma_stacks_when_second_lilligant_enters() {
+    // Verifies two things:
+    //  1. Bonus stacks: two Toughness Aroma sources → each Grass Pokémon gets +40 HP.
+    //  2. Entering after: a Grass Pokémon placed AFTER Lilligant is already in play
+    //     immediately receives the (now doubled) bonus.
+    let mut game = get_initialized_game(0);
+    game.play_until_stable();
+
+    let mut state = game.get_state_clone();
+    // Start with only B1018Lilligant (80 HP) in the active slot. Self-bonus gives it 100 HP.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1018Lilligant)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+
+    // Put B1329Lilligant (full-art reprint, identical ability) in hand so it can be placed.
+    let b1329_card = get_card_by_enum(CardId::B1329Lilligant);
+    state.hands[0].push(b1329_card.clone());
+    game.set_state(state);
+
+    // Sanity: before placing B1329, B1018 only gets +20 from its own ability.
+    assert_eq!(
+        game.get_state_clone().in_play_pokemon[0][0]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        100 // 80 + 20
+    );
+
+    // Place B1329Lilligant on bench slot 1. This triggers the catch-all bonus refresh.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Place(b1329_card, 1),
+        is_stack: false,
+    });
+
+    // Now two Toughness Aroma sources are in play (+20 each → +40 per Grass Pokémon).
+    // Both Lilligants are Grass, so both get +40 HP: 80 + 40 = 120.
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.in_play_pokemon[0][0]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        120 // 80 + 40
+    );
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        120 // 80 + 40 — entered AFTER B1018, immediately gets doubled bonus
     );
 }


### PR DESCRIPTION
Adds a new passive AbilityMechanic::IncreaseHpForTypeInPlay, mapped from
the shared "Each of your [G] Pokémon gets +20 HP." effect text used by
both B1 018 and B1 329 Lilligant.

Since PlayedCard::get_effective_total_hp only has access to &self, the
team-wide bonus is cached on each PlayedCard (ability_team_hp_bonus) and
recomputed by State::refresh_ability_team_hp_bonus_all, mirroring the
existing stadium_hp_bonus pattern. The refresh is invoked as a catch-all
in wrap_with_common_logic (alongside the existing knockout check) so any
action that changes board composition keeps bonuses in sync, and also
from set_board for test setups that bypass apply_action.