### PR TITLE
Implement Puppy-Loving Girl trainer card

### DIFF
--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -209,6 +209,7 @@ pub fn forecast_trainer_action(
         CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
             professor_turo_effect(acting_player, state)
         }
+        CardId::B3b066Elesa | CardId::B3b083Elesa => Outcomes::single_fn(elesa_effect),
         CardId::B3b067PuppyLovingGirl | CardId::B3b084PuppyLovingGirl => {
             puppy_loving_girl_effect(acting_player, state)
         }
@@ -1413,6 +1414,18 @@ fn sightseer_effect(acting_player: usize, state: &State) -> Outcomes {
     }
 
     Outcomes::from_parts(probabilities, outcomes)
+}
+
+fn elesa_effect(_: &mut StdRng, state: &mut State, _: &Action) {
+    // Return all Pokémon Tools attached to each Pokémon (both yours and your opponent's) to
+    // their owner's hand.
+    for player in 0..2 {
+        for pokemon in state.in_play_pokemon[player].iter_mut().flatten() {
+            if let Some(tool) = pokemon.attached_tool.take() {
+                state.hands[player].push(tool);
+            }
+        }
+    }
 }
 
 fn puppy_loving_girl_effect(acting_player: usize, state: &State) -> Outcomes {

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -208,6 +208,9 @@ pub fn forecast_trainer_action(
         CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
             professor_turo_effect(acting_player, state)
         }
+        CardId::B3b067PuppyLovingGirl | CardId::B3b084PuppyLovingGirl => {
+            puppy_loving_girl_effect(acting_player, state)
+        }
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1400,6 +1403,36 @@ fn sightseer_effect(acting_player: usize, state: &State) -> Outcomes {
         outcomes.push(Box::new(move |rng, state, _action| {
             for card in &top_cards {
                 if matches!(card, Card::Pokemon(p) if p.stage == 1) {
+                    state.transfer_card_from_deck_to_hand(acting_player, card);
+                }
+            }
+            state.decks[acting_player].shuffle(false, rng);
+        }));
+    }
+
+    Outcomes::from_parts(probabilities, outcomes)
+}
+
+fn puppy_loving_girl_effect(acting_player: usize, state: &State) -> Outcomes {
+    // Look at the top 4 cards of your deck. Put all Pokémon you find there that have the
+    // Puppy Pile attack into your hand. Shuffle the other cards back into your deck.
+    let deck_cards: Vec<Card> = state.decks[acting_player].cards.to_vec();
+    let look_count = min(4, deck_cards.len());
+
+    if look_count == 0 {
+        return Outcomes::single_fn(|_, _, _| {});
+    }
+
+    let top_combinations = generate_combinations(&deck_cards, look_count);
+    let num_outcomes = top_combinations.len();
+    let probabilities = vec![1.0 / num_outcomes as f64; num_outcomes];
+    let mut outcomes: Mutations = vec![];
+
+    for top_cards in top_combinations {
+        outcomes.push(Box::new(move |rng, state, _action| {
+            for card in &top_cards {
+                if matches!(card, Card::Pokemon(p) if p.attacks.iter().any(|a| a.title == "Puppy Pile"))
+                {
                     state.transfer_card_from_deck_to_hand(acting_player, card);
                 }
             }

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -15,6 +15,7 @@ use crate::{
     card_ids::CardId,
     card_logic::{
         can_rare_candy_evolve, diantha_targets, ilima_targets, quick_grow_extract_candidates,
+        wallace_candidates,
     },
     combinatorics::generate_combinations,
     effects::TurnEffect,
@@ -211,6 +212,7 @@ pub fn forecast_trainer_action(
         CardId::B3b067PuppyLovingGirl | CardId::B3b084PuppyLovingGirl => {
             puppy_loving_girl_effect(acting_player, state)
         }
+        CardId::B3b068Wallace | CardId::B3b085Wallace => wallace_effect(acting_player, state),
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1459,6 +1461,31 @@ fn quick_grow_extract_effect(acting_player: usize, state: &State) -> Outcomes {
     }
 
     // Create one outcome per possible evolution
+    let num_outcomes = evolution_choices.len();
+    let probabilities = vec![1.0 / (num_outcomes as f64); num_outcomes];
+    let mut outcomes: Mutations = vec![];
+
+    for (in_play_idx, evolution_card) in evolution_choices {
+        outcomes.push(Box::new(move |rng, state, action| {
+            apply_evolve(action.actor, state, &evolution_card, in_play_idx, true);
+            state.decks[action.actor].shuffle(false, rng);
+        }));
+    }
+
+    Outcomes::from_parts(probabilities, outcomes)
+}
+
+fn wallace_effect(acting_player: usize, state: &State) -> Outcomes {
+    // Choose 1 of your [W] Pokémon in play with a maximum HP of 50 or less. Put a random [W]
+    // Pokémon from your deck that evolves from that Pokémon onto that Pokémon to evolve it.
+    let evolution_choices = wallace_candidates(state, acting_player);
+
+    if evolution_choices.is_empty() {
+        return Outcomes::single_fn(|rng, state, action| {
+            state.decks[action.actor].shuffle(false, rng);
+        });
+    }
+
     let num_outcomes = evolution_choices.len();
     let probabilities = vec![1.0 / (num_outcomes as f64); num_outcomes];
     let mut outcomes: Mutations = vec![];

--- a/src/card_logic/mod.rs
+++ b/src/card_logic/mod.rs
@@ -2,8 +2,10 @@ mod diantha;
 mod ilima;
 mod quick_grow_extract;
 mod rare_candy;
+mod wallace;
 
 pub use diantha::diantha_targets;
 pub use ilima::ilima_targets;
 pub use quick_grow_extract::quick_grow_extract_candidates;
 pub use rare_candy::{can_rare_candy_evolve, get_highest_evolutions};
+pub use wallace::wallace_candidates;

--- a/src/card_logic/wallace.rs
+++ b/src/card_logic/wallace.rs
@@ -8,9 +8,11 @@ use crate::{
 /// Returns a vector of (in_play_index, evolution_card) tuples for all Water-type Pokémon in
 /// play that:
 /// - Are owned by the specified player
-/// - Were not played this turn
 /// - Have a maximum HP of 50 or less
 /// - Have at least one valid Water-type evolution in the player's deck
+///
+/// Unlike a normal evolution, Wallace has no restriction against evolving a Pokémon that was
+/// played this same turn.
 pub fn wallace_candidates(state: &State, player: usize) -> Vec<(usize, Card)> {
     let mut evolution_choices = vec![];
 
@@ -18,10 +20,7 @@ pub fn wallace_candidates(state: &State, player: usize) -> Vec<(usize, Card)> {
         let Card::Pokemon(pokemon_card) = &pokemon.card else {
             continue;
         };
-        if pokemon.get_energy_type() != Some(EnergyType::Water)
-            || pokemon.played_this_turn
-            || pokemon_card.hp > 50
-        {
+        if pokemon.get_energy_type() != Some(EnergyType::Water) || pokemon_card.hp > 50 {
             continue;
         }
 

--- a/src/card_logic/wallace.rs
+++ b/src/card_logic/wallace.rs
@@ -1,0 +1,40 @@
+use crate::{
+    models::{Card, EnergyType},
+    State,
+};
+
+/// Find all valid evolution candidates for Wallace.
+///
+/// Returns a vector of (in_play_index, evolution_card) tuples for all Water-type Pokémon in
+/// play that:
+/// - Are owned by the specified player
+/// - Were not played this turn
+/// - Have a maximum HP of 50 or less
+/// - Have at least one valid Water-type evolution in the player's deck
+pub fn wallace_candidates(state: &State, player: usize) -> Vec<(usize, Card)> {
+    let mut evolution_choices = vec![];
+
+    for (in_play_idx, pokemon) in state.enumerate_in_play_pokemon(player) {
+        let Card::Pokemon(pokemon_card) = &pokemon.card else {
+            continue;
+        };
+        if pokemon.get_energy_type() != Some(EnergyType::Water)
+            || pokemon.played_this_turn
+            || pokemon_card.hp > 50
+        {
+            continue;
+        }
+
+        for deck_card in state.decks[player].cards.iter() {
+            if let Card::Pokemon(deck_pokemon) = deck_card {
+                if deck_pokemon.energy_type == EnergyType::Water
+                    && pokemon.card.can_evolve_into(deck_card)
+                {
+                    evolution_choices.push((in_play_idx, deck_card.clone()));
+                }
+            }
+        }
+    }
+
+    evolution_choices
+}

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -3,6 +3,7 @@ use crate::{
     card_ids::CardId,
     card_logic::{
         can_rare_candy_evolve, diantha_targets, ilima_targets, quick_grow_extract_candidates,
+        wallace_candidates,
     },
     effects::TurnEffect,
     hooks::{
@@ -243,6 +244,7 @@ pub fn trainer_move_generation_implementation(
         CardId::B3b067PuppyLovingGirl | CardId::B3b084PuppyLovingGirl => {
             can_play_trainer(state, trainer_card)
         }
+        CardId::B3b068Wallace | CardId::B3b085Wallace => can_play_wallace(state, trainer_card),
         _ => None,
     }
 }
@@ -814,6 +816,17 @@ fn can_play_quick_grow_extract(
 
     // Check if there are any valid evolution candidates
     if quick_grow_extract_candidates(state, state.current_player).is_empty() {
+        cannot_play_trainer()
+    } else {
+        can_play_trainer(state, trainer_card)
+    }
+}
+
+/// Check if Wallace can be played
+/// Requires at least 1 Water pokemon with 50 HP or less, that wasn't played this turn,
+/// with a valid Water evolution available in deck
+fn can_play_wallace(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    if wallace_candidates(state, state.current_player).is_empty() {
         cannot_play_trainer()
     } else {
         can_play_trainer(state, trainer_card)

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -241,6 +241,7 @@ pub fn trainer_move_generation_implementation(
         CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
             can_play_professor_turo(state, trainer_card)
         }
+        CardId::B3b066Elesa | CardId::B3b083Elesa => can_play_trainer(state, trainer_card),
         CardId::B3b067PuppyLovingGirl | CardId::B3b084PuppyLovingGirl => {
             can_play_trainer(state, trainer_card)
         }

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -240,6 +240,9 @@ pub fn trainer_move_generation_implementation(
         CardId::B3a073ProfessorTuro | CardId::B3a088ProfessorTuro => {
             can_play_professor_turo(state, trainer_card)
         }
+        CardId::B3b067PuppyLovingGirl | CardId::B3b084PuppyLovingGirl => {
+            can_play_trainer(state, trainer_card)
+        }
         _ => None,
     }
 }

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -2,6 +2,8 @@
 mod barry_test;
 #[path = "trainers/cynthia_test.rs"]
 mod cynthia_test;
+#[path = "trainers/elesa_test.rs"]
+mod elesa_test;
 #[path = "trainers/field_blower_test.rs"]
 mod field_blower_test;
 #[path = "trainers/iris_trainer_test.rs"]

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -20,3 +20,5 @@ mod professor_turo_test;
 mod puppy_loving_girl_test;
 #[path = "trainers/volkner_test.rs"]
 mod volkner_test;
+#[path = "trainers/wallace_test.rs"]
+mod wallace_test;

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -16,5 +16,7 @@ mod marlon_test;
 mod professor_sada_test;
 #[path = "trainers/professor_turo_test.rs"]
 mod professor_turo_test;
+#[path = "trainers/puppy_loving_girl_test.rs"]
+mod puppy_loving_girl_test;
 #[path = "trainers/volkner_test.rs"]
 mod volkner_test;

--- a/tests/trainers/elesa_test.rs
+++ b/tests/trainers/elesa_test.rs
@@ -79,6 +79,122 @@ fn test_elesa_returns_all_tools_to_owners_hand() {
 }
 
 #[test]
+fn test_elesa_knocks_out_opponent_active_hanging_on_via_giant_cape() {
+    // Opponent's Bulbasaur (70 base HP) has a Giant Cape (+20 HP) and 70 damage on it, so it's
+    // sitting at 20 remaining HP only because of the Giant Cape. Once Elesa returns the Giant
+    // Cape to hand, its effective HP drops back to 70 and the existing 70 damage counters
+    // knock it out, awarding a point and requiring the opponent to promote from the bench.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_tool(get_card_by_enum(CardId::A2147GiantCape))
+                .with_damage(70),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+
+    let elesa = make_trainer_card(CardId::B3b066Elesa);
+    state.hands[0] = vec![Card::Trainer(elesa.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: elesa,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    assert!(
+        state.in_play_pokemon[1][0].is_none(),
+        "Opponent's Bulbasaur should have been knocked out and removed from the active spot"
+    );
+    assert_eq!(
+        state.points[0], 1,
+        "Player should have won 1 point for knocking out opponent's Bulbasaur"
+    );
+
+    // Opponent must now promote from the bench.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 1);
+    assert!(choices.iter().all(|choice| {
+        matches!(
+            choice.action,
+            SimpleAction::Activate {
+                player: 1,
+                in_play_idx: _
+            }
+        )
+    }));
+}
+
+#[test]
+fn test_elesa_knocks_out_opponent_active_hanging_on_via_leaf_cape() {
+    // Opponent's Charmander (60 base HP) has a Leaf Cape (+30 HP) and 60 damage on it, so it's
+    // sitting at 30 remaining HP only because of the Leaf Cape. Once Elesa returns the Leaf
+    // Cape to hand, its effective HP drops back to 60 and the existing 60 damage counters
+    // knock it out, awarding a point and requiring the opponent to promote from the bench.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![
+            PlayedCard::from_id(CardId::A1033Charmander)
+                .with_tool(get_card_by_enum(CardId::A3147LeafCape))
+                .with_damage(60),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    let elesa = make_trainer_card(CardId::B3b066Elesa);
+    state.hands[0] = vec![Card::Trainer(elesa.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: elesa,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    assert!(
+        state.in_play_pokemon[1][0].is_none(),
+        "Opponent's Charmander should have been knocked out and removed from the active spot"
+    );
+    assert_eq!(
+        state.points[0], 1,
+        "Player should have won 1 point for knocking out opponent's Charmander"
+    );
+
+    // Opponent must now promote from the bench.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 1);
+    assert!(choices.iter().all(|choice| {
+        matches!(
+            choice.action,
+            SimpleAction::Activate {
+                player: 1,
+                in_play_idx: _
+            }
+        )
+    }));
+}
+
+#[test]
 fn test_elesa_no_tools_attached_does_nothing() {
     let mut game = get_initialized_game(0);
     let mut state = game.get_state_clone();

--- a/tests/trainers/elesa_test.rs
+++ b/tests/trainers/elesa_test.rs
@@ -138,19 +138,20 @@ fn test_elesa_knocks_out_opponent_active_hanging_on_via_giant_cape() {
 
 #[test]
 fn test_elesa_knocks_out_opponent_active_hanging_on_via_leaf_cape() {
-    // Opponent's Charmander (60 base HP) has a Leaf Cape (+30 HP) and 60 damage on it, so it's
-    // sitting at 30 remaining HP only because of the Leaf Cape. Once Elesa returns the Leaf
-    // Cape to hand, its effective HP drops back to 60 and the existing 60 damage counters
-    // knock it out, awarding a point and requiring the opponent to promote from the bench.
+    // Leaf Cape only attaches to [G] Pokémon, so use Oddish (60 base HP, Grass). It has a Leaf
+    // Cape (+30 HP) and 60 damage on it, so it's sitting at 30 remaining HP only because of the
+    // Leaf Cape. Once Elesa returns the Leaf Cape to hand, its effective HP drops back to 60 and
+    // the existing 60 damage counters knock it out, awarding a point and requiring the opponent
+    // to promote from the bench.
     let mut game = get_initialized_game(0);
     let mut state = game.get_state_clone();
     state.current_player = 0;
     state.turn_count = 3;
 
     state.set_board(
-        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
         vec![
-            PlayedCard::from_id(CardId::A1033Charmander)
+            PlayedCard::from_id(CardId::A1011Oddish)
                 .with_tool(get_card_by_enum(CardId::A3147LeafCape))
                 .with_damage(60),
             PlayedCard::from_id(CardId::A1001Bulbasaur),
@@ -173,11 +174,11 @@ fn test_elesa_knocks_out_opponent_active_hanging_on_via_leaf_cape() {
     let state = game.get_state_clone();
     assert!(
         state.in_play_pokemon[1][0].is_none(),
-        "Opponent's Charmander should have been knocked out and removed from the active spot"
+        "Opponent's Oddish should have been knocked out and removed from the active spot"
     );
     assert_eq!(
         state.points[0], 1,
-        "Player should have won 1 point for knocking out opponent's Charmander"
+        "Player should have won 1 point for knocking out opponent's Oddish"
     );
 
     // Opponent must now promote from the bench.

--- a/tests/trainers/elesa_test.rs
+++ b/tests/trainers/elesa_test.rs
@@ -1,0 +1,112 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn make_trainer_card(card_id: CardId) -> deckgym::models::TrainerCard {
+    get_card_by_enum(card_id).as_trainer()
+}
+
+#[test]
+fn test_elesa_returns_all_tools_to_owners_hand() {
+    // Elesa: "Return all Pokémon Tools attached to each Pokémon (both yours and your
+    // opponent's) to their owner's hand."
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_tool(get_card_by_enum(CardId::A2148RockyHelmet)),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)
+            .with_tool(get_card_by_enum(CardId::A2148RockyHelmet))],
+    );
+
+    let elesa = make_trainer_card(CardId::B3b066Elesa);
+    state.hands[0] = vec![Card::Trainer(elesa.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: elesa,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+
+    let player_active = state.in_play_pokemon[0][0]
+        .as_ref()
+        .expect("Player active should remain");
+    assert!(
+        player_active.attached_tool.is_none(),
+        "Rocky Helmet should have been detached from player's Bulbasaur"
+    );
+    let opponent_active = state.in_play_pokemon[1][0]
+        .as_ref()
+        .expect("Opponent active should remain");
+    assert!(
+        opponent_active.attached_tool.is_none(),
+        "Rocky Helmet should have been detached from opponent's Charmander"
+    );
+
+    let player_hand_tool_count = state.hands[0]
+        .iter()
+        .filter(|c| matches!(c, Card::Trainer(tc) if tc.id == "A2 148"))
+        .count();
+    assert_eq!(
+        player_hand_tool_count, 1,
+        "Player should get their Rocky Helmet back in hand"
+    );
+
+    let opponent_hand_tool_count = state.hands[1]
+        .iter()
+        .filter(|c| matches!(c, Card::Trainer(tc) if tc.id == "A2 148"))
+        .count();
+    assert_eq!(
+        opponent_hand_tool_count, 1,
+        "Opponent should get their Rocky Helmet back in hand"
+    );
+}
+
+#[test]
+fn test_elesa_no_tools_attached_does_nothing() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+
+    let elesa = make_trainer_card(CardId::B3b066Elesa);
+    state.hands[0] = vec![Card::Trainer(elesa.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: elesa,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    assert!(state.hands[0].is_empty(), "No tools should return to hand");
+    assert!(
+        !state.hands[1].iter().any(|c| matches!(c, Card::Trainer(tc) if tc.trainer_card_type == deckgym::models::TrainerType::Tool)),
+        "No tools should return to hand"
+    );
+}

--- a/tests/trainers/puppy_loving_girl_test.rs
+++ b/tests/trainers/puppy_loving_girl_test.rs
@@ -1,0 +1,104 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn make_trainer_card(card_id: CardId) -> deckgym::models::TrainerCard {
+    get_card_by_enum(card_id).as_trainer()
+}
+
+#[test]
+fn test_puppy_loving_girl_puts_puppy_pile_pokemon_into_hand() {
+    // Puppy-Loving Girl: "Look at the top 4 cards of your deck. Put all Pokémon you find there
+    // that have the Puppy Pile attack into your hand. Shuffle the other cards back into your deck."
+    // Deck's top 4 cards contain Lillipup (has Puppy Pile) and other Pokémon without it.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let lillipup_card = get_card_by_enum(CardId::B3137Lillipup);
+    let charmander_card = get_card_by_enum(CardId::A1033Charmander);
+    state.decks[0].cards = vec![lillipup_card.clone(), charmander_card.clone()];
+
+    let puppy_loving_girl = make_trainer_card(CardId::B3b067PuppyLovingGirl);
+    state.hands[0] = vec![Card::Trainer(puppy_loving_girl.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: puppy_loving_girl,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    let has_lillipup = state.hands[0]
+        .iter()
+        .any(|c| matches!(c, Card::Pokemon(p) if p.id == "B3 137"));
+    assert!(has_lillipup, "Lillipup should be moved to hand");
+
+    let has_charmander = state.hands[0]
+        .iter()
+        .any(|c| matches!(c, Card::Pokemon(p) if p.id == "A1 033"));
+    assert!(
+        !has_charmander,
+        "Charmander should NOT be moved to hand since it doesn't have Puppy Pile"
+    );
+    assert!(
+        state.decks[0].cards.contains(&charmander_card),
+        "Charmander should remain in the deck"
+    );
+}
+
+#[test]
+fn test_puppy_loving_girl_no_puppy_pile_pokemon_does_nothing() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let charmander_card = get_card_by_enum(CardId::A1033Charmander);
+    state.decks[0].cards = vec![charmander_card.clone()];
+
+    let puppy_loving_girl = make_trainer_card(CardId::B3b067PuppyLovingGirl);
+    state.hands[0] = vec![Card::Trainer(puppy_loving_girl.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: puppy_loving_girl,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    let has_charmander = state.hands[0]
+        .iter()
+        .any(|c| matches!(c, Card::Pokemon(p) if p.id == "A1 033"));
+    assert!(
+        !has_charmander,
+        "Charmander should NOT be moved to hand since it doesn't have Puppy Pile"
+    );
+    assert!(
+        state.decks[0].cards.contains(&charmander_card),
+        "Charmander should remain in the deck"
+    );
+}

--- a/tests/trainers/wallace_test.rs
+++ b/tests/trainers/wallace_test.rs
@@ -1,0 +1,86 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn make_trainer_card(card_id: CardId) -> deckgym::models::TrainerCard {
+    get_card_by_enum(card_id).as_trainer()
+}
+
+#[test]
+fn test_wallace_evolves_low_hp_water_pokemon_from_deck() {
+    // Wallace: "Choose 1 of your [W] Pokémon in play with a maximum HP of 50 or less. Put a
+    // random [W] Pokémon from your deck that evolves from that Pokémon onto that Pokémon to
+    // evolve it."
+    // Staryu (50 HP, Water) is on the board; Starmie (evolves from Staryu) is the only card
+    // in the deck, so the evolution outcome is deterministic.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1074Staryu)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let starmie_card = get_card_by_enum(CardId::A1075Starmie);
+    state.decks[0].cards = vec![starmie_card.clone()];
+
+    let wallace = make_trainer_card(CardId::B3b068Wallace);
+    state.hands[0] = vec![Card::Trainer(wallace.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: wallace,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    let active = state.in_play_pokemon[0][0]
+        .as_ref()
+        .expect("Active Pokemon should still be present");
+    assert_eq!(active.get_name(), "Starmie");
+    assert!(
+        state.decks[0].cards.is_empty(),
+        "Starmie should have been removed from the deck"
+    );
+}
+
+#[test]
+fn test_wallace_no_valid_target_does_nothing() {
+    // Wallace requires a [W] Pokémon in play with max HP of 50 or less; Wartortle (80 HP)
+    // doesn't qualify, so the card should have no effect (and thus can't be played).
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1054Wartortle)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let blastoise_card = get_card_by_enum(CardId::A1055Blastoise);
+    state.decks[0].cards = vec![blastoise_card.clone()];
+
+    let wallace = make_trainer_card(CardId::B3b068Wallace);
+    state.hands[0] = vec![Card::Trainer(wallace)];
+    game.set_state(state);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        !choices
+            .iter()
+            .any(|choice| matches!(&choice.action, SimpleAction::Play { trainer_card } if trainer_card.id == "B3b 068")),
+        "Wallace shouldn't be playable without a valid low-HP Water Pokémon target"
+    );
+}

--- a/tests/trainers/wallace_test.rs
+++ b/tests/trainers/wallace_test.rs
@@ -55,6 +55,50 @@ fn test_wallace_evolves_low_hp_water_pokemon_from_deck() {
 }
 
 #[test]
+fn test_wallace_can_evolve_pokemon_played_this_turn() {
+    // Unlike a normal evolution, Wallace has no "not played this turn" restriction: you can
+    // put a Magikarp down and evolve it into Gyarados with Wallace on the same turn.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    let mut magikarp = PlayedCard::from_id(CardId::A1077Magikarp);
+    magikarp.played_this_turn = true;
+
+    state.set_board(
+        vec![magikarp],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let gyarados_card = get_card_by_enum(CardId::A1078Gyarados);
+    state.decks[0].cards = vec![gyarados_card.clone()];
+
+    let wallace = make_trainer_card(CardId::B3b068Wallace);
+    state.hands[0] = vec![Card::Trainer(wallace.clone())];
+    game.set_state(state);
+
+    let play_action = Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: wallace,
+        },
+        is_stack: false,
+    };
+    game.apply_action(&play_action);
+
+    let state = game.get_state_clone();
+    let active = state.in_play_pokemon[0][0]
+        .as_ref()
+        .expect("Active Pokemon should still be present");
+    assert_eq!(active.get_name(), "Gyarados");
+    assert!(
+        state.decks[0].cards.is_empty(),
+        "Gyarados should have been removed from the deck"
+    );
+}
+
+#[test]
 fn test_wallace_no_valid_target_does_nothing() {
     // Wallace requires a [W] Pokémon in play with max HP of 50 or less; Wartortle (80 HP)
     // doesn't qualify, so the card should have no effect (and thus can't be played).


### PR DESCRIPTION
Look at the top 4 cards of the deck and move any Pokémon with the
Puppy Pile attack into hand, shuffling the rest back.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019nuwXaniBVQ2tWRPALFKpR