### PR TITLE
Implement Snover (A2 044) Ice Shard attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -252,6 +252,10 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfEx { extra_damage } => {
             extra_damage_if_opponent_is_ex(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::ExtraDamageIfDefenderType {
+            energy_type,
+            extra_damage,
+        } => extra_damage_if_defender_type(state, attack.fixed_damage, *energy_type, *extra_damage),
         Mechanic::ExtraDamageIfOpponentHasSpecialCondition { extra_damage } => unseen_claw_attack(
             state.current_player,
             state,
@@ -2451,6 +2455,22 @@ fn extra_damage_if_opponent_is_ex(
     let opponent = (state.current_player + 1) % 2;
     let opponent_active = state.get_active(opponent);
     let damage = if opponent_active.card.is_ex() {
+        base_damage + extra_damage
+    } else {
+        base_damage
+    };
+    active_damage_doutcome(damage)
+}
+
+fn extra_damage_if_defender_type(
+    state: &State,
+    base_damage: u32,
+    energy_type: EnergyType,
+    extra_damage: u32,
+) -> AttackOutcomes {
+    let opponent = (state.current_player + 1) % 2;
+    let opponent_active = state.get_active(opponent);
+    let damage = if opponent_active.card.get_type() == Some(energy_type) {
         base_damage + extra_damage
     } else {
         base_damage

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -74,6 +74,10 @@ pub enum Mechanic {
     ExtraDamageIfEx {
         extra_damage: u32,
     },
+    ExtraDamageIfDefenderType {
+        energy_type: EnergyType,
+        extra_damage: u32,
+    },
     ExtraDamageIfOpponentHasSpecialCondition {
         extra_damage: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1051,7 +1051,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::ExtraDamageIfEx { extra_damage: 80 },
     );
     // map.insert("If your opponent's Active Pokémon is a [D] Pokémon, this attack does 30 more damage.", todo_implementation);
-    // map.insert("If your opponent's Active Pokémon is a [F] Pokémon, this attack does 30 more damage.", todo_implementation);
+    map.insert(
+        "If your opponent's Active Pokémon is a [F] Pokémon, this attack does 30 more damage.",
+        Mechanic::ExtraDamageIfDefenderType {
+            energy_type: EnergyType::Fighting,
+            extra_damage: 30,
+        },
+    );
     // map.insert("If your opponent's Active Pokémon is a [G] Pokémon, this attack does 40 more damage.", todo_implementation);
     // map.insert("If your opponent's Active Pokémon is a [G] Pokémon, this attack does 50 more damage.", todo_implementation);
     // map.insert("If your opponent's Active Pokémon is a [M] Pokémon, this attack does 30 more damage.", todo_implementation);

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -144,6 +144,8 @@ mod shinx_hide_test;
 mod slither_wing_test;
 #[path = "pokemon/smoochum_test.rs"]
 mod smoochum_test;
+#[path = "pokemon/snover_ice_shard_test.rs"]
+mod snover_ice_shard_test;
 #[path = "pokemon/spewpa_signs_of_evolution_test.rs"]
 mod spewpa_signs_of_evolution_test;
 #[path = "pokemon/sunflora_quick_grow_beam_test.rs"]

--- a/tests/pokemon/snover_ice_shard_test.rs
+++ b/tests/pokemon/snover_ice_shard_test.rs
@@ -1,0 +1,56 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Ice Shard deals 10 damage, plus 30 more when the opponent's Active Pokemon
+/// is a Fighting Pokemon.
+#[test]
+fn test_snover_ice_shard_extra_damage_vs_fighting() {
+    // Machop (A1 143) is a Fighting Pokemon with 70 HP. Its weakness is Psychic,
+    // so Snover's Water-type attack does not trigger a weakness bonus.
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A2044Snover).with_energy(vec![EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1143Machop)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A2044Snover, 0),
+        is_stack: false,
+    });
+
+    // 10 base + 30 (opponent is Fighting) = 40 damage. 70 - 40 = 30 HP remaining.
+    let opponent_hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        opponent_hp, 30,
+        "Ice Shard should deal 40 damage to a Fighting Pokemon (70 - 40 = 30)"
+    );
+}
+
+/// Ice Shard deals only its base 10 damage when the opponent's Active Pokemon
+/// is not a Fighting Pokemon.
+#[test]
+fn test_snover_ice_shard_base_damage_vs_non_fighting() {
+    // Bulbasaur (A1 001) is a Grass Pokemon with 70 HP; weakness is Fire, so no
+    // weakness bonus from Snover's Water-type attack.
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A2044Snover).with_energy(vec![EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A2044Snover, 0),
+        is_stack: false,
+    });
+
+    // 10 base damage only. 70 - 10 = 60 HP remaining.
+    let opponent_hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        opponent_hp, 60,
+        "Ice Shard should deal only 10 base damage to a non-Fighting Pokemon (70 - 10 = 60)"
+    );
+}


### PR DESCRIPTION
## Summary

Implements the previously-unimplemented **Snover (A2 044)** attack, **Ice Shard**:

> If your opponent's Active Pokémon is a [F] Pokémon, this attack does 30 more damage.

Base damage is 10; +30 when the opponent's Active Pokémon is a Fighting type.

## Implementation

- Adds a generic `ExtraDamageIfDefenderType { energy_type, extra_damage }` mechanic, mirroring the existing `ExtraDamageIfEx`. It's parameterized by type + amount so it can serve other "extra damage vs a given type" attacks in the future (e.g. the neighboring `[D]`/`[G]`/`[M]` stubs in the effect map).
- Wires Snover's effect text to the new mechanic in `effect_mechanic_map.rs`.

## Testing

- Added Game-level integration tests (`tests/pokemon/snover_ice_shard_test.rs`) covering:
  - +30 vs a Fighting Pokémon (Machop): 40 damage.
  - Base-only vs a non-Fighting Pokémon (Bulbasaur): 10 damage.
- `cargo test --features test-utils --test pokemon` — 234 passed.
- `cargo test --features test-utils --test mechanics` — 22 passed.
- `cargo run --bin card_test -- "A2 044"` — 10k games across all example decks, no errors.
- `cargo fmt` + `cargo clippy --features tui -- -D warnings` clean.
- `card_status` now reports A2 044 Snover as ✓ Complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)