### PR TITLE
Fix energy discard handling when retreating

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -512,8 +512,10 @@ fn apply_retreat(player: usize, state: &mut State, bench_idx: usize, is_free: bo
 
         // Start walking from the back in the attached, removing energies until retreat cost is paid
         let mut remaining_cost = retreat_cost;
+        let mut discarded: Vec<EnergyType> = vec![];
         while remaining_cost > 0 && !attached_energy.is_empty() {
             let energy = attached_energy.pop().unwrap();
+            discarded.push(energy);
             if energy == EnergyType::Grass && double_grass {
                 remaining_cost = remaining_cost.saturating_sub(2);
             } else {
@@ -522,6 +524,10 @@ fn apply_retreat(player: usize, state: &mut State, bench_idx: usize, is_free: bo
         }
         if remaining_cost > 0 {
             panic!("Not enough energy to pay retreat cost");
+        }
+
+        if !discarded.is_empty() {
+            state.discard_energies[player].extend(discarded);
         }
     }
 

--- a/tests/mechanics.rs
+++ b/tests/mechanics.rs
@@ -4,3 +4,5 @@ mod ability_effects_test;
 mod attack_effects_test;
 #[path = "mechanics/confusion_test.rs"]
 mod confusion_test;
+#[path = "mechanics/retreat_test.rs"]
+mod retreat_test;

--- a/tests/mechanics/retreat_test.rs
+++ b/tests/mechanics/retreat_test.rs
@@ -1,0 +1,36 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+#[test]
+fn test_retreat_discards_energy_into_discard_energies() {
+    let mut game = get_initialized_game(42);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1035Charizard)
+                .with_energy(vec![EnergyType::Fire, EnergyType::Water]),
+            PlayedCard::from_id(CardId::A1053Squirtle),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.turn_count = 3;
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Retreat(1),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+
+    assert_eq!(state.discard_energies[0].len(), 2);
+    assert!(state.discard_energies[0].contains(&EnergyType::Fire));
+    assert!(state.discard_energies[0].contains(&EnergyType::Water));
+}


### PR DESCRIPTION
When a Pokémon is retreated with some energy cost, that discarded energies were not properly moved to `state.discard_energies`. This PR fixes the issue.
