### PR TITLE
Implement Kid's Room stadium

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -13,8 +13,10 @@ use crate::{
     },
     effects::TurnEffect,
     hooks::{get_retreat_cost, on_bench_from_hand, on_evolve, to_playable_card},
-    models::{Card, EnergyType},
-    stadiums::{is_area_zero_active, is_fragrant_forest_active, is_mesagoza_active},
+    models::{Card, EnergyType, TrainerType},
+    stadiums::{
+        is_area_zero_active, is_fragrant_forest_active, is_kids_room_active, is_mesagoza_active,
+    },
     state::State,
     tools,
 };
@@ -84,6 +86,9 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         }
         SimpleAction::ShuffleOwnCardsIntoDeck { cards } => {
             forecast_shuffle_own_cards_into_deck(action.actor, cards)
+        }
+        SimpleAction::SwitchHandCardForRandomTool { hand_card } => {
+            forecast_switch_hand_card_for_random_tool(state, action.actor, hand_card)
         }
         SimpleAction::ShuffleOpponentSupporter { supporter_card } => {
             forecast_shuffle_opponent_supporter(action.actor, supporter_card)
@@ -798,6 +803,9 @@ fn forecast_use_stadium(state: &State, acting_player: usize) -> Outcomes {
     if is_area_zero_active(state) {
         return forecast_area_zero_effect(state, acting_player);
     }
+    if is_kids_room_active(state) {
+        return forecast_kids_room_effect(state, acting_player);
+    }
     Outcomes::single_fn(|_, _, _| {})
 }
 
@@ -858,6 +866,69 @@ fn forecast_fragrant_forest_effect(state: &State, acting_player: usize) -> Outco
                 mutation(rng, state, action);
             })
         })
+}
+
+/// Kid's Room: Once during each player's turn, that player may choose a card in their hand and
+/// switch it with a random Pokémon Tool card in their deck.
+fn forecast_kids_room_effect(state: &State, acting_player: usize) -> Outcomes {
+    let choices: Vec<SimpleAction> = state.hands[acting_player]
+        .iter()
+        .map(|card| SimpleAction::SwitchHandCardForRandomTool {
+            hand_card: card.clone(),
+        })
+        .collect();
+
+    Outcomes::single_fn(move |_, state, action| {
+        state.has_used_stadium[action.actor] = true;
+        if !choices.is_empty() {
+            state
+                .move_generation_stack
+                .push((action.actor, choices.clone()));
+        }
+    })
+}
+
+fn is_tool_card(card: &Card) -> bool {
+    matches!(card, Card::Trainer(t) if t.trainer_card_type == TrainerType::Tool)
+}
+
+/// Kid's Room: switch the chosen hand card with a random Pokémon Tool card from the deck.
+fn forecast_switch_hand_card_for_random_tool(
+    state: &State,
+    acting_player: usize,
+    hand_card: &Card,
+) -> Outcomes {
+    let deck_tools: Vec<Card> = state.decks[acting_player]
+        .cards
+        .iter()
+        .filter(|card| is_tool_card(card))
+        .cloned()
+        .collect();
+
+    let num_deck_tools = deck_tools.len();
+    if num_deck_tools == 0 {
+        // Should not happen if move generation is correct, but just shuffle deck
+        return Outcomes::single_fn(|rng, state, action| {
+            state.decks[action.actor].shuffle(false, rng);
+        });
+    }
+
+    let probabilities = vec![1.0 / (num_deck_tools as f64); num_deck_tools];
+    let mut outcomes: Mutations = vec![];
+    for tool_card in deck_tools {
+        let hand_card_clone = hand_card.clone();
+        outcomes.push(Box::new(move |rng, state, action| {
+            state.transfer_card_from_hand_to_deck(action.actor, &hand_card_clone);
+            state.transfer_card_from_deck_to_hand(action.actor, &tool_card);
+            state.decks[action.actor].shuffle(false, rng);
+            debug!(
+                "Kid's Room: Switched {:?} from hand with {:?} from deck",
+                hand_card_clone, tool_card
+            );
+        }));
+    }
+
+    Outcomes::from_parts(probabilities, outcomes)
 }
 
 // Test that when evolving a damanged pokemon, damage stays.

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -8,15 +8,11 @@ use crate::{
     actions::{
         abilities::AbilityMechanic,
         apply_abilities_action::forecast_ability,
-        apply_action_helpers::{apply_activate, wrap_with_common_logic, Mutation},
-        shared_mutations::{pokemon_search_outcomes, pokemon_search_outcomes_by_type_for_player},
+        apply_action_helpers::{apply_activate, wrap_with_common_logic},
     },
     effects::TurnEffect,
     hooks::{get_retreat_cost, on_bench_from_hand, on_evolve, to_playable_card},
-    models::{Card, EnergyType, TrainerType},
-    stadiums::{
-        is_area_zero_active, is_fragrant_forest_active, is_kids_room_active, is_mesagoza_active,
-    },
+    models::{Card, EnergyType},
     state::State,
     tools,
 };
