### PR TITLE
Implement Caterpie's Quick Growth ability

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -201,4 +201,8 @@ pub enum AbilityMechanic {
     /// Passive: while a Pokémon with this ability is in play, attack generation also offers the
     /// active evolved Pokémon the attacks from its previous evolutions (its under-cards).
     TimeRecall,
+    /// Caterpie's Quick Growth: "At the end of your opponent's turn, if this Pokémon is in the
+    /// Active Spot, put a random card from your deck that evolves from this Pokémon onto this
+    /// Pokémon to evolve it."
+    QuickGrowth,
 }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -265,6 +265,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::AncientRoar => switch_out_opponent_active_to_bench(),
         AbilityMechanic::FutureSystem => panic!("FutureSystem is a passive ability"),
         AbilityMechanic::TimeRecall => panic!("TimeRecall is a passive ability"),
+        AbilityMechanic::QuickGrowth => {
+            panic!("QuickGrowth is triggered at the end of the opponent's turn")
+        }
     }
 }
 

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -137,6 +137,10 @@ fn start_turn_ability_outcomes(state: &State, player: usize) -> (Probabilities, 
             )
             .into_branches()
         }
+        AbilityMechanic::QuickGrowth => {
+            shared_mutations::quick_growth_evolution_outcomes_for_player(player, state)
+                .into_branches()
+        }
         _ => (vec![1.0], vec![noop_mutation()]),
     }
 }

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -466,6 +466,12 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "Once during your turn, you may remove a random Special Condition from your Active Pokémon.",
             AbilityMechanic::RemoveRandomSpecialConditionFromActive,
         );
+
+        // b3b mechanics
+        map.insert(
+            "At the end of your opponent's turn, if this Pokémon is in the Active Spot, put a random card from your deck that evolves from this Pokémon onto this Pokémon to evolve it.",
+            AbilityMechanic::QuickGrowth,
+        );
         map
     });
 

--- a/src/actions/shared_mutations.rs
+++ b/src/actions/shared_mutations.rs
@@ -2,8 +2,11 @@ use log::debug;
 use std::cmp::min;
 
 use crate::{
-    actions::{apply_action_helpers::Mutations, apply_place_card, outcomes::Outcomes},
+    actions::{
+        apply_action_helpers::Mutations, apply_evolve, apply_place_card, outcomes::Outcomes,
+    },
     combinatorics::generate_combinations,
+    hooks::can_evolve_into,
     models::{Card, EnergyType, TrainerType},
     State,
 };
@@ -139,6 +142,41 @@ where
     }
 
     Outcomes::from_parts(probabilities, outcomes)
+}
+
+/// Generates outcomes for Caterpie's Quick Growth ability: pick a random card from
+/// `player`'s deck that evolves from their current active Pokémon and evolve it.
+/// Returns a no-op (just shuffle) when no eligible evolution exists in the deck.
+pub(crate) fn quick_growth_evolution_outcomes_for_player(player: usize, state: &State) -> Outcomes {
+    let active = state.get_active(player);
+    let evolution_cards: Vec<Card> = state.decks[player]
+        .cards
+        .iter()
+        .filter(|card| can_evolve_into(card, active))
+        .cloned()
+        .collect();
+
+    if evolution_cards.is_empty() {
+        return Outcomes::single_fn(move |rng, state, _action| {
+            state.decks[player].shuffle(false, rng);
+        });
+    }
+
+    let n = evolution_cards.len();
+    let probabilities = vec![1.0 / n as f64; n];
+    let mutations: Mutations = evolution_cards
+        .into_iter()
+        .map(
+            |evo_card| -> crate::actions::apply_action_helpers::Mutation {
+                Box::new(move |rng, state, _action| {
+                    apply_evolve(player, state, &evo_card, 0, true);
+                    state.decks[player].shuffle(false, rng);
+                })
+            },
+        )
+        .collect();
+
+    Outcomes::from_parts(probabilities, mutations)
 }
 
 pub(crate) fn search_and_bench_by_name(state: &State, card_name: String) -> Outcomes {

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -175,6 +175,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::AncientRoar => false, // triggered on bench placement, not via UseAbility
         AbilityMechanic::FutureSystem => false, // passive ability
         AbilityMechanic::TimeRecall => false,  // passive ability (consumed in attack generation)
+        AbilityMechanic::QuickGrowth => false, // triggered at end of opponent's turn
     }
 }
 

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -30,6 +30,8 @@ mod carracosta_blocking_shell_test;
 mod cascoon_harden_test;
 #[path = "pokemon/castform_test.rs"]
 mod castform_test;
