### PR TITLE
Implement Small Balloon and Elegant Cape tools (B3b)

### DIFF
--- a/src/hooks/retreat.rs
+++ b/src/hooks/retreat.rs
@@ -38,6 +38,9 @@ pub(crate) fn get_retreat_cost(state: &State, card: &PlayedCard) -> Vec<EnergyTy
         if has_tool(card, CardId::B2a087BigAirBalloon) && pokemon_card.stage == 2 {
             return vec![];
         }
+        if has_tool(card, CardId::B3b064SmallBalloon) && pokemon_card.stage == 0 {
+            normal_cost.pop();
+        }
         // Implement Retreat Cost Modifiers here
         let mut to_subtract = state
             .get_current_turn_effects()

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -213,6 +213,10 @@ impl PlayedCard {
             && is_ancient_pokemon(&self.get_name())
         {
             effective_hp += 40;
+        } else if has_tool(self, CardId::B3b065ElegantCape)
+            && matches!(&self.card, Card::Pokemon(p) if p.stage == 1)
+        {
+            effective_hp += 30;
         }
 
         effective_hp += self.stadium_hp_bonus;

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -58,6 +58,10 @@ static ANCIENT_BOOSTER_ENERGY_CAPSULE_EFFECT: LazyLock<String> =
     LazyLock::new(|| tool_effect_text_from_card_id(CardId::B3a069AncientBoosterEnergyCapsule));
 static FUTURE_BOOSTER_ENERGY_CAPSULE_EFFECT: LazyLock<String> =
     LazyLock::new(|| tool_effect_text_from_card_id(CardId::B3a070FutureBoosterEnergyCapsule));
+static SMALL_BALLOON_EFFECT: LazyLock<String> =
+    LazyLock::new(|| tool_effect_text_from_card_id(CardId::B3b064SmallBalloon));
+static ELEGANT_CAPE_EFFECT: LazyLock<String> =
+    LazyLock::new(|| tool_effect_text_from_card_id(CardId::B3b065ElegantCape));
 
 pub fn tool_effects_equal(trainer_card: &TrainerCard, reference_tool_id: CardId) -> bool {
     ensure_tool_trainer(trainer_card);
@@ -91,8 +95,8 @@ pub fn can_attach_tool_to(trainer_card: &TrainerCard, pokemon: &PlayedCard) -> b
     if effect == METAL_CORE_BARRIER_EFFECT.as_str() {
         return pokemon.card.get_type() == Some(EnergyType::Metal);
     }
-    // Big Air Balloon can be attached to any Pokemon (verified in-game); its effect simply
-    // doesn't apply unless the holder is a Stage 2.
+    // Big Air Balloon, Small Balloon and Elegant Cape can be attached to any Pokemon (verified
+    // in-game); their effects simply don't apply unless the holder is the matching stage.
     true
 }
 
@@ -128,5 +132,7 @@ pub fn is_tool_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == LUCKY_EGG_EFFECT.as_str()
             || e == ANCIENT_BOOSTER_ENERGY_CAPSULE_EFFECT.as_str()
             || e == FUTURE_BOOSTER_ENERGY_CAPSULE_EFFECT.as_str()
+            || e == SMALL_BALLOON_EFFECT.as_str()
+            || e == ELEGANT_CAPE_EFFECT.as_str()
     )
 }

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -91,9 +91,8 @@ pub fn can_attach_tool_to(trainer_card: &TrainerCard, pokemon: &PlayedCard) -> b
     if effect == METAL_CORE_BARRIER_EFFECT.as_str() {
         return pokemon.card.get_type() == Some(EnergyType::Metal);
     }
-    if effect == BIG_AIR_BALLOON_EFFECT.as_str() {
-        return matches!(&pokemon.card, Card::Pokemon(p) if p.stage == 2);
-    }
+    // Big Air Balloon can be attached to any Pokemon (verified in-game); its effect simply
+    // doesn't apply unless the holder is a Stage 2.
     true
 }
 

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -2,6 +2,8 @@
 mod big_air_balloon_test;
 #[path = "tools/booster_capsule_test.rs"]
 mod booster_capsule_test;
