### PR TITLE
Make Pokémon Tools attachable to any Pokémon; gate effects by holder

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -295,7 +295,10 @@ fn apply_attach_tool(state: &mut State, actor: usize, in_play_idx: usize, tool_c
         .expect("Pokemon should be there if attaching tool to it");
     pokemon.attached_tool = Some(tool_card.clone());
 
-    if tools::has_tool(pokemon, crate::card_ids::CardId::A4153SteelApron) {
+    // Steel Apron: "...recovers from all Special Conditions..." only for a [M] holder.
+    if tools::has_tool(pokemon, crate::card_ids::CardId::A4153SteelApron)
+        && pokemon.get_energy_type() == Some(crate::models::EnergyType::Metal)
+    {
         pokemon.cure_status_conditions();
     }
 }

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -495,7 +495,10 @@ fn get_metal_core_barrier_reduction(
     let defending_pokemon = &state.in_play_pokemon[target_player][target_idx]
         .as_ref()
         .expect("Defending Pokemon should be there when checking Metal Core Barrier");
-    if has_tool(defending_pokemon, CardId::B2148MetalCoreBarrier) {
+    // Metal Core Barrier: "The [M] Pokémon this card is attached to takes -50 damage..."
+    if has_tool(defending_pokemon, CardId::B2148MetalCoreBarrier)
+        && defending_pokemon.get_energy_type() == Some(EnergyType::Metal)
+    {
         debug!("Metal Core Barrier: Reducing damage by 50");
         return 50;
     }
@@ -515,7 +518,10 @@ fn get_steel_apron_reduction(
     let defending_pokemon = &state.in_play_pokemon[target_player][target_idx]
         .as_ref()
         .expect("Defending Pokemon should be there when checking Steel Apron");
-    if has_tool(defending_pokemon, CardId::A4153SteelApron) {
+    // Steel Apron: "The [M] Pokémon this card is attached to takes -10 damage..."
+    if has_tool(defending_pokemon, CardId::A4153SteelApron)
+        && defending_pokemon.get_energy_type() == Some(EnergyType::Metal)
+    {
         debug!("Steel Apron: Reducing damage by 10");
         return 10;
     }
@@ -1266,8 +1272,11 @@ pub(crate) fn on_knockout(
         .as_ref()
         .expect("Pokemon should be there if knocked out");
 
-    // Handle Electrical Cord
-    if has_tool(knocked_out_pokemon, CardId::A3a065ElectricalCord) {
+    // Handle Electrical Cord: "If the [L] Pokémon this card is attached to is in the Active
+    // Spot and is Knocked Out by damage from an attack..."
+    if has_tool(knocked_out_pokemon, CardId::A3a065ElectricalCord)
+        && knocked_out_pokemon.get_energy_type() == Some(EnergyType::Lightning)
+    {
         // Only triggers if knocked out in active spot from an active attack
         if knocked_out_idx != 0 || !is_from_active_attack {
             return;

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -436,7 +436,11 @@ impl State {
             return;
         }
 
-        if has_tool(pokemon, crate::card_ids::CardId::A4153SteelApron) {
+        // Steel Apron: "The [M] Pokémon this card is attached to ... can't be affected by any
+        // Special Conditions." The immunity only applies to a [M] holder.
+        if has_tool(pokemon, crate::card_ids::CardId::A4153SteelApron)
+            && pokemon.get_energy_type() == Some(EnergyType::Metal)
+        {
             debug!("Steel Apron: Pokémon is immune to status conditions");
             return;
         }

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -204,11 +204,19 @@ impl PlayedCard {
     pub(crate) fn get_effective_total_hp(&self) -> u32 {
         let mut effective_hp = self.base_hp;
 
-        // Tool bonuses
+        // Tool bonuses. Type/stage-specific caps only apply to matching Pokémon (the tools are
+        // attachable to anything, but their HP bonus is gated by the holder).
         if has_tool(self, CardId::A2147GiantCape) {
             effective_hp += 20;
-        } else if has_tool(self, CardId::A3147LeafCape) || has_tool(self, CardId::B3b065ElegantCape)
+        } else if has_tool(self, CardId::A3147LeafCape)
+            && self.get_energy_type() == Some(EnergyType::Grass)
         {
+            // Leaf Cape: "The [G] Pokémon this card is attached to gets +30 HP."
+            effective_hp += 30;
+        } else if has_tool(self, CardId::B3b065ElegantCape)
+            && matches!(&self.card, Card::Pokemon(p) if p.stage == 1)
+        {
+            // Elegant Cape: "The Stage 1 Pokémon this card is attached to gets +30 HP."
             effective_hp += 30;
         } else if has_tool(self, CardId::B3a069AncientBoosterEnergyCapsule)
             && is_ancient_pokemon(&self.get_name())

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -3,7 +3,7 @@ use std::sync::LazyLock;
 use crate::{
     card_ids::CardId,
     database::get_card_by_enum,
-    models::{Card, EnergyType, PlayedCard, TrainerCard, TrainerType},
+    models::{Card, PlayedCard, TrainerCard, TrainerType},
     State,
 };
 
@@ -77,46 +77,19 @@ pub fn has_tool(played_card: &PlayedCard, reference_tool_id: CardId) -> bool {
     trainer_card.effect == reference_effect
 }
 
-pub fn can_attach_tool_to(trainer_card: &TrainerCard, pokemon: &PlayedCard) -> bool {
-    let trainer_card = ensure_tool_trainer(trainer_card);
-    let effect = trainer_card.effect.as_str();
-    if effect == LEAF_CAPE_EFFECT.as_str() {
-        return pokemon.card.get_type() == Some(EnergyType::Grass);
-    }
-    if effect == ELECTRICAL_CORD_EFFECT.as_str() {
-        return pokemon.card.get_type() == Some(EnergyType::Lightning);
-    }
-    if effect == INFLATABLE_BOAT_EFFECT.as_str() {
-        return pokemon.card.get_type() == Some(EnergyType::Water);
-    }
-    if effect == STEEL_APRON_EFFECT.as_str() {
-        return pokemon.card.get_type() == Some(EnergyType::Metal);
-    }
-    if effect == METAL_CORE_BARRIER_EFFECT.as_str() {
-        return pokemon.card.get_type() == Some(EnergyType::Metal);
-    }
-    if effect == BIG_AIR_BALLOON_EFFECT.as_str() {
-        return matches!(&pokemon.card, Card::Pokemon(p) if p.stage == 2);
-    }
-    if effect == SMALL_BALLOON_EFFECT.as_str() {
-        return matches!(&pokemon.card, Card::Pokemon(p) if p.stage == 0);
-    }
-    if effect == ELEGANT_CAPE_EFFECT.as_str() {
-        return matches!(&pokemon.card, Card::Pokemon(p) if p.stage == 1);
-    }
-    true
-}
-
 pub(crate) fn enumerate_tool_choices<'a>(
     trainer_card: &TrainerCard,
     state: &'a State,
     actor: usize,
 ) -> Vec<(usize, &'a PlayedCard)> {
-    let trainer_card = ensure_tool_trainer(trainer_card);
+    ensure_tool_trainer(trainer_card);
+    // Pokémon Tools can be attached to ANY Pokémon — the game never restricts attachment by
+    // type or stage. Tools whose effect is type/stage-specific (Leaf Cape [G] +30 HP, Big Air
+    // Balloon Stage-2 free retreat, Steel Apron [M] −10, etc.) gate the *effect* at its
+    // application site, not the attachment. The only attachment rule is one tool per Pokémon.
     state
         .enumerate_in_play_pokemon(actor)
         .filter(|(_, x)| !x.has_tool_attached())
-        .filter(|(_, x)| can_attach_tool_to(trainer_card, x))
         .collect()
 }
 

--- a/tests/steel_apron_test.rs
+++ b/tests/steel_apron_test.rs
@@ -14,7 +14,9 @@ fn steel_apron_trainer() -> deckgym::models::TrainerCard {
 }
 
 #[test]
-fn test_steel_apron_only_attaches_to_metal() {
+fn test_steel_apron_attaches_to_any_pokemon() {
+    // Pokémon Tools are attachable to ANY Pokémon; only the effect is gated to [M]. Steel Apron
+    // should therefore be offered on both the Metal Meltan and the Grass Bulbasaur.
     let mut game = get_initialized_game(0);
     let mut state = game.get_state_clone();
 
@@ -40,15 +42,46 @@ fn test_steel_apron_only_attaches_to_metal() {
 
     let state = game.get_state_clone();
     let (_actor, choices) = state.generate_possible_actions();
-    let attachable_indices: Vec<usize> = choices
+    let mut attachable_indices: Vec<usize> = choices
         .iter()
         .filter_map(|choice| match choice.action {
             SimpleAction::AttachTool { in_play_idx, .. } => Some(in_play_idx),
             _ => None,
         })
         .collect();
+    attachable_indices.sort_unstable();
 
-    assert_eq!(attachable_indices, vec![0]);
+    assert_eq!(attachable_indices, vec![0, 1]);
+}
+
+#[test]
+fn test_steel_apron_gives_no_damage_reduction_to_non_metal_holder() {
+    // Attached to a non-[M] Pokémon, Steel Apron's -10 damage reduction must not apply.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_tool(get_card_by_enum(CardId::A4153SteelApron))],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    let attack = Action {
+        actor: 0,
+        action: attack_action(CardId::A1001Bulbasaur, 0),
+        is_stack: false,
+    };
+    game.apply_action(&attack);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        70 - 40,
+        "Steel Apron should NOT reduce damage on a non-Metal holder (full 40 damage)"
+    );
 }
 
 #[test]

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -10,5 +10,7 @@ mod protective_poncho_test;
 mod raikou_rocky_helmet_order_test;
 #[path = "tools/small_balloon_test.rs"]
 mod small_balloon_test;
+#[path = "tools/tool_effect_gating_test.rs"]
+mod tool_effect_gating_test;
 #[path = "tools/tools_integration_test.rs"]
 mod tools_integration_test;

--- a/tests/tools/tool_effect_gating_test.rs
+++ b/tests/tools/tool_effect_gating_test.rs
@@ -1,0 +1,56 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Pokémon Tools are attachable to any Pokémon, but stage/type-specific effects only apply to a
+/// matching holder. These tests lock in the effect-gating for the tools whose restriction used
+/// to live in `can_attach_tool_to`.
+
+#[test]
+fn test_leaf_cape_gives_no_hp_to_non_grass_holder() {
+    // Charmander (Fire, 60 HP) holding Leaf Cape ([G] +30 HP) should stay at 60.
+    let game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1033Charmander)
+            .with_tool(get_card_by_enum(CardId::A3147LeafCape))],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    assert_eq!(game.get_state_clone().get_active(0).get_remaining_hp(), 60);
+}
+
+#[test]
+fn test_elegant_cape_gives_no_hp_to_non_stage_1_holder() {
+    // Bulbasaur (Basic, 70 HP) holding Elegant Cape (Stage 1 +30 HP) should stay at 70.
+    let game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_tool(get_card_by_enum(CardId::B3b065ElegantCape))],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    assert_eq!(game.get_state_clone().get_active(0).get_remaining_hp(), 70);
+}
+
+#[test]
+fn test_metal_core_barrier_gives_no_reduction_to_non_metal_holder() {
+    // Bulbasaur (Grass) holding Metal Core Barrier ([M] -50 damage) takes full damage.
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_tool(get_card_by_enum(CardId::B2148MetalCoreBarrier))],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1001Bulbasaur, 0), // Vine Whip, 40
+        is_stack: false,
+    });
+
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        70 - 40,
+        "Metal Core Barrier should not reduce damage on a non-Metal holder"
+    );
+}

--- a/tests/tools/tools_integration_test.rs
+++ b/tests/tools/tools_integration_test.rs
@@ -66,7 +66,7 @@ fn test_giant_cape_attach_increases_hp() {
 }
 
 #[test]
-fn test_elegant_cape_only_attaches_to_stage_1_and_increases_hp() {
+fn test_elegant_cape_attaches_to_any_and_boosts_only_stage_1() {
     let mut game = get_initialized_game(0);
     let mut state = game.get_state_clone();
 
@@ -93,15 +93,18 @@ fn test_elegant_cape_only_attaches_to_stage_1_and_increases_hp() {
     let state = game.get_state_clone();
     let (_actor, choices) = state.generate_possible_actions();
 
-    let attachable_indices: Vec<usize> = choices
+    let mut attachable_indices: Vec<usize> = choices
         .iter()
         .filter_map(|choice| match choice.action {
             SimpleAction::AttachTool { in_play_idx, .. } => Some(in_play_idx),
             _ => None,
         })
         .collect();
+    attachable_indices.sort_unstable();
 
-    assert_eq!(attachable_indices, vec![1]);
+    // Attachable to both the Basic (Bulbasaur) and the Stage 1 (Ivysaur); only the Stage 1
+    // holder gets the +30 HP.
+    assert_eq!(attachable_indices, vec![0, 1]);
 
     let attach_action = Action {
         actor: 0,
@@ -120,7 +123,7 @@ fn test_elegant_cape_only_attaches_to_stage_1_and_increases_hp() {
 }
 
 #[test]
-fn test_leaf_cape_only_attaches_to_grass() {
+fn test_leaf_cape_attaches_to_any_and_boosts_only_grass() {
     let mut game = get_initialized_game(0);
     let mut state = game.get_state_clone();
 
@@ -149,15 +152,18 @@ fn test_leaf_cape_only_attaches_to_grass() {
     let state = game.get_state_clone();
     let (_actor, choices) = state.generate_possible_actions();
 
-    let attachable_indices: Vec<usize> = choices
+    let mut attachable_indices: Vec<usize> = choices
         .iter()
         .filter_map(|choice| match choice.action {
             SimpleAction::AttachTool { in_play_idx, .. } => Some(in_play_idx),
             _ => None,
         })
         .collect();
+    attachable_indices.sort_unstable();
 
-    assert_eq!(attachable_indices, vec![0]);
+    // Attachable to both the Grass Bulbasaur and the Fire Charmander; only the Grass holder
+    // gets the +30 HP.
+    assert_eq!(attachable_indices, vec![0, 1]);
 
     let attach_action = Action {
         actor: 0,


### PR DESCRIPTION
Follow-up to your review comment on the Big Air Balloon fix — you were right that the same bug affects all the other tools, so this generalizes it and removes the `can_attach_tool_to` piece entirely.

## The bug

Pokémon Tools are never restricted by the holder's type or stage in the actual game — only their **effect** is conditional. The engine enforced the restriction at *attachment* time via `can_attach_tool_to`, which (a) diverged from the game and (b) meant several effects were never independently gated: they relied on the attach check to guarantee they'd never reach a non-matching holder.

## Change

- **Remove `can_attach_tool_to` entirely.** `enumerate_tool_choices` now enforces only the one real rule: one tool per Pokémon.
- **Gate each type/stage-specific effect at its application site** (so behavior is preserved now that any holder is possible):

  | Tool | Effect | Now gated on |
  |------|--------|--------------|
  | Leaf Cape | +30 HP | holder is [G] |
  | Elegant Cape | +30 HP | holder is Stage 1 |
  | Steel Apron | −10 dmg, status cure + immunity | holder is [M] |
  | Metal Core Barrier | −50 dmg | holder is [M] |
  | Electrical Cord | move [L] energy on KO | holder is [L] |

  Inflatable Boat, Big Air Balloon and Small Balloon were already effect-gated (their attach restriction was redundant), so they just lose the attach check.

## Tests

- Flipped the two integration tests that asserted the old attach restrictions (`leaf_cape_only_attaches_to_grass`, `elegant_cape_only_attaches_to_stage_1`) and the Steel Apron `only_attaches_to_metal` test to the new behavior (attaches to any holder; effect gated).
- Added `tests/tools/tool_effect_gating_test.rs`: each tool attaches to a non-matching holder but grants **no** effect (Leaf Cape on Fire → no HP; Elegant Cape on Basic → no HP; Metal Core Barrier on non-Metal → full damage), plus a Steel Apron non-Metal no-reduction test.

Full suite (28 targets), `cargo fmt`, `cargo clippy --features "tui test-utils" -- -D warnings` all pass. Also fuzzed the 5 re-gated tools (10k games each) with no panics.

Note: this branch is now rebased on current `main`, so it also picks up your Small Balloon / Elegant Cape merges — those two tools are among the ones cleaned up here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)