### PR TITLE
Add support for Milotic ex's Aqua Charge ability

### DIFF
--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -291,6 +291,13 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             },
         );
         map.insert(
+            "Once during your turn, you may take a [W] Energy from your Energy Zone and attach it to this Pokémon.",
+            AbilityMechanic::AttachEnergyFromZoneToSelf {
+                energy_type: EnergyType::Water,
+                amount: 1,
+            },
+        );
+        map.insert(
             "Once during your turn, you may take a [P] Energy from your Energy Zone and attach it to the [P] Pokémon in the Active Spot.",
             AbilityMechanic::AttachEnergyFromZoneToActiveTypedPokemon {
                 energy_type: EnergyType::Psychic,

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -124,6 +124,8 @@ mod mega_steelix_adamantine_rolling_test;
 mod meowstic_test;
 #[path = "pokemon/meowth_carefree_steps_test.rs"]
 mod meowth_carefree_steps_test;
+#[path = "pokemon/milotic_ex_aqua_charge_test.rs"]
+mod milotic_ex_aqua_charge_test;
 #[path = "pokemon/miraidon_ex_test.rs"]
 mod miraidon_ex_test;
 #[path = "pokemon/morpeko_test.rs"]

--- a/tests/pokemon/milotic_ex_aqua_charge_test.rs
+++ b/tests/pokemon/milotic_ex_aqua_charge_test.rs
@@ -1,0 +1,59 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_test_game_with_board,
+};
+
+/// Aqua Charge: "Once during your turn, you may take a [W] Energy from your Energy Zone and
+/// attach it to this Pokémon."
+#[test]
+fn test_milotic_ex_aqua_charge_attaches_water_energy() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3b015MiloticEx)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    // Milotic ex starts with no energy attached.
+    assert!(game.get_state_clone().in_play_pokemon[0][0]
+        .as_ref()
+        .unwrap()
+        .attached_energy
+        .is_empty());
+
+    let ability_action = Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 0 },
+        is_stack: false,
+    };
+    game.apply_action(&ability_action);
+
+    let milotic = game.get_state_clone().in_play_pokemon[0][0]
+        .as_ref()
+        .unwrap()
+        .clone();
+    assert_eq!(milotic.attached_energy, vec![EnergyType::Water]);
+
+    // The ability is "once during your turn", so it should no longer be available.
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(!actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseAbility { in_play_idx: 0 })));
+}
+
+/// Aqua Charge can be used from the Bench as well as the Active Spot.
+#[test]
+fn test_milotic_ex_aqua_charge_available_from_bench() {
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::B3b015MiloticEx),
+        ],
+        vec![PlayedCard::from_id(CardId::A1002Ivysaur)],
+    );
+
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseAbility { in_play_idx: 1 })));
+}


### PR DESCRIPTION
## Summary
Implements support for Milotic ex's Aqua Charge ability, which allows attaching a Water Energy from the Energy Zone to itself once per turn. This ability can be used from both the Active Spot and the Bench.

## Changes
- Added `AttachEnergyFromZoneToSelf` ability mechanic mapping for Water Energy in the effect ability mechanic map
- Added comprehensive test coverage for Aqua Charge:
  - Verifies that Water Energy is correctly attached to Milotic ex when the ability is used
  - Confirms the "once per turn" restriction is enforced
  - Tests that the ability is available when Milotic ex is on the Bench

## Implementation Details
The ability is mapped to the existing `AttachEnergyFromZoneToSelf` mechanic with Water Energy type, following the same pattern as other similar energy attachment abilities in the codebase.

https://claude.ai/code/session_01MHRBxzrpkiUHarroAmNu5S