### PR TITLE
Implement Snorlax (Massive Body)

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -129,6 +129,9 @@ pub enum AbilityMechanic {
         energy_type: Option<EnergyType>,
     },
     NoOpponentSupportInActive,
+    /// Snorlax's Massive Body: as long as this Pokémon is in the Active Spot, the opponent
+    /// can't play any Stadium cards from their hand.
+    NoOpponentStadiumInActive,
     DoubleGrassEnergy,
     PreventOpponentActiveEvolution,
     ReduceRetreatCostOfYourActiveBasicFromBench {

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -188,6 +188,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::NoOpponentSupportInActive => {
             panic!("NoOpponentSupportInActive is a passive ability")
         }
+        AbilityMechanic::NoOpponentStadiumInActive => {
+            panic!("NoOpponentStadiumInActive is a passive ability")
+        }
         AbilityMechanic::DoubleGrassEnergy => panic!("DoubleGrassEnergy is a passive ability"),
         AbilityMechanic::PreventOpponentActiveEvolution => {
             panic!("PreventOpponentActiveEvolution is a passive ability")

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -39,6 +39,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "As long as this Pokémon is in the Active Spot, your opponent can't use any Supporter cards from their hand.",
             AbilityMechanic::NoOpponentSupportInActive,
         );
+        map.insert(
+            "As long as this Pokémon is in the Active Spot, your opponent can't play any Stadium cards from their hand.",
+            AbilityMechanic::NoOpponentStadiumInActive,
+        );
         // map.insert("As long as this Pokémon is on your Bench, attacks used by your Pokémon that evolve from Poliwhirl do +40 damage to your opponent's Active Pokémon.", todo_implementation);
         map.insert(
             "As long as this Pokémon is on your Bench, prevent all damage done to this Pokémon by attacks.",

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -142,6 +142,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::ImmuneToStatusConditions => false, // Passive ability
         AbilityMechanic::SoothingWind { .. } => false,      // Passive ability
         AbilityMechanic::NoOpponentSupportInActive => false,
+        AbilityMechanic::NoOpponentStadiumInActive => false, // Passive ability
         AbilityMechanic::DoubleGrassEnergy => false,
         AbilityMechanic::PreventOpponentActiveEvolution => false,
         AbilityMechanic::ReduceRetreatCostOfYourActiveBasicFromBench { .. } => false,

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    actions::SimpleAction,
+    actions::{abilities::AbilityMechanic, get_ability_mechanic, SimpleAction},
     card_ids::CardId,
     card_logic::{
         can_rare_candy_evolve, diantha_targets, ilima_targets, quick_grow_extract_candidates,
@@ -291,6 +291,23 @@ fn can_play_stadium(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Sim
             return cannot_play_trainer();
         }
     }
+
+    // Snorlax's Massive Body: as long as it is in the opponent's Active Spot, this player
+    // can't play any Stadium cards from their hand.
+    let opponent = (state.current_player + 1) % 2;
+    let blocked_by_massive_body =
+        state.in_play_pokemon[opponent][0]
+            .as_ref()
+            .is_some_and(|opponent_active| {
+                matches!(
+                    get_ability_mechanic(&opponent_active.card),
+                    Some(AbilityMechanic::NoOpponentStadiumInActive)
+                )
+            });
+    if blocked_by_massive_body {
+        return cannot_play_trainer();
+    }
+
     can_play_trainer(state, trainer_card)
 }
 

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -152,6 +152,8 @@ mod shinx_hide_test;
 mod slither_wing_test;
 #[path = "pokemon/smoochum_test.rs"]
 mod smoochum_test;
+#[path = "pokemon/snorlax_massive_body_test.rs"]
+mod snorlax_massive_body_test;
 #[path = "pokemon/snover_ice_shard_test.rs"]
 mod snover_ice_shard_test;
 #[path = "pokemon/spewpa_signs_of_evolution_test.rs"]

--- a/tests/pokemon/snorlax_massive_body_test.rs
+++ b/tests/pokemon/snorlax_massive_body_test.rs
@@ -1,0 +1,46 @@
+use deckgym::{
+    actions::SimpleAction, card_ids::CardId, database::get_card_by_enum, models::PlayedCard,
+    test_support::get_test_game_with_board,
+};
+
+#[test]
+fn test_massive_body_blocks_opponent_stadiums_only_while_active() {
+    // Opponent's active Snorlax blocks the current player from playing Stadium cards.
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::B3b055Snorlax)],
+    );
+    let mut state = game.get_state_clone();
+    state.hands[0].push(get_card_by_enum(CardId::B2153TrainingArea));
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !actions.iter().any(|a| matches!(
+            &a.action,
+            SimpleAction::Play { trainer_card } if trainer_card.name == "Training Area"
+        )),
+        "Massive Body should block the opponent from playing Stadium cards"
+    );
+
+    // Control: with Snorlax on the opponent's Bench instead, the Stadium is playable.
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::B3b055Snorlax),
+        ],
+    );
+    let mut state = game.get_state_clone();
+    state.hands[0].push(get_card_by_enum(CardId::B2153TrainingArea));
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        actions.iter().any(|a| matches!(
+            &a.action,
+            SimpleAction::Play { trainer_card } if trainer_card.name == "Training Area"
+        )),
+        "Massive Body should not apply from the Bench"
+    );
+}


### PR DESCRIPTION
Implements **Snorlax** (B3b 055, and reprints 076/100) and its *Massive Body* ability: "As long as this Pokémon is in the Active Spot, your opponent can't play any Stadium cards from their hand."

## Change

Adds a new passive ability mechanic `NoOpponentStadiumInActive`, checked in `can_play_stadium` the same way Gengar ex's Shadowy Spellbind (`NoOpponentSupportInActive`) already gates Supporter cards: if the opponent's Active Pokémon has the ability, Stadium plays are filtered out of move generation.

The attack (Mega Punch, 70) needs no effect logic.

## Tests

- `tests/pokemon/snorlax_massive_body_test.rs`: an opponent's Active Snorlax blocks the current player from playing a Stadium; a benched Snorlax does not (the effect is Active-only).

Full suite (28 targets), `cargo fmt`, `cargo clippy --features "tui test-utils" -- -D warnings` all pass; fuzzed 10k games with no panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