@@ -24,8 +20,9 @@ use crate::{
 use super::{
     apply_action_helpers::{forecast_end_turn, handle_damage, Mutations},
     apply_attack_action::forecast_attack,
+    apply_stadium_action::{self, forecast_use_stadium},
     apply_trainer_action::forecast_trainer_action,
-    outcomes::{CoinSeq, Outcomes},
+    outcomes::Outcomes,
     Action, SimpleAction,
 };
 
@@ -88,7 +85,11 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
             forecast_shuffle_own_cards_into_deck(action.actor, cards)
         }
         SimpleAction::SwitchHandCardForRandomTool { hand_card } => {
-            forecast_switch_hand_card_for_random_tool(state, action.actor, hand_card)
+            apply_stadium_action::forecast_switch_hand_card_for_random_tool(
+                state,
+                action.actor,
+                hand_card,
+            )
         }
         SimpleAction::ShuffleOpponentSupporter { supporter_card } => {
             forecast_shuffle_opponent_supporter(action.actor, supporter_card)
@@ -790,145 +791,6 @@ fn apply_heal_all_eevee_evolutions(acting_player: usize, state: &mut State) {
             pokemon.heal(20);
         }
     }
-}
-
-/// Forecasts the UseStadium action for activated stadiums like Mesagoza, Fragrant Forest, and Area Zero.
-fn forecast_use_stadium(state: &State, acting_player: usize) -> Outcomes {
-    if is_mesagoza_active(state) {
-        return forecast_mesagoza_effect(state, acting_player);
-    }
-    if is_fragrant_forest_active(state) {
-        return forecast_fragrant_forest_effect(state, acting_player);
-    }
-    if is_area_zero_active(state) {
-        return forecast_area_zero_effect(state, acting_player);
-    }
-    if is_kids_room_active(state) {
-        return forecast_kids_room_effect(state, acting_player);
-    }
-    Outcomes::single_fn(|_, _, _| {})
-}
-
-/// Area Zero: Once during each player's turn, that player may shuffle a Basic Pokémon from their
-/// hand into their deck. If they do, they draw a card.
-fn forecast_area_zero_effect(state: &State, acting_player: usize) -> Outcomes {
-    let choices: Vec<SimpleAction> = state.hands[acting_player]
-        .iter()
-        .filter(|card| card.is_basic())
-        .map(|card| SimpleAction::ShuffleOwnCardsIntoDeck {
-            cards: vec![card.clone()],
-        })
-        .collect();
-
-    Outcomes::single_fn(move |_, state, action| {
-        state.has_used_stadium[action.actor] = true;
-        if !choices.is_empty() {
-            state
-                .move_generation_stack
-                .push((action.actor, choices.clone()));
-        }
-    })
-}
-
-/// Mesagoza: Once during each player's turn, that player may flip a coin.
-/// If heads, that player puts a random Pokémon from their deck into their hand.
-fn forecast_mesagoza_effect(state: &State, acting_player: usize) -> Outcomes {
-    // Get the search outcomes for any Pokemon (reusing existing logic)
-    let (search_probs, search_mutations) =
-        pokemon_search_outcomes(acting_player, state, false).into_branches();
-
-    let mut branches: Vec<(f64, Mutation, Vec<CoinSeq>)> =
-        Vec::with_capacity(search_probs.len() + 1);
-    for (prob, mutation) in search_probs.into_iter().zip(search_mutations) {
-        let wrapped: Mutation = Box::new(move |rng, state, action| {
-            state.has_used_stadium[action.actor] = true;
-            mutation(rng, state, action);
-            debug!("Mesagoza: Flipped heads, searched for Pokemon");
-        });
-        branches.push((0.5 * prob, wrapped, vec![CoinSeq(vec![true])]));
-    }
-    let tails_mutation: Mutation = Box::new(move |_, state, action| {
-        state.has_used_stadium[action.actor] = true;
-        debug!("Mesagoza: Flipped tails, nothing happens");
-    });
-    branches.push((0.5, tails_mutation, vec![CoinSeq(vec![false])]));
-
-    // Not `binary_coin`: heads fans out into many weighted search outcomes, not one mutation.
-    Outcomes::from_coin_branches(branches).expect("Mesagoza coin branches should be valid")
-}
-
-/// Fragrant Forest: Once during each player's turn, that player may put a random Basic [G] Pokémon from their deck into their hand.
-fn forecast_fragrant_forest_effect(state: &State, acting_player: usize) -> Outcomes {
-    pokemon_search_outcomes_by_type_for_player(acting_player, state, true, EnergyType::Grass)
-        .map_mutations(|mutation| {
-            Box::new(move |rng, state, action| {
-                state.has_used_stadium[action.actor] = true;
-                mutation(rng, state, action);
-            })
-        })
-}
-
-/// Kid's Room: Once during each player's turn, that player may choose a card in their hand and
-/// switch it with a random Pokémon Tool card in their deck.
-fn forecast_kids_room_effect(state: &State, acting_player: usize) -> Outcomes {
-    let choices: Vec<SimpleAction> = state.hands[acting_player]
-        .iter()
-        .map(|card| SimpleAction::SwitchHandCardForRandomTool {
-            hand_card: card.clone(),
-        })
-        .collect();
-
-    Outcomes::single_fn(move |_, state, action| {
-        state.has_used_stadium[action.actor] = true;
-        if !choices.is_empty() {
-            state
-                .move_generation_stack
-                .push((action.actor, choices.clone()));
-        }
-    })
-}
-
-fn is_tool_card(card: &Card) -> bool {
-    matches!(card, Card::Trainer(t) if t.trainer_card_type == TrainerType::Tool)
-}
-
-/// Kid's Room: switch the chosen hand card with a random Pokémon Tool card from the deck.
-fn forecast_switch_hand_card_for_random_tool(
-    state: &State,
-    acting_player: usize,
-    hand_card: &Card,
-) -> Outcomes {
-    let deck_tools: Vec<Card> = state.decks[acting_player]
-        .cards
-        .iter()
-        .filter(|card| is_tool_card(card))
-        .cloned()
-        .collect();
-
-    let num_deck_tools = deck_tools.len();
-    if num_deck_tools == 0 {
-        // Should not happen if move generation is correct, but just shuffle deck
-        return Outcomes::single_fn(|rng, state, action| {
-            state.decks[action.actor].shuffle(false, rng);
-        });
-    }
-
-    let probabilities = vec![1.0 / (num_deck_tools as f64); num_deck_tools];
-    let mut outcomes: Mutations = vec![];
-    for tool_card in deck_tools {
-        let hand_card_clone = hand_card.clone();
-        outcomes.push(Box::new(move |rng, state, action| {
-            state.transfer_card_from_hand_to_deck(action.actor, &hand_card_clone);
-            state.transfer_card_from_deck_to_hand(action.actor, &tool_card);
-            state.decks[action.actor].shuffle(false, rng);
-            debug!(
-                "Kid's Room: Switched {:?} from hand with {:?} from deck",
-                hand_card_clone, tool_card
-            );
-        }));
-    }
-
-    Outcomes::from_parts(probabilities, outcomes)
 }
 
 // Test that when evolving a damanged pokemon, damage stays.

