### PR TITLE
Implement Carbink (Glittering Gift)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -186,7 +186,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ChargeYourTypeAnyWay { energy_type, count } => {
             charge_energy_any_way_to_type(attack.fixed_damage, *energy_type, *count)
         }
-        Mechanic::ManaphyOceanicGift => manaphy_oceanic(),
+        Mechanic::AttachEnergyFromZoneToTwoBenched { energy_type } => {
+            attach_energy_to_two_benched(*energy_type)
+        }
         Mechanic::PalkiaExDimensionalStorm => palkia_dimensional_storm(state),
         Mechanic::MegaKangaskhanExDoublePunchingFamily => {
             mega_kangaskhan_ex_double_punching_family(attack)
@@ -1031,8 +1033,9 @@ fn waterfall_evolution(state: &State) -> AttackOutcomes {
     AttackOutcomes::from_parts(probabilities, outcomes)
 }
 
-/// For Manaphy's Oceanic attack: Choose 2 benched Pokémon and attach Water Energy to each
-fn manaphy_oceanic() -> AttackOutcomes {
+/// For Manaphy's Oceanic Gift / Carbink's Glittering Gift: Choose 2 benched Pokémon and attach
+/// an Energy of the given type to each
+fn attach_energy_to_two_benched(energy_type: EnergyType) -> AttackOutcomes {
     active_damage_effect_doutcome(0, move |_, state, action| {
         let benched_pokemon: Vec<usize> = state
             .enumerate_bench_pokemon(action.actor)
@@ -1043,7 +1046,7 @@ fn manaphy_oceanic() -> AttackOutcomes {
         if benched_pokemon.len() == 1 {
             // Only 1 benched Pokémon, can only choose that one
             choices.push(SimpleAction::Attach {
-                attachments: vec![(1, EnergyType::Water, benched_pokemon[0])],
+                attachments: vec![(1, energy_type, benched_pokemon[0])],
                 is_turn_energy: false,
             });
         } else if benched_pokemon.len() >= 2 {
@@ -1053,8 +1056,8 @@ fn manaphy_oceanic() -> AttackOutcomes {
                 for j in (i + 1)..benched_pokemon.len() {
                     choices.push(SimpleAction::Attach {
                         attachments: vec![
-                            (1, EnergyType::Water, benched_pokemon[i]),
-                            (1, EnergyType::Water, benched_pokemon[j]),
+                            (1, energy_type, benched_pokemon[i]),
+                            (1, energy_type, benched_pokemon[j]),
                         ],
                         is_turn_energy: false,
                     });

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -161,7 +161,11 @@ pub enum Mechanic {
         count: usize,
     },
     // Fairly unique mechanics
-    ManaphyOceanicGift,
+    /// Manaphy's Oceanic Gift / Carbink's Glittering Gift: choose 2 of your Benched Pokémon and
+    /// attach an Energy of the given type to each.
+    AttachEnergyFromZoneToTwoBenched {
+        energy_type: EnergyType,
+    },
     PalkiaExDimensionalStorm,
     MegaKangaskhanExDoublePunchingFamily,
     MoltresExInfernoDance,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -81,7 +81,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             require_attacker_energy_match: true,
         },
     );
-    map.insert("Choose 2 of your Benched Pokémon. For each of those Pokémon, take a [W] Energy from your Energy Zone and attach it to that Pokémon.", Mechanic::ManaphyOceanicGift);
+    map.insert(
+        "Choose 2 of your Benched Pokémon. For each of those Pokémon, take a [W] Energy from your Energy Zone and attach it to that Pokémon.",
+        Mechanic::AttachEnergyFromZoneToTwoBenched { energy_type: EnergyType::Water },
+    );
+    map.insert(
+        "Choose 2 of your Benched Pokémon. For each of those Pokémon, take a [P] Energy from your Energy Zone and attach it to that Pokémon.",
+        Mechanic::AttachEnergyFromZoneToTwoBenched { energy_type: EnergyType::Psychic },
+    );
     map.insert(
         "Choose either Poisoned or Confused. Your opponent's Active Pokémon is now affected by that Special Condition.",
         Mechanic::ChooseStatusToInflict {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -24,6 +24,8 @@ mod brambleghast_accept_pain_test;
 mod breloom_test;
 #[path = "pokemon/camerupt_eruption_test.rs"]
 mod camerupt_eruption_test;
+#[path = "pokemon/carbink_glittering_gift_test.rs"]
+mod carbink_glittering_gift_test;
 #[path = "pokemon/carracosta_blocking_shell_test.rs"]
 mod carracosta_blocking_shell_test;
 #[path = "pokemon/cascoon_harden_test.rs"]

--- a/tests/pokemon/carbink_glittering_gift_test.rs
+++ b/tests/pokemon/carbink_glittering_gift_test.rs
@@ -1,0 +1,56 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+#[test]
+fn test_glittering_gift_attaches_psychic_energy_to_two_benched() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3b031Carbink).with_energy(vec![EnergyType::Psychic]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1033Charmander),
+            PlayedCard::from_id(CardId::A1053Squirtle),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b031Carbink, 0),
+        is_stack: false,
+    });
+
+    // With 3 benched Pokemon there should be C(3,2) = 3 pair choices.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(choices.len(), 3);
+    assert!(choices.iter().all(|choice| matches!(
+        &choice.action,
+        SimpleAction::Attach { attachments, .. } if attachments.len() == 2
+    )));
+
+    // Pick the first pair and verify both Pokemon got a Psychic Energy.
+    let chosen = choices[0].clone();
+    let targets: Vec<usize> = match &chosen.action {
+        SimpleAction::Attach { attachments, .. } => {
+            attachments.iter().map(|(_, _, idx)| *idx).collect()
+        }
+        _ => unreachable!(),
+    };
+    game.apply_action(&chosen);
+
+    let state = game.get_state_clone();
+    for idx in targets {
+        assert_eq!(
+            state.in_play_pokemon[0][idx]
+                .as_ref()
+                .unwrap()
+                .attached_energy,
+            vec![EnergyType::Psychic],
+            "each chosen benched Pokemon should have received a [P] Energy"
+        );
+    }
+}


### PR DESCRIPTION
Implements **Carbink** (B3b 031) and its *Glittering Gift* attack: "Choose 2 of your Benched Pokémon. For each of those Pokémon, take a [P] Energy from your Energy Zone and attach it to that Pokémon."

## Change

Generalizes the existing `ManaphyOceanicGift` mechanic into `AttachEnergyFromZoneToTwoBenched { energy_type }`, so Manaphy's Oceanic Gift ([W]) and Carbink's Glittering Gift ([P]) share one implementation — same choose-2-benched logic, parameterized by energy type. Both effect-text entries map to it.

## Tests

- `tests/pokemon/carbink_glittering_gift_test.rs`: with 3 benched Pokémon the attack offers the C(3,2)=3 pair choices, and applying one attaches a [P] Energy to each chosen Pokémon.
- Manaphy's existing test continues to pass against the generalized mechanic (regression).

Full suite (28 targets), `cargo fmt`, `cargo clippy --features "tui test-utils" -- -D warnings` all pass; Carbink and Manaphy fuzzed 10k games each with no panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
