### PR TITLE
Fix forced switch incorrectly consuming retreat action

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -529,6 +529,8 @@ fn apply_retreat(player: usize, state: &mut State, bench_idx: usize, is_free: bo
         if !discarded.is_empty() {
             state.discard_energies[player].extend(discarded);
         }
+
+        state.has_retreated = true;
     }
 
     apply_activate(player, state, bench_idx);

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -664,8 +664,6 @@ pub(crate) fn apply_activate(player: usize, state: &mut State, bench_idx: usize)
     if let Some(pokemon) = state.in_play_pokemon[player][0].as_mut() {
         pokemon.moved_to_active_this_turn = true;
     }
-
-    state.has_retreated = true;
 }
 
 // Apply common logic in outcomes

--- a/tests/mechanics/retreat_test.rs
+++ b/tests/mechanics/retreat_test.rs
@@ -34,3 +34,58 @@ fn test_retreat_discards_energy_into_discard_energies() {
     assert!(state.discard_energies[0].contains(&EnergyType::Fire));
     assert!(state.discard_energies[0].contains(&EnergyType::Water));
 }
+
+#[test]
+fn test_forced_activate_does_not_consume_current_player_retreat() {
+    let mut game = get_initialized_game(42);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass]),
+            PlayedCard::from_id(CardId::A1033Charmander).with_energy(vec![EnergyType::Fire]),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1094Pikachu),
+            PlayedCard::from_id(CardId::A1053Squirtle),
+        ],
+    );
+    state.turn_count = 3;
+    state.current_player = 0;
+    game.set_state(state);
+
+    let (_, before_actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        before_actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(1))),
+        "Expected Retreat(1) to be available before forced switch"
+    );
+
+    // My forced switch
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Activate {
+            player: 0,
+            in_play_idx: 1,
+        },
+        is_stack: false,
+    });
+    // Opponent's forced switch
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Activate {
+            player: 1,
+            in_play_idx: 1,
+        },
+        is_stack: false,
+    });
+
+    let (_, after_actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        after_actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(1))),
+        "Forced switch should not consume current player's retreat right"
+    );
+}


### PR DESCRIPTION
Forced switch effects, e.g., Shifting Stream (Greninja ex's ability) or Cyrus, were incorrectly consuming the current player's retreat right.
This PR fixes the issue by limiting retreat consumption to actual retreat actions only.