--- a/src/actions/apply_stadium_action.rs
+++ b/src/actions/apply_stadium_action.rs
@@ -1,0 +1,159 @@
+use log::debug;
+
+use crate::{
+    actions::{
+        apply_action_helpers::Mutation,
+        shared_mutations::{pokemon_search_outcomes, pokemon_search_outcomes_by_type_for_player},
+    },
+    models::{Card, EnergyType, TrainerType},
+    stadiums::{
+        is_area_zero_active, is_fragrant_forest_active, is_kids_room_active, is_mesagoza_active,
+    },
+    State,
+};
+
+use super::{
+    apply_action_helpers::Mutations,
+    outcomes::{CoinSeq, Outcomes},
+    SimpleAction,
+};
+
+/// Forecasts the UseStadium action for activated stadiums like Mesagoza, Fragrant Forest, Area
+/// Zero, and Kid's Room.
+pub(crate) fn forecast_use_stadium(state: &State, acting_player: usize) -> Outcomes {
+    if is_mesagoza_active(state) {
+        return forecast_mesagoza_effect(state, acting_player);
+    }
+    if is_fragrant_forest_active(state) {
+        return forecast_fragrant_forest_effect(state, acting_player);
+    }
+    if is_area_zero_active(state) {
+        return forecast_area_zero_effect(state, acting_player);
+    }
+    if is_kids_room_active(state) {
+        return forecast_kids_room_effect(state, acting_player);
+    }
+    Outcomes::single_fn(|_, _, _| {})
+}
+
+/// Area Zero: Once during each player's turn, that player may shuffle a Basic Pokémon from their
+/// hand into their deck. If they do, they draw a card.
+fn forecast_area_zero_effect(state: &State, acting_player: usize) -> Outcomes {
+    let choices: Vec<SimpleAction> = state.hands[acting_player]
+        .iter()
+        .filter(|card| card.is_basic())
+        .map(|card| SimpleAction::ShuffleOwnCardsIntoDeck {
+            cards: vec![card.clone()],
+        })
+        .collect();
+
+    Outcomes::single_fn(move |_, state, action| {
+        state.has_used_stadium[action.actor] = true;
+        if !choices.is_empty() {
+            state
+                .move_generation_stack
+                .push((action.actor, choices.clone()));
+        }
+    })
+}
+
+/// Mesagoza: Once during each player's turn, that player may flip a coin.
+/// If heads, that player puts a random Pokémon from their deck into their hand.
+fn forecast_mesagoza_effect(state: &State, acting_player: usize) -> Outcomes {
+    // Get the search outcomes for any Pokemon (reusing existing logic)
+    let (search_probs, search_mutations) =
+        pokemon_search_outcomes(acting_player, state, false).into_branches();
+
+    let mut branches: Vec<(f64, Mutation, Vec<CoinSeq>)> =
+        Vec::with_capacity(search_probs.len() + 1);
+    for (prob, mutation) in search_probs.into_iter().zip(search_mutations) {
+        let wrapped: Mutation = Box::new(move |rng, state, action| {
+            state.has_used_stadium[action.actor] = true;
+            mutation(rng, state, action);
+            debug!("Mesagoza: Flipped heads, searched for Pokemon");
+        });
+        branches.push((0.5 * prob, wrapped, vec![CoinSeq(vec![true])]));
+    }
+    let tails_mutation: Mutation = Box::new(move |_, state, action| {
+        state.has_used_stadium[action.actor] = true;
+        debug!("Mesagoza: Flipped tails, nothing happens");
+    });
+    branches.push((0.5, tails_mutation, vec![CoinSeq(vec![false])]));
+
+    // Not `binary_coin`: heads fans out into many weighted search outcomes, not one mutation.
+    Outcomes::from_coin_branches(branches).expect("Mesagoza coin branches should be valid")
+}
+
+/// Fragrant Forest: Once during each player's turn, that player may put a random Basic [G] Pokémon from their deck into their hand.
+fn forecast_fragrant_forest_effect(state: &State, acting_player: usize) -> Outcomes {
+    pokemon_search_outcomes_by_type_for_player(acting_player, state, true, EnergyType::Grass)
+        .map_mutations(|mutation| {
+            Box::new(move |rng, state, action| {
+                state.has_used_stadium[action.actor] = true;
+                mutation(rng, state, action);
+            })
+        })
+}
+
+/// Kid's Room: Once during each player's turn, that player may choose a card in their hand and
+/// switch it with a random Pokémon Tool card in their deck.
+fn forecast_kids_room_effect(state: &State, acting_player: usize) -> Outcomes {
+    let choices: Vec<SimpleAction> = state.hands[acting_player]
+        .iter()
+        .map(|card| SimpleAction::SwitchHandCardForRandomTool {
+            hand_card: card.clone(),
+        })
+        .collect();
+
+    Outcomes::single_fn(move |_, state, action| {
+        state.has_used_stadium[action.actor] = true;
+        if !choices.is_empty() {
+            state
+                .move_generation_stack
+                .push((action.actor, choices.clone()));
+        }
+    })
+}
+
+fn is_tool_card(card: &Card) -> bool {
+    matches!(card, Card::Trainer(t) if t.trainer_card_type == TrainerType::Tool)
+}
+
+/// Kid's Room: switch the chosen hand card with a random Pokémon Tool card from the deck.
+pub(crate) fn forecast_switch_hand_card_for_random_tool(
+    state: &State,
+    acting_player: usize,
+    hand_card: &Card,
+) -> Outcomes {
+    let deck_tools: Vec<Card> = state.decks[acting_player]
+        .cards
+        .iter()
+        .filter(|card| is_tool_card(card))
+        .cloned()
+        .collect();
+
+    let num_deck_tools = deck_tools.len();
+    if num_deck_tools == 0 {
+        // Should not happen if move generation is correct, but just shuffle deck
+        return Outcomes::single_fn(|rng, state, action| {
+            state.decks[action.actor].shuffle(false, rng);
+        });
+    }
+
+    let probabilities = vec![1.0 / (num_deck_tools as f64); num_deck_tools];
+    let mut outcomes: Mutations = vec![];
+    for tool_card in deck_tools {
+        let hand_card_clone = hand_card.clone();
+        outcomes.push(Box::new(move |rng, state, action| {
+            state.transfer_card_from_hand_to_deck(action.actor, &hand_card_clone);
+            state.transfer_card_from_deck_to_hand(action.actor, &tool_card);
+            state.decks[action.actor].shuffle(false, rng);
+            debug!(
+                "Kid's Room: Switched {:?} from hand with {:?} from deck",
+                hand_card_clone, tool_card
+            );
+        }));
+    }
+
+    Outcomes::from_parts(probabilities, outcomes)
+}

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -3,6 +3,7 @@ mod apply_abilities_action;
 mod apply_action;
 mod apply_action_helpers;
 mod apply_attack_action;
