### PR TITLE
Add DamagePerOwnToolAttached mechanic for Emolga and Dedenne ex

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -491,6 +491,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfToolAttached { extra_damage } => {
             extra_damage_if_tool_attached(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::DamagePerOwnToolAttached { damage_per } => {
+            damage_per_own_tool_attached(state, *damage_per)
+        }
         Mechanic::DiscardRandomGlobalEnergy { count } => {
             discard_random_global_energy_attack(attack.fixed_damage, *count, state)
         }
@@ -2467,6 +2470,15 @@ fn extra_damage_if_tool_attached(
         base_damage
     };
     active_damage_doutcome(damage)
+}
+
+fn damage_per_own_tool_attached(state: &State, damage_per: u32) -> AttackOutcomes {
+    let current_player = state.current_player;
+    let tool_count = state
+        .enumerate_in_play_pokemon(current_player)
+        .filter(|(_, pokemon)| pokemon.has_tool_attached())
+        .count() as u32;
+    active_damage_doutcome(damage_per * tool_count)
 }
 
 fn extra_damage_if_knocked_out_last_turn_attack(

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -445,4 +445,10 @@ pub enum Mechanic {
         attack_name: String,
         damage_per: u32,
     },
+    /// Emolga (Windup Thunder) / Dedenne ex (Dede-Circuit):
+    /// deal `damage_per` damage for each Pokémon Tool attached to any of your
+    /// Pokémon in play (active + bench).
+    DamagePerOwnToolAttached {
+        damage_per: u32,
+    },
 }

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -864,6 +864,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "If this Pokémon has a Pokémon Tool attached, this attack does 50 more damage.",
         Mechanic::ExtraDamageIfToolAttached { extra_damage: 50 },
     );
+    map.insert(
+        "This attack does 30 damage for each Pokémon Tool attached to all of your Pokémon.",
+        Mechanic::DamagePerOwnToolAttached { damage_per: 30 },
+    );
+    map.insert(
+        "This attack does 40 damage for each Pokémon Tool attached to all of your Pokémon.",
+        Mechanic::DamagePerOwnToolAttached { damage_per: 40 },
+    );
     // map.insert("If this Pokémon has any [W] Energy attached, this attack does 40 more damage.", todo_implementation);
     map.insert("If this Pokémon has at least 1 extra [W] Energy attached, this attack does 40 more damage.", 
         Mechanic::ExtraDamageIfExtraEnergy {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -52,6 +52,8 @@ mod dusknoir_shadow_void_test;
 mod dustox_select_powder_test;
 #[path = "pokemon/emboar_flare_storm_test.rs"]
 mod emboar_flare_storm_test;
+#[path = "pokemon/emolga_dedenne_ex_tool_damage_test.rs"]
+mod emolga_dedenne_ex_tool_damage_test;
 #[path = "pokemon/flutter_mane_ex_test.rs"]
 mod flutter_mane_ex_test;
 #[path = "pokemon/flygon_ex_test.rs"]

--- a/tests/pokemon/emolga_dedenne_ex_tool_damage_test.rs
+++ b/tests/pokemon/emolga_dedenne_ex_tool_damage_test.rs
@@ -1,0 +1,96 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Emolga's Windup Thunder does 30 damage for each Pokémon Tool attached to all
+/// of your Pokémon in play (active + bench).
+#[test]
+fn test_emolga_windup_thunder_damage_scales_with_tools() {
+    let rocky_helmet = get_card_by_enum(CardId::A2148RockyHelmet);
+    let giant_cape = get_card_by_enum(CardId::A2147GiantCape);
+
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3b023Emolga)
+                .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning])
+                .with_tool(rocky_helmet),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_tool(giant_cape),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1004VenusaurEx),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+
+    // 2 tools attached → 30 × 2 = 60 damage
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b023Emolga, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let opponent_active_hp = state.get_active(1).get_remaining_hp();
+    let venusaur_ex_max_hp = 190;
+    assert_eq!(opponent_active_hp, venusaur_ex_max_hp - 60);
+}
+
+/// With no tools attached, Windup Thunder deals 0 damage.
+#[test]
+fn test_emolga_windup_thunder_no_damage_without_tools() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3b023Emolga)
+                .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+
+    // 0 tools → 30 × 0 = 0 damage
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b023Emolga, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let opponent_active_hp = state.get_active(1).get_remaining_hp();
+    let venusaur_ex_max_hp = 190;
+    assert_eq!(opponent_active_hp, venusaur_ex_max_hp);
+}
+
+/// Dedenne ex's Dede-Circuit does 40 damage for each Pokémon Tool attached to
+/// all of your Pokémon in play.
+#[test]
+fn test_dedenne_ex_dede_circuit_damage_scales_with_tools() {
+    let rocky_helmet = get_card_by_enum(CardId::A2148RockyHelmet);
+
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3b024DedenneEx)
+                .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_tool(rocky_helmet),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1004VenusaurEx),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+
+    // 1 tool on benched Bulbasaur → 40 × 1 = 40 damage
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b024DedenneEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let opponent_active_hp = state.get_active(1).get_remaining_hp();
+    let venusaur_ex_max_hp = 190;
+    assert_eq!(opponent_active_hp, venusaur_ex_max_hp - 40);
+}


### PR DESCRIPTION
## Summary
Implements support for attacks that deal damage based on the number of Pokémon Tools attached to your own Pokémon in play. This enables proper functionality for Emolga's Windup Thunder and Dedenne ex's Dede-Circuit attacks.

## Key Changes
- Added new `DamagePerOwnToolAttached` mechanic variant to handle attacks that scale damage with tool count
- Implemented `damage_per_own_tool_attached()` function that counts tools across all in-play Pokémon (active + bench) and multiplies by the damage-per-tool value
- Added effect mechanic mappings for both 30 and 40 damage-per-tool attack descriptions
- Added comprehensive test coverage with three test cases:
  - Emolga's Windup Thunder with multiple tools attached (60 damage from 2 tools)
  - Emolga's Windup Thunder with no tools (0 damage)
  - Dedenne ex's Dede-Circuit with benched tool (40 damage from 1 tool)

## Implementation Details
The mechanic correctly counts tools on all Pokémon controlled by the current player, including benched Pokémon, and applies the damage multiplier accordingly. Tests follow the established pattern using `get_test_game_with_board` for clean, maintainable test setup.

https://claude.ai/code/session_01WCxgRsao2Efjcv4ynRJvWs