### PR TITLE
Add Iron Bundle Bundled Pump attack implementation

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -697,6 +697,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         extra_damage: 40,
         self_damage: 20,
     });
+    map.insert("Flip a coin. If heads, this attack does 50 more damage. If tails, this Pokémon also does 50 damage to itself.", Mechanic::CoinFlipExtraDamageOrSelfDamage {
+        extra_damage: 50,
+        self_damage: 50,
+    });
     map.insert(
         "Flip a coin. If heads, this attack does 50 more damage.",
         Mechanic::CoinFlipExtraDamage { extra_damage: 50 },

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -74,6 +74,8 @@ mod honchkrow_evil_admonition_test;
 mod houndstone_last_respects_test;
 #[path = "pokemon/iron_bundle_ex_test.rs"]
 mod iron_bundle_ex_test;
+#[path = "pokemon/iron_bundle_test.rs"]
+mod iron_bundle_test;
 #[path = "pokemon/iron_hands_test.rs"]
 mod iron_hands_test;
 #[path = "pokemon/iron_leaves_test.rs"]

--- a/tests/pokemon/iron_bundle_test.rs
+++ b/tests/pokemon/iron_bundle_test.rs
@@ -1,0 +1,110 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard, TrainerCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+fn played_card_with_base_hp(card_id: CardId, base_hp: u32) -> PlayedCard {
+    PlayedCard::new(get_card_by_enum(card_id), 0, base_hp, vec![], false, vec![])
+}
+
+fn trainer_from_id(card_id: CardId) -> TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+fn use_bundled_pump(seed: u64, force_heads: bool) -> (u32, u32) {
+    let mut game = get_initialized_game(seed);
+    let mut state = game.get_state_clone();
+    let will = trainer_from_id(CardId::A4156Will);
+
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3b020IronBundle)
+            .with_energy(vec![EnergyType::Water, EnergyType::Colorless])],
+        vec![played_card_with_base_hp(CardId::A1001Bulbasaur, 200)],
+    );
+    state.hands[0] = if force_heads {
+        vec![Card::Trainer(will.clone())]
+    } else {
+        vec![]
+    };
+    game.set_state(state);
+
+    if force_heads {
+        game.apply_action(&Action {
+            actor: 0,
+            action: deckgym::actions::SimpleAction::Play { trainer_card: will },
+            is_stack: false,
+        });
+    }
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b020IronBundle, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    (
+        state.get_active(0).get_remaining_hp(),
+        state.get_active(1).get_remaining_hp(),
+    )
+}
+
+/// Bundled Pump on heads deals 100 damage (50 + 50 extra) and no self damage.
+#[test]
+fn test_iron_bundle_bundled_pump_heads_extra_damage_no_self_damage() {
+    for seed in 0..50 {
+        let (iron_bundle_hp, opponent_hp) = use_bundled_pump(seed, true);
+
+        assert_eq!(
+            opponent_hp, 100,
+            "Seed {seed}: Bundled Pump (heads) should deal 100 damage (200 - 100 = 100)"
+        );
+        assert_eq!(
+            iron_bundle_hp, 80,
+            "Seed {seed}: Will forces heads, so Bundled Pump should not damage Iron Bundle"
+        );
+    }
+}
+
+/// Bundled Pump on tails deals 50 damage to opponent and 50 self damage.
+#[test]
+fn test_iron_bundle_bundled_pump_tails_self_damage() {
+    let mut saw_tails = false;
+
+    for seed in 0..200 {
+        let (iron_bundle_hp, opponent_hp) = use_bundled_pump(seed, false);
+
+        if iron_bundle_hp == 30 {
+            // Tails: 50 self damage (80 - 50 = 30), opponent takes base 50
+            saw_tails = true;
+            assert_eq!(
+                opponent_hp, 150,
+                "Seed {seed}: Bundled Pump (tails) should deal 50 damage (200 - 50 = 150)"
+            );
+        } else {
+            // Heads: no self damage, opponent takes 100
+            assert_eq!(
+                iron_bundle_hp, 80,
+                "Seed {seed}: Bundled Pump should leave Iron Bundle at 80 HP on heads or 30 HP on tails"
+            );
+            assert_eq!(
+                opponent_hp, 100,
+                "Seed {seed}: Bundled Pump (heads) should deal 100 damage"
+            );
+        }
+    }
+
+    assert!(
+        saw_tails,
+        "Expected at least one tails outcome where Bundled Pump does 50 damage to Iron Bundle"
+    );
+}


### PR DESCRIPTION
## Summary
Implements the "Bundled Pump" attack for Iron Bundle, which features a coin flip mechanic that either deals extra damage or causes self-damage.

## Changes
- **Effect Mechanic**: Added `CoinFlipExtraDamageOrSelfDamage` mechanic mapping for the attack text "Flip a coin. If heads, this attack does 50 more damage. If tails, this Pokémon also does 50 damage to itself."
  - Heads outcome: 50 base damage + 50 extra damage = 100 total damage, no self-damage
  - Tails outcome: 50 base damage, 50 self-damage to the attacking Pokémon

- **Tests**: Added comprehensive test coverage for Iron Bundle's Bundled Pump attack
  - `test_iron_bundle_bundled_pump_heads_extra_damage_no_self_damage`: Verifies heads outcome with forced coin flip using Will trainer card
  - `test_iron_bundle_bundled_pump_tails_self_damage`: Verifies tails outcome with random coin flips across multiple seeds

The tests use the Game class public API with helper functions to set up board state and apply actions, following project conventions.

https://claude.ai/code/session_01CZr7Yd7Adpd21knKvXt4tG