### PR TITLE
Add Ninetales B3b 009 Ember Dance attack support

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -619,6 +619,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             num_coins: 4,
         },
     );
+    map.insert(
+        "Flip 9 coins. This attack does 20 damage for each heads.",
+        Mechanic::ExtraDamageForEachHeads {
+            include_fixed_damage: false,
+            damage_per_head: 20,
+            num_coins: 9,
+        },
+    );
     map.insert("Flip a coin for each Energy attached to this Pokémon. This attack does 50 damage for each heads.", Mechanic::CelebiExPowerfulBloom);
     // map.insert("Flip a coin for each Pokémon you have in play. This attack does 20 damage for each heads.", todo_implementation);
     // map.insert("Flip a coin for each Pokémon you have in play. This attack does 40 damage for each heads.", todo_implementation);

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -118,6 +118,8 @@ mod meowth_carefree_steps_test;
 mod miraidon_ex_test;
 #[path = "pokemon/morpeko_test.rs"]
 mod morpeko_test;
+#[path = "pokemon/ninetales_ember_dance_test.rs"]
+mod ninetales_ember_dance_test;
 #[path = "pokemon/porygonz_cyberjack_test.rs"]
 mod porygonz_cyberjack_test;
 #[path = "pokemon/rampardos_head_smash_test.rs"]

--- a/tests/pokemon/ninetales_ember_dance_test.rs
+++ b/tests/pokemon/ninetales_ember_dance_test.rs
@@ -1,0 +1,77 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Ninetales B3b 009 - Ember Dance: flip 9 coins, 20 damage for each heads.
+/// Verifies the attack resolves without panic and deals a multiple of 20.
+#[test]
+fn test_ninetales_ember_dance_deals_damage_per_heads() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3b009Ninetales).with_energy(vec![
+                EnergyType::Fire,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let initial_hp = game.get_state_clone().get_active(1).get_remaining_hp();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b009Ninetales, 0),
+        is_stack: false,
+    });
+
+    let remaining_hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    let damage_dealt = initial_hp - remaining_hp;
+
+    // Damage must be a multiple of 20 (20 per head, 0–9 heads possible)
+    assert_eq!(
+        damage_dealt % 20,
+        0,
+        "Ember Dance damage ({damage_dealt}) must be a multiple of 20"
+    );
+    assert!(
+        damage_dealt <= 180,
+        "Ember Dance max damage is 180 (9 heads × 20), got {damage_dealt}"
+    );
+}
+
+/// Ember Dance is available when Ninetales has the required energy attached.
+#[test]
+fn test_ninetales_ember_dance_is_available_with_energy() {
+    use deckgym::actions::SimpleAction;
+
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3b009Ninetales).with_energy(vec![
+                EnergyType::Fire,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+
+    let has_ember_dance = actions.iter().any(|a| {
+        if let SimpleAction::Attack(atk) = &a.action {
+            atk.title == "Ember Dance"
+        } else {
+            false
+        }
+    });
+
+    assert!(
+        has_ember_dance,
+        "Ember Dance should be available when Ninetales has [R][C][C] energy"
+    );
+}


### PR DESCRIPTION
## Summary
Adds support for Ninetales B3b 009's Ember Dance attack, which flips 9 coins and deals 20 damage for each heads result.

## Changes
- **Effect mechanic mapping**: Added a new entry to `EFFECT_MECHANIC_MAP` for the "Flip 9 coins. This attack does 20 damage for each heads." effect text, mapped to `ExtraDamageForEachHeads` mechanic with 9 coins and 20 damage per heads
- **Test coverage**: Added comprehensive tests for Ember Dance:
  - Verifies the attack resolves without panic and deals damage in multiples of 20 (0–180 damage range)
  - Confirms the attack is available when Ninetales has the required energy ([R][C][C])

## Implementation Details
The attack uses the existing `ExtraDamageForEachHeads` mechanic with `include_fixed_damage: false` since all damage comes from coin flips (no base damage). The randomized coin flip logic is handled by the existing mechanic implementation.

https://claude.ai/code/session_01WjrNUuYVXQrAft78fnbE1F