+#[path = "pokemon/caterpie_quick_growth_test.rs"]
+mod caterpie_quick_growth_test;
 #[path = "pokemon/celebi_time_recall_test.rs"]
 mod celebi_time_recall_test;
 #[path = "pokemon/chansey_blissey_test.rs"]

--- a/tests/pokemon/caterpie_quick_growth_test.rs
+++ b/tests/pokemon/caterpie_quick_growth_test.rs
@@ -1,0 +1,137 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+/// Caterpie (B3b 001/B3b 091) Quick Growth:
+/// "At the end of your opponent's turn, if this Pokémon is in the Active Spot,
+/// put a random card from your deck that evolves from this Pokémon onto this
+/// Pokémon to evolve it."
+#[test]
+fn test_quick_growth_evolves_caterpie_at_end_of_opponent_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3b001Caterpie)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 1;
+    // Put exactly one Metapod (evolves from Caterpie) in player 0's deck.
+    state.decks[0].cards = vec![get_card_by_enum(CardId::B3b002Metapod)];
+    game.set_state(state);
+
+    // Opponent (player 1) ends their turn without attacking.
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    let active = state.get_active(0);
+    assert!(
+        matches!(&active.card, Card::Pokemon(p) if p.name == "Metapod"),
+        "Caterpie should have evolved into Metapod via Quick Growth; got {:?}",
+        active.card.get_name()
+    );
+    assert!(
+        state.decks[0].cards.is_empty(),
+        "Metapod should have been removed from the deck"
+    );
+}
+
+#[test]
+fn test_quick_growth_no_op_when_no_evolution_in_deck() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3b001Caterpie)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 1;
+    // No Metapod in the deck — only unrelated cards.
+    state.decks[0].cards = vec![get_card_by_enum(CardId::A1001Bulbasaur)];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    let active = state.get_active(0);
+    assert!(
+        matches!(&active.card, Card::Pokemon(p) if p.name == "Caterpie"),
+        "Caterpie should stay unevolved when no Metapod is in deck; got {:?}",
+        active.card.get_name()
+    );
+}
+
+/// The full-art variant (B3b 091) has the identical ability and should behave
+/// the same way.
+#[test]
+fn test_quick_growth_full_art_variant_evolves() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3b091Caterpie)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 1;
+    state.decks[0].cards = vec![get_card_by_enum(CardId::B3b002Metapod)];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    let active = state.get_active(0);
+    assert!(
+        matches!(&active.card, Card::Pokemon(p) if p.name == "Metapod"),
+        "Full-art Caterpie should also evolve via Quick Growth; got {:?}",
+        active.card.get_name()
+    );
+}
+
+/// The "Hook" attack (10 damage, Grass energy) should deal damage normally.
+#[test]
+fn test_caterpie_hook_attack_deals_10_damage() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3b001Caterpie).with_energy(vec![EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let opponent_hp_before = game.get_state_clone().get_active(1).get_remaining_hp();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b001Caterpie, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        opponent_hp_before - 10,
+        "Hook should deal exactly 10 damage"
+    );
+}


### PR DESCRIPTION
## Summary
Adds support for Caterpie's Quick Growth ability, which automatically evolves the Pokémon at the end of the opponent's turn if a valid evolution card exists in the deck.

## Changes
- **New ability mechanic**: Added `QuickGrowth` to `AbilityMechanic` enum with documentation
- **Ability mapping**: Registered Quick Growth's text in `EFFECT_ABILITY_MECHANIC_MAP`
- **Evolution logic**: Implemented `quick_growth_evolution_outcomes_for_player()` in `shared_mutations.rs` that:
  - Filters the player's deck for cards that can evolve from the active Pokémon
  - Randomly selects one if available, otherwise performs a no-op shuffle
  - Uses existing `apply_evolve()` and `can_evolve_into()` utilities
- **Turn-end trigger**: Integrated Quick Growth into `start_turn_ability_outcomes()` to trigger at the end of opponent's turn
- **Forecast handling**: Added panic in `forecast_ability_by_mechanic()` to prevent incorrect forecasting of this triggered ability
- **Comprehensive tests**: Added 4 test cases covering:
  - Basic evolution when Metapod is in deck
  - No-op behavior when no valid evolution exists
  - Full-art variant (B3b 091) behavior
  - Caterpie's Hook attack (10 damage with Grass energy)

## Implementation Details
The ability leverages the existing evolution framework and integrates with the turn-end ability system. When triggered, it generates probabilistic outcomes based on the number of valid evolution cards in the deck, ensuring each has equal probability of selection.

https://claude.ai/code/session_01DXJfo8LPdFbsRYoscvQ8jE