+mod apply_stadium_action;
 mod apply_trainer_action;
 pub(crate) mod attack_helpers;
 pub(crate) mod attack_outcome;

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -98,6 +98,10 @@ pub enum SimpleAction {
     ShuffleOwnCardsIntoDeck {
         cards: Vec<Card>,
     },
+    /// Kid's Room: switch a specific card from hand with a random Pokemon Tool card from deck
+    SwitchHandCardForRandomTool {
+        hand_card: Card,
+    },
     /// Silver: shuffle a specific Supporter from opponent's hand into their deck
     ShuffleOpponentSupporter {
         supporter_card: Card,
@@ -263,6 +267,9 @@ impl fmt::Display for SimpleAction {
             }
             SimpleAction::ShuffleOwnCardsIntoDeck { cards } => {
                 write!(f, "ShuffleOwnCardsIntoDeck({:?})", cards)
+            }
+            SimpleAction::SwitchHandCardForRandomTool { hand_card } => {
+                write!(f, "SwitchHandCardForRandomTool({hand_card})")
             }
             SimpleAction::ShuffleOpponentSupporter { supporter_card } => {
                 write!(f, "ShuffleOpponentSupporter({supporter_card})")

--- a/src/move_generation/mod.rs
+++ b/src/move_generation/mod.rs
@@ -5,7 +5,9 @@ mod move_generation_trainer;
 use crate::actions::{abilities::AbilityMechanic, get_ability_mechanic, Action, SimpleAction};
 use crate::hooks::{can_evolve_into, can_retreat, contains_energy, get_retreat_cost};
 use crate::models::Card;
-use crate::stadiums::{can_use_area_zero, can_use_fragrant_forest, can_use_mesagoza};
+use crate::stadiums::{
+    can_use_area_zero, can_use_fragrant_forest, can_use_kids_room, can_use_mesagoza,
+};
 use crate::state::State;
 
 use attacks::generate_attack_actions;
@@ -113,6 +115,7 @@ pub fn generate_possible_actions(state: &State) -> (usize, Vec<Action>) {
     if can_use_mesagoza(state, current_player)
         || can_use_fragrant_forest(state, current_player)
         || can_use_area_zero(state, current_player)
+        || can_use_kids_room(state, current_player)
     {
         actions.push(SimpleAction::UseStadium);
     }

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -59,6 +59,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::CommunicatePokemon { .. } => 5,
         SimpleAction::ShufflePokemonIntoDeck { .. } => 5,
         SimpleAction::ShuffleOwnCardsIntoDeck { .. } => 5,
+        SimpleAction::SwitchHandCardForRandomTool { .. } => 5,
         SimpleAction::ShuffleOpponentSupporter { .. } => 5,
         SimpleAction::DiscardOpponentSupporter { .. } => 5,
         SimpleAction::DiscardOwnCards { .. } => 5,

--- a/src/stadiums.rs
+++ b/src/stadiums.rs
@@ -48,6 +48,8 @@ static FRAGRANT_FOREST_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3153FragrantForest));
 static AREA_ZERO_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3a074AreaZero));
