### PR TITLE
Add Hisuian Lilligant Dress Up attack tests and mechanic

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -837,6 +837,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     map.insert(
+        "If this Pokémon has a Pokémon Tool attached, this attack does 20 more damage.",
+        Mechanic::ExtraDamageIfToolAttached { extra_damage: 20 },
+    );
+    map.insert(
         "If this Pokémon has a Pokémon Tool attached, this attack does 30 more damage.",
         Mechanic::ExtraDamageIfToolAttached { extra_damage: 30 },
     );

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -66,6 +66,8 @@ mod grovyle_slicing_snipe_test;
 mod hatterene_test;
 #[path = "pokemon/heracross_test.rs"]
 mod heracross_test;
+#[path = "pokemon/hisuian_lilligant_dress_up_test.rs"]
+mod hisuian_lilligant_dress_up_test;
 #[path = "pokemon/hitmonchan_ex_test.rs"]
 mod hitmonchan_ex_test;
 #[path = "pokemon/honchkrow_evil_admonition_test.rs"]

--- a/tests/pokemon/hisuian_lilligant_dress_up_test.rs
+++ b/tests/pokemon/hisuian_lilligant_dress_up_test.rs
@@ -1,0 +1,62 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_hisuian_lilligant_dress_up_base_damage_without_tool() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3b007HisuianLilligant)
+            .with_energy(vec![EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b007HisuianLilligant, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        30,
+        "Dress Up should deal 40 damage without a Tool (Bulbasaur has 70 HP)"
+    );
+}
+
+#[test]
+fn test_hisuian_lilligant_dress_up_extra_damage_with_tool() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3b007HisuianLilligant)
+            .with_energy(vec![EnergyType::Grass])
+            .with_tool(get_card_by_enum(CardId::A2148RockyHelmet))],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b007HisuianLilligant, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        10,
+        "Dress Up should deal 60 damage with a Tool attached (Bulbasaur has 70 HP)"
+    );
+}


### PR DESCRIPTION
## Summary
Add support for Hisuian Lilligant's "Dress Up" attack, which deals 40 damage and an additional 20 damage if the attacking Pokémon has a Pokémon Tool attached.

## Changes
- **New test file**: `tests/pokemon/hisuian_lilligant_dress_up_test.rs`
  - Test base damage (40) without a Tool attached
  - Test increased damage (60) with a Tool attached (Rocky Helmet)
  
- **Updated effect mechanic**: Added mapping for "+20 damage if Tool attached" in `effect_mechanic_map.rs`
  - Complements existing "+30 damage if Tool attached" mechanic
  - Enables proper damage calculation for Dress Up attack

- **Test registration**: Added module registration in `tests/pokemon.rs`

https://claude.ai/code/session_01M1bUGB7wPjwteVSdPhmLKL