### PR TITLE
Implement Hisuian Zoroark ex's Spiteful Illusion attack

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -622,6 +622,13 @@ fn forecast_effect_attack_by_mechanic(
             *energy_type,
             *damage_per_pokemon,
         ),
+        Mechanic::ExtraDamagePerPokemonInDiscard { damage_per_pokemon } => {
+            extra_damage_per_pokemon_in_discard_attack(
+                state,
+                attack.fixed_damage,
+                *damage_per_pokemon,
+            )
+        }
         Mechanic::ExtraDamagePerOwnPoint { damage_per_point } => {
             extra_damage_per_own_point_attack(state, attack.fixed_damage, *damage_per_point)
         }
@@ -3424,6 +3431,20 @@ fn extra_damage_per_pokemon_type_in_discard_attack(
     let pokemon_count = state.discard_piles[state.current_player]
         .iter()
         .filter(|card| matches!(card, Card::Pokemon(pokemon) if pokemon.energy_type == energy_type))
+        .count() as u32;
+    let total_damage = base_damage + (pokemon_count * damage_per_pokemon);
+    active_damage_doutcome(total_damage)
+}
+
+// Hisuian Zoroark ex - Spiteful Illusion: Extra damage per Pokemon in own discard pile
+fn extra_damage_per_pokemon_in_discard_attack(
+    state: &State,
+    base_damage: u32,
+    damage_per_pokemon: u32,
+) -> AttackOutcomes {
+    let pokemon_count = state.discard_piles[state.current_player]
+        .iter()
+        .filter(|card| matches!(card, Card::Pokemon(_)))
         .count() as u32;
     let total_damage = base_damage + (pokemon_count * damage_per_pokemon);
     active_damage_doutcome(total_damage)

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -210,6 +210,9 @@ pub enum Mechanic {
         energy_type: EnergyType,
         damage_per_pokemon: u32,
     },
+    ExtraDamagePerPokemonInDiscard {
+        damage_per_pokemon: u32,
+    },
     ExtraDamagePerOwnPoint {
         damage_per_point: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1972,6 +1972,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("This attack also does 50 damage to 1 of your opponent's Benched Pokémon.", todo_implementation);
     map.insert(
+        "This attack does 20 more damage for each Pokémon in your discard pile.",
+        Mechanic::ExtraDamagePerPokemonInDiscard {
+            damage_per_pokemon: 20,
+        },
+    );
+    map.insert(
         "This attack does 20 more damage for each [P] Pokémon in your discard pile.",
         Mechanic::ExtraDamagePerPokemonTypeInDiscard {
             energy_type: EnergyType::Psychic,

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -72,6 +72,8 @@ mod hatterene_test;
 mod heracross_test;
 #[path = "pokemon/hisuian_lilligant_dress_up_test.rs"]
 mod hisuian_lilligant_dress_up_test;
+#[path = "pokemon/hisuian_zoroark_ex_test.rs"]
+mod hisuian_zoroark_ex_test;
 #[path = "pokemon/hitmonchan_ex_test.rs"]
 mod hitmonchan_ex_test;
 #[path = "pokemon/honchkrow_evil_admonition_test.rs"]

--- a/tests/pokemon/hisuian_zoroark_ex_test.rs
+++ b/tests/pokemon/hisuian_zoroark_ex_test.rs
@@ -1,0 +1,76 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_hisuian_zoroark_ex_spiteful_illusion_scales_with_own_discard_pile() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3b060HisuianZoroarkEx).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+    state.current_player = 0;
+    state.discard_piles[0] = vec![
+        get_card_by_enum(CardId::A1033Charmander),
+        get_card_by_enum(CardId::A1053Squirtle),
+    ];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b060HisuianZoroarkEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        70,
+        "Spiteful Illusion should do 80 + 20*2 = 120 damage for 2 Pokemon in own discard pile"
+    );
+}
+
+#[test]
+fn test_hisuian_zoroark_ex_spiteful_illusion_base_damage_with_empty_discard_pile() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3b060HisuianZoroarkEx).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+    state.current_player = 0;
+    state.discard_piles[0] = vec![];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b060HisuianZoroarkEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        110,
+        "Spiteful Illusion should do 80 damage with an empty discard pile"
+    );
+}


### PR DESCRIPTION
Add ExtraDamagePerPokemonInDiscard mechanic for the "does 20 more
damage for each Pokemon in your discard pile" effect and wire up
Hisuian Zoroark ex's Spiteful Illusion attack.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QRTNXm8DHoLsyfNWZ7vMy6