+static KIDS_ROOM_EFFECT: LazyLock<String> =
+    LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3b069KidsRoom));
 
 pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
     ensure_stadium_trainer(trainer_card);
@@ -63,6 +65,7 @@ pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == ARENA_OF_ANTIQUITY_EFFECT.as_str()
             || e == FRAGRANT_FOREST_EFFECT.as_str()
             || e == AREA_ZERO_EFFECT.as_str()
+            || e == KIDS_ROOM_EFFECT.as_str()
     )
 }
 
@@ -179,4 +182,26 @@ pub fn can_use_area_zero(state: &State, player: usize) -> bool {
         return false;
     }
     state.hands[player].iter().any(|card| card.is_basic())
+}
+
+pub fn is_kids_room_active(state: &State) -> bool {
+    has_stadium(state, CardId::B3b069KidsRoom)
+}
+
+/// Returns true if the player can use Kid's Room's effect (stadium is active, not used this turn,
+/// hand has a card, and deck has a Pokemon Tool card)
+pub fn can_use_kids_room(state: &State, player: usize) -> bool {
+    if !is_kids_room_active(state) {
+        return false;
+    }
+    if state.has_used_stadium[player] {
+        return false;
+    }
+    if state.hands[player].is_empty() {
+        return false;
+    }
+    state.decks[player]
+        .cards
+        .iter()
+        .any(|card| matches!(card, Card::Trainer(t) if t.trainer_card_type == TrainerType::Tool))
 }