+#[path = "tools/elegant_cape_test.rs"]
+mod elegant_cape_test;
 #[path = "tools/lucky_egg_test.rs"]
 mod lucky_egg_test;
 #[path = "tools/lucky_ice_pop_test.rs"]
@@ -10,5 +12,7 @@ mod lucky_ice_pop_test;
 mod protective_poncho_test;
 #[path = "tools/raikou_rocky_helmet_order_test.rs"]
 mod raikou_rocky_helmet_order_test;
+#[path = "tools/small_balloon_test.rs"]
+mod small_balloon_test;
 #[path = "tools/tools_integration_test.rs"]
 mod tools_integration_test;

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -1,3 +1,5 @@
+#[path = "tools/big_air_balloon_test.rs"]
+mod big_air_balloon_test;
 #[path = "tools/booster_capsule_test.rs"]
 mod booster_capsule_test;
 #[path = "tools/lucky_egg_test.rs"]

--- a/tests/tools/big_air_balloon_test.rs
+++ b/tests/tools/big_air_balloon_test.rs
@@ -1,0 +1,60 @@
+use deckgym::{
+    actions::SimpleAction, card_ids::CardId, database::get_card_by_enum, models::PlayedCard,
+    test_support::get_test_game_with_board,
+};
+
+#[test]
+fn test_big_air_balloon_attaches_to_basic_but_only_frees_stage_2_retreat() {
+    // The tool can be attached to any Pokemon (verified in-game)...
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    let mut state = game.get_state_clone();
+    state.hands[0].push(get_card_by_enum(CardId::B2a087BigAirBalloon));
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        actions.iter().any(|a| matches!(
+            &a.action,
+            SimpleAction::Play { trainer_card } if trainer_card.name == "Big Air Balloon"
+        )),
+        "Big Air Balloon should be attachable to non-Stage 2 Pokemon"
+    );
+
+    // ...but only a Stage 2 holder gets the free retreat. Bulbasaur (retreat cost 1, no
+    // energy) still cannot retreat with the balloon attached.
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_tool(get_card_by_enum(CardId::B2a087BigAirBalloon)),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(_))),
+        "Big Air Balloon should not remove a non-Stage 2 Pokemon's retreat cost"
+    );
+
+    // Control: a Stage 2 holder (Venusaur ex, retreat cost 3) retreats for free.
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1004VenusaurEx)
+                .with_tool(get_card_by_enum(CardId::B2a087BigAirBalloon)),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(_))),
+        "Big Air Balloon should give a Stage 2 Pokemon free retreat"
+    );
+}

--- a/tests/tools/elegant_cape_test.rs
+++ b/tests/tools/elegant_cape_test.rs
@@ -1,0 +1,54 @@
+use deckgym::{
+    actions::SimpleAction, card_ids::CardId, database::get_card_by_enum, models::PlayedCard,
+    test_support::get_test_game_with_board,
+};
+
+#[test]
+fn test_elegant_cape_grants_30_hp_to_stage_1() {
+    // Ivysaur (A1 002) is a Stage 1 with 90 HP; Elegant Cape should bring it to 120.
+    let game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1002Ivysaur)
+            .with_tool(get_card_by_enum(CardId::B3b065ElegantCape))],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(0).get_remaining_hp(),
+        120,
+        "Elegant Cape should grant +30 HP to the Stage 1 it is attached to"
+    );
+}
+
+#[test]
+fn test_elegant_cape_attaches_to_basic_but_grants_no_hp() {
+    // The tool can be attached to any Pokemon (verified in-game)...
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    let mut state = game.get_state_clone();
+    state.hands[0].push(get_card_by_enum(CardId::B3b065ElegantCape));
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        actions.iter().any(|a| matches!(
+            &a.action,
+            SimpleAction::Play { trainer_card } if trainer_card.name == "Elegant Cape"
+        )),
+        "Elegant Cape should be attachable to non-Stage 1 Pokemon"
+    );
+
+    // ...but the +30 HP only applies to Stage 1 Pokemon. Bulbasaur stays at 70 HP.
+    let game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_tool(get_card_by_enum(CardId::B3b065ElegantCape))],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    assert_eq!(
+        game.get_state_clone().get_active(0).get_remaining_hp(),
+        70,
+        "Elegant Cape should not grant HP to a non-Stage 1 Pokemon"
+    );
+}

