### PR TITLE
Implement Psyduck's Confusion Wave attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -233,6 +233,9 @@ fn forecast_effect_attack_by_mechanic(
                 damage_and_self_multiple_status_attack(attack.fixed_damage, conditions.clone())
             }
         }
+        Mechanic::InflictStatusConditionsOnBothActive { conditions } => {
+            damage_and_both_active_multiple_status_attack(attack.fixed_damage, conditions.clone())
+        }
         Mechanic::ChanceStatusAttack { condition } => {
             damage_chance_status_attack(attack.fixed_damage, *condition)
         }
@@ -1792,6 +1795,21 @@ fn damage_and_self_multiple_status_attack(
     active_damage_effect_doutcome(damage, move |_, state, action| {
         for status in &statuses {
             state.apply_status_condition(action.actor, 0, *status);
+        }
+    })
+}
+
+/// For attacks that deal damage to opponent and apply multiple status effects to both
+/// Active Pokémon (attacker and defender), e.g. Psyduck's Confusion Wave.
+fn damage_and_both_active_multiple_status_attack(
+    damage: u32,
+    statuses: Vec<StatusCondition>,
+) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        for status in &statuses {
+            state.apply_status_condition(action.actor, 0, *status);
+            state.apply_status_condition(opponent, 0, *status);
         }
     })
 }

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -50,6 +50,9 @@ pub enum Mechanic {
         conditions: Vec<StatusCondition>,
         target_opponent: bool,
     },
+    InflictStatusConditionsOnBothActive {
+        conditions: Vec<StatusCondition>,
+    },
     ChanceStatusAttack {
         condition: StatusCondition,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -59,7 +59,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::DiscardOpponentActiveToolsBeforeDamage,
     );
     // map.insert("Both Active Pokémon are now Asleep.", todo_implementation);
-    // map.insert("Both Active Pokémon are now Confused.", todo_implementation);
+    map.insert(
+        "Both Active Pokémon are now Confused.",
+        Mechanic::InflictStatusConditionsOnBothActive {
+            conditions: vec![StatusCondition::Confused],
+        },
+    );
     // map.insert("Change the type of a random Energy attached to your opponent's Active Pokémon to 1 of the following at random: [G], [R], [W], [L], [P], [F], [D], or [M].", todo_implementation);
     // map.insert("Change the type of the next Energy that will be generated for your opponent to 1 of the following at random: [G], [R], [W], [L], [P], [F], [D], or [M].", todo_implementation);
     map.insert(

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -134,6 +134,8 @@ mod morpeko_test;
 mod ninetales_ember_dance_test;
 #[path = "pokemon/porygonz_cyberjack_test.rs"]
 mod porygonz_cyberjack_test;
+#[path = "pokemon/psyduck_test.rs"]
+mod psyduck_test;
 #[path = "pokemon/rampardos_head_smash_test.rs"]
 mod rampardos_head_smash_test;
 #[path = "pokemon/roaring_moon_test.rs"]

--- a/tests/pokemon/psyduck_test.rs
+++ b/tests/pokemon/psyduck_test.rs
@@ -1,0 +1,39 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::PlayedCard,
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_psyduck_confusion_wave_confuses_both_actives() {
+    // Psyduck's Confusion Wave: Both Active Pokémon are now Confused.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3b011Psyduck)],
+        vec![PlayedCard::from_id(CardId::A1053Squirtle)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    assert!(!game.get_state_clone().get_active(0).is_confused());
+    assert!(!game.get_state_clone().get_active(1).is_confused());
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b011Psyduck, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(
+        state.get_active(0).is_confused(),
+        "Psyduck itself should be Confused after using Confusion Wave"
+    );
+    assert!(
+        state.get_active(1).is_confused(),
+        "Opponent's Active Pokémon should be Confused after Confusion Wave"
+    );
+}


### PR DESCRIPTION
Adds InflictStatusConditionsOnBothActive mechanic to handle "Both
Active Pokémon are now Confused." effect text, used by Psyduck
(B3b 011 / P-B 071).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UtvM3eJ22RKxxSgU53KgGo