### PR TITLE
Implement Growlithe's Puppy Pile attack damage calculation

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -706,6 +706,10 @@ fn forecast_effect_attack_by_mechanic(
             *extra_damage,
             conditions.clone(),
         ),
+        Mechanic::DamagePerOwnPokemonWithAttackName {
+            attack_name,
+            damage_per,
+        } => damage_per_own_pokemon_with_attack_name(state, attack_name, *damage_per),
     }
 }
 
@@ -1387,6 +1391,30 @@ fn evolution_bench_count_damage_attack(
         damage_per * evolution_count
     };
     active_damage_doutcome(total_damage)
+}
+
+fn damage_per_own_pokemon_with_attack_name(
+    state: &State,
+    attack_name: &str,
+    damage_per: u32,
+) -> AttackOutcomes {
+    let player = state.current_player;
+    let has_attack = |card: &crate::models::Card| {
+        if let crate::models::Card::Pokemon(p) = card {
+            p.attacks.iter().any(|a| a.title == attack_name)
+        } else {
+            false
+        }
+    };
+    let in_play_count = state
+        .enumerate_in_play_pokemon(player)
+        .filter(|(_, played)| has_attack(&played.card))
+        .count() as u32;
+    let in_hand_count = state.hands[player]
+        .iter()
+        .filter(|card| has_attack(card))
+        .count() as u32;
+    active_damage_doutcome(damage_per * (in_play_count + in_hand_count))
 }
 
 fn also_choice_bench_damage(

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -435,4 +435,10 @@ pub enum Mechanic {
         extra_damage: u32,
         conditions: Vec<StatusCondition>,
     },
+    /// Growlithe – Puppy Pile: deal damage_per × (number of own Pokémon in play and hand
+    /// that have an attack named `attack_name`).
+    DamagePerOwnPokemonWithAttackName {
+        attack_name: String,
+        damage_per: u32,
+    },
 }

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2171,7 +2171,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::ExtraDamageIfDefenderConfused { extra_damage: 70 },
     );
     // map.insert("Move 2 random Energy from this Pokémon to 1 of your Benched Pokémon.", todo_implementation);
-    // map.insert("Reveal all of your Pokémon in play and in your hand that have the Puppy Pile attack, and this attack does 20 damage for each Pokémon you revealed in this way.", todo_implementation);
+    map.insert(
+        "Reveal all of your Pokémon in play and in your hand that have the Puppy Pile attack, and this attack does 20 damage for each Pokémon you revealed in this way.",
+        Mechanic::DamagePerOwnPokemonWithAttackName {
+            attack_name: "Puppy Pile".to_string(),
+            damage_per: 20,
+        },
+    );
     // map.insert("Take a [C] Energy from your Energy Zone and attach it to this Pokémon.", todo_implementation);
     // map.insert("The Defending Pokémon loses all Abilities. This effect lasts until the Defending Pokémon leaves the Active Spot.", todo_implementation);
     map.insert(

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -62,6 +62,8 @@ mod gallade_test;
 mod gardevoir_psy_turbo_test;
 #[path = "pokemon/grovyle_slicing_snipe_test.rs"]
 mod grovyle_slicing_snipe_test;
+#[path = "pokemon/growlithe_puppy_pile_test.rs"]
+mod growlithe_puppy_pile_test;
 #[path = "pokemon/hatterene_test.rs"]
 mod hatterene_test;
 #[path = "pokemon/heracross_test.rs"]

--- a/tests/pokemon/growlithe_puppy_pile_test.rs
+++ b/tests/pokemon/growlithe_puppy_pile_test.rs
@@ -1,0 +1,69 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+fn puppy_pile_damage(bench: Vec<PlayedCard>, hand_puppy_pile_cards: Vec<CardId>) -> u32 {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    let mut player_board = vec![PlayedCard::from_id(CardId::B3b010Growlithe)
+        .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])];
+    player_board.extend(bench);
+
+    // Use 200 HP to avoid knockout obscuring the damage value.
+    let opponent_active = PlayedCard::new(
+        get_card_by_enum(CardId::A1001Bulbasaur),
+        0,
+        200,
+        vec![],
+        false,
+        vec![],
+    );
+    state.set_board(player_board, vec![opponent_active]);
+    state.current_player = 0;
+
+    state.hands[0] = hand_puppy_pile_cards
+        .into_iter()
+        .map(get_card_by_enum)
+        .collect();
+
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b010Growlithe, 0),
+        is_stack: false,
+    });
+
+    game.get_state_clone().get_active(1).get_remaining_hp()
+}
+
+#[test]
+fn test_puppy_pile_counts_attacker_itself() {
+    // Only the active Growlithe with Puppy Pile is in play, none in hand.
+    // 1 pokemon × 20 = 20 damage + 20 flat Fire weakness = 40 total.
+    // 200 HP - 40 = 160 HP remaining.
+    let remaining_hp = puppy_pile_damage(vec![], vec![]);
+    assert_eq!(
+        remaining_hp, 160,
+        "1 Puppy Pile pokemon → 20 damage + 20 weakness = 40; 200 - 40 = 160"
+    );
+}
+
+#[test]
+fn test_puppy_pile_counts_bench_and_hand_pokemon() {
+    // Active Growlithe (1) + benched Yamper (1) + 2 in hand = 4 × 20 = 80 damage.
+    // Bulbasaur Fire weakness adds flat +20 = 100 total. 200 - 100 = 100 HP remaining.
+    let remaining_hp = puppy_pile_damage(
+        vec![PlayedCard::from_id(CardId::B3b025Yamper)],
+        vec![CardId::B3b010Growlithe, CardId::B3b034Fidough],
+    );
+    assert_eq!(
+        remaining_hp, 100,
+        "4 Puppy Pile pokemon → 80 damage + 20 weakness = 100; 200 - 100 = 100"
+    );
+}


### PR DESCRIPTION
## Summary
Implements the damage calculation for Growlithe's "Puppy Pile" attack, which deals 20 damage for each Pokémon in play and in hand that has the Puppy Pile attack.

## Changes
- Added `DamagePerOwnPokemonWithAttackName` mechanic variant to support attacks that scale damage based on the count of own Pokémon with a specific attack name
- Implemented `damage_per_own_pokemon_with_attack_name()` function to calculate total damage by counting both in-play and in-hand Pokémon matching the attack name criteria
- Mapped the Puppy Pile attack effect text to the new mechanic in the effect mechanic map
- Added comprehensive test coverage with two test cases:
  - Verifies the attack counts the attacker itself (1 Pokémon = 20 damage + weakness)
  - Verifies the attack counts benched Pokémon and cards in hand (4 Pokémon = 80 damage + weakness)

## Implementation Details
The new mechanic counts Pokémon in two ways:
1. In-play Pokémon: Uses `enumerate_in_play_pokemon()` to find active and benched Pokémon with the matching attack
2. In-hand Pokémon: Directly filters the player's hand for cards with the matching attack

Total damage is calculated as `damage_per × (in_play_count + in_hand_count)`.

https://claude.ai/code/session_01EqPjaAUr21Tik6AvEeFwWP