--- a/tests/stadiums.rs
+++ b/tests/stadiums.rs
@@ -4,5 +4,7 @@ mod area_zero_test;
 mod arena_of_antiquity_test;
 #[path = "stadiums/fragrant_forest_test.rs"]
 mod fragrant_forest_test;
+#[path = "stadiums/kids_room_test.rs"]
+mod kids_room_test;
 #[path = "stadiums/stadium_test.rs"]
 mod stadium_test;

--- a/tests/stadiums/kids_room_test.rs
+++ b/tests/stadiums/kids_room_test.rs
@@ -1,0 +1,188 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn trainer_from_id(card_id: CardId) -> deckgym::models::TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+/// Sets up a game with Kid's Room active, a non-tool card in player 0's hand, and (optionally)
+/// a Pokemon Tool card in player 0's deck.
+fn setup_game_with_kids_room(tool_in_deck: bool) -> deckgym::Game<'static> {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 2;
+
+    state.hands[0] = vec![
+        get_card_by_enum(CardId::B3b069KidsRoom),
+        get_card_by_enum(CardId::PA001Potion),
+    ];
+
+    if tool_in_deck {
+        state.decks[0]
+            .cards
+            .push(get_card_by_enum(CardId::A2148RockyHelmet));
+    }
+
+    game.set_state(state);
+
+    let trainer_card = trainer_from_id(CardId::B3b069KidsRoom);
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    });
+
+    game
+}
+
+#[test]
+fn test_kids_room_use_stadium_available_with_tool_in_deck() {
+    let game = setup_game_with_kids_room(true);
+    let state = game.get_state_clone();
+
+    assert!(
+        state.active_stadium.is_some(),
+        "Kid's Room should be active"
+    );
+
+    let (_actor, actions) = state.generate_possible_actions();
+    let has_use_stadium = actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium));
+
+    assert!(
+        has_use_stadium,
+        "UseStadium should be available when Kid's Room is active, hand has a card, and deck has a Tool"
+    );
+}
+
+#[test]
+fn test_kids_room_use_stadium_not_available_without_tool_in_deck() {
+    let game = setup_game_with_kids_room(false);
+    let state = game.get_state_clone();
+
+    let (_actor, actions) = state.generate_possible_actions();
+    let has_use_stadium = actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium));
+
+    assert!(
+        !has_use_stadium,
+        "UseStadium should NOT be available when deck has no Pokemon Tool card"
+    );
+}
+
+#[test]
+fn test_kids_room_switches_hand_card_with_random_tool_from_deck() {
+    let mut game = setup_game_with_kids_room(true);
+
+    // Use the stadium effect
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseStadium,
+        is_stack: false,
+    });
+
+    // The game queues a choice of which hand card to switch — pick the Potion.
+    let state = game.get_state_clone();
+    let stack_top = state.move_generation_stack.last().cloned();
+    let (_actor, choices) = stack_top.expect("Kid's Room should push a choice of hand cards");
+    let choice = choices
+        .iter()
+        .find(|action| {
+            matches!(
+                action,
+                SimpleAction::SwitchHandCardForRandomTool { hand_card }
+                    if hand_card.get_name() == "Potion"
+            )
+        })
+        .expect("Potion should be an available choice")
+        .clone();
+    game.apply_action(&Action {
+        actor: 0,
+        action: choice,
+        is_stack: true,
+    });
+
+    let state = game.get_state_clone();
+
+    // Potion should have left the hand and Rocky Helmet should now be in hand.
+    assert!(
+        !state.hands[0]
+            .iter()
+            .any(|card| card.get_name() == "Potion"),
+        "Potion should have been switched out of hand"
+    );
+    assert!(
+        state.hands[0]
+            .iter()
+            .any(|card| card.get_name() == "Rocky Helmet"),
+        "Rocky Helmet should have been switched into hand"
+    );
+
+    // Potion should now be in the deck, and Rocky Helmet should be gone from it.
+    assert!(
+        state.decks[0]
+            .cards
+            .iter()
+            .any(|card| card.get_name() == "Potion"),
+        "Potion should have been placed into the deck"
+    );
+    assert!(
+        !state.decks[0]
+            .cards
+            .iter()
+            .any(|card| card.get_name() == "Rocky Helmet"),
+        "Rocky Helmet should have left the deck"
+    );
+
+    assert!(
+        state.has_used_stadium[0],
+        "has_used_stadium[0] should be true after using Kid's Room"
+    );
+}
+
+#[test]
+fn test_kids_room_cannot_use_twice_per_turn() {
+    let mut game = setup_game_with_kids_room(true);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseStadium,
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    if let Some((_actor, choices)) = state.move_generation_stack.last().cloned() {
+        game.apply_action(&Action {
+            actor: 0,
+            action: choices[0].clone(),
+            is_stack: true,
+        });
+    }
+
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    let has_use_stadium = actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium));
+
+    assert!(
+        !has_use_stadium,
+        "UseStadium should NOT be available after using Kid's Room once this turn"
+    );
+}