--- a/tests/tools/small_balloon_test.rs
+++ b/tests/tools/small_balloon_test.rs
@@ -1,0 +1,84 @@
+use deckgym::{
+    actions::SimpleAction, card_ids::CardId, database::get_card_by_enum, models::PlayedCard,
+    test_support::get_test_game_with_board,
+};
+
+#[test]
+fn test_small_balloon_lets_basic_retreat_for_free() {
+    // Bulbasaur (A1 001) is a Basic with a retreat cost of 1. With Small Balloon attached and no
+    // energy, it should be able to retreat for free.
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_tool(get_card_by_enum(CardId::B3b064SmallBalloon)),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(_))),
+        "Small Balloon should reduce a Basic's retreat cost of 1 to 0"
+    );
+
+    // Control: without the tool, the same Bulbasaur cannot pay its retreat cost.
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(_))),
+        "Without Small Balloon, Caterpie should not be able to retreat with no energy"
+    );
+}
+
+#[test]
+fn test_small_balloon_attaches_to_evolved_pokemon_but_does_not_reduce_their_cost() {
+    // The tool can be attached to any Pokemon (verified in-game)...
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1002Ivysaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    let mut state = game.get_state_clone();
+    state.hands[0].push(get_card_by_enum(CardId::B3b064SmallBalloon));
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        actions.iter().any(|a| matches!(
+            &a.action,
+            SimpleAction::Play { trainer_card } if trainer_card.name == "Small Balloon"
+        )),
+        "Small Balloon should be attachable to non-Basic Pokemon"
+    );
+
+    // ...but the retreat reduction only applies to Basic Pokemon. Ivysaur has a retreat cost
+    // of 2; with the balloon and 1 energy it still cannot retreat.
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1002Ivysaur)
+                .with_tool(get_card_by_enum(CardId::B3b064SmallBalloon))
+                .with_energy(vec![deckgym::models::EnergyType::Grass]),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(_))),
+        "Small Balloon should not reduce a non-Basic Pokemon's retreat cost"
+    );
+}


### PR DESCRIPTION
Implements two B3b Pokémon Tools:

- **Small Balloon** (B3b 064 / 106) — the Basic Pokémon this is attached to has −1 Retreat Cost.
- **Elegant Cape** (B3b 065) — the Stage 1 Pokémon this is attached to gets +30 HP.

Both follow the existing tool patterns: the retreat reduction is applied in `get_retreat_cost` (like Inflatable Boat) and the HP bonus in `get_effective_total_hp` (like Giant/Leaf Cape). Both tools can be attached to any Pokémon; the effects are gated to the matching stage where they apply.

## Stacked on #322

> ⚠️ This branch also contains the commit from #322 ("Fix Big Air Balloon to attach to any Pokémon") — it's the base of this stack, so it shows up as the first commit here. **Review after #322 merges**; that commit will drop out of this diff automatically once #322 lands on `main`. The net-new content in this PR is just the two commits' worth for Small Balloon + Elegant Cape.

The "attach to any Pokémon, stage-gate only the effect" rule that #322 establishes is the same rule these two tools rely on (verified in-game).

## Test

`Game`-level integration tests in `tests/tools/`:
- **Small Balloon**: a Basic with cost 1 can retreat for free; the same Basic without the tool cannot; attaches to an evolved Pokémon but gives it no reduction.
- **Elegant Cape**: a Stage 1 (Ivysaur, 90 HP) becomes 120 HP; attaches to a Basic but grants it no HP.

`cargo fmt`, `cargo clippy --features "tui test-utils" -- -D warnings`, and the tools test suite all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)