--- a/tests/stadiums/kids_room_test.rs
+++ b/tests/stadiums/kids_room_test.rs
@@ -98,25 +98,19 @@ fn test_kids_room_switches_hand_card_with_random_tool_from_deck() {
     });
 
     // The game queues a choice of which hand card to switch — pick the Potion.
-    let state = game.get_state_clone();
-    let stack_top = state.move_generation_stack.last().cloned();
-    let (_actor, choices) = stack_top.expect("Kid's Room should push a choice of hand cards");
+    let (_actor, choices) = game.get_state_clone().generate_possible_actions();
     let choice = choices
         .iter()
         .find(|action| {
             matches!(
-                action,
+                &action.action,
                 SimpleAction::SwitchHandCardForRandomTool { hand_card }
                     if hand_card.get_name() == "Potion"
             )
         })
         .expect("Potion should be an available choice")
         .clone();
-    game.apply_action(&Action {
-        actor: 0,
-        action: choice,
-        is_stack: true,
-    });
+    game.apply_action(&choice);
 
     let state = game.get_state_clone();
 
@@ -166,14 +160,8 @@ fn test_kids_room_cannot_use_twice_per_turn() {
         is_stack: false,
     });
 
-    let state = game.get_state_clone();
-    if let Some((_actor, choices)) = state.move_generation_stack.last().cloned() {
-        game.apply_action(&Action {
-            actor: 0,
-            action: choices[0].clone(),
-            is_stack: true,
-        });
-    }
+    let (_actor, choices) = game.get_state_clone().generate_possible_actions();
+    game.apply_action(&choices[0]);
 
     let state = game.get_state_clone();
     let (_actor, actions) = state.generate_possible_actions();


### PR DESCRIPTION
Kid's Room lets each player, once per turn, choose a card in their hand
and switch it with a random Pokemon Tool card from their deck. Adds the
SwitchHandCardForRandomTool action for the swap, following the same
choice-then-resolve pattern used by Area Zero and Mesagoza.