### PR TITLE
Implement Ursaluna (Guts)

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -87,6 +87,9 @@ pub enum AbilityMechanic {
     InfiltratingInspection,
     DiscardTopCardOpponentDeck,
     CoinFlipToPreventDamage,
+    /// Ursaluna's Guts: if this Pokémon would be Knocked Out by damage from an attack, flip a
+    /// coin. If heads, it is not Knocked Out and its remaining HP becomes 10.
+    CoinFlipToSurviveKnockOut,
     CheckupDamageToOpponentActive {
         amount: u32,
     },

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -147,6 +147,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::CoinFlipToPreventDamage => {
             panic!("CoinFlipToPreventDamage is a passive ability")
         }
+        AbilityMechanic::CoinFlipToSurviveKnockOut => {
+            panic!("CoinFlipToSurviveKnockOut is a passive ability")
+        }
         AbilityMechanic::CheckupDamageToOpponentActive { .. } => {
             panic!("CheckupDamageToOpponentActive is a passive ability")
         }

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -11,14 +11,19 @@ use crate::{
         apply_action_helpers::{apply_activate, wrap_with_common_logic},
     },
     effects::TurnEffect,
-    hooks::{get_retreat_cost, on_bench_from_hand, on_evolve, to_playable_card},
+    hooks::{
+        get_retreat_cost, on_bench_from_hand, on_evolve, to_playable_card, DamageModifierContext,
+    },
     models::{Card, EnergyType},
     state::State,
     tools,
 };
 
 use super::{
-    apply_action_helpers::{forecast_end_turn, handle_damage, Mutations},
+    apply_action_helpers::{
+        forecast_end_turn, guts_would_flip, handle_damage, handle_damage_only, handle_knockouts,
+        Mutations,
+    },
     apply_attack_action::forecast_attack,
     apply_stadium_action::{self, forecast_use_stadium},
     apply_trainer_action::forecast_trainer_action,
@@ -53,7 +58,6 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::Evolve { .. }
         | SimpleAction::Activate { .. }
         | SimpleAction::Retreat(_)
-        | SimpleAction::ApplyDamage { .. }
         | SimpleAction::ScheduleDelayedSpotDamage { .. }
         | SimpleAction::Heal { .. }
         | SimpleAction::HealAndDiscardEnergy { .. }
@@ -69,6 +73,11 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::ApplyStatusToOpponentActive { .. }
         | SimpleAction::Noop => forecast_deterministic_action(),
         SimpleAction::UseAbility { in_play_idx } => forecast_ability(state, action, *in_play_idx),
+        SimpleAction::ApplyDamage {
+            attacking_ref,
+            targets,
+            is_from_active_attack,
+        } => forecast_apply_damage(state, *attacking_ref, targets, *is_from_active_attack),
         SimpleAction::Attack(attack) => {
             forecast_attack(action.actor, state, attack, action.is_stack)
         }
@@ -155,6 +164,81 @@ fn forecast_deterministic_action() -> Outcomes {
     })
 }
 
+/// ApplyDamage (damage queued through the move-generation stack, e.g. Mega Kangaskhan's second
+/// punch or Raikou ex's spot damage) is deterministic unless a target has the Guts ability and
+/// would be knocked out: each such target flips its own survival coin, independently of any
+/// Guts flip already resolved earlier in the same attack.
+fn forecast_apply_damage(
+    state: &State,
+    attacking_ref: (usize, usize),
+    targets: &[(u32, usize, usize)],
+    is_from_active_attack: bool,
+) -> Outcomes {
+    // Sum raw damage per target (mirroring handle_damage_only) to find the Guts coin flips.
+    let mut damage_map: HashMap<(usize, usize), u32> = HashMap::new();
+    for (damage, player, idx) in targets {
+        *damage_map.entry((*player, *idx)).or_insert(0) += damage;
+    }
+    let flipping: Vec<(usize, usize)> = damage_map
+        .into_iter()
+        .filter(|(target, raw_total)| {
+            guts_would_flip(
+                state,
+                attacking_ref,
+                *raw_total,
+                *target,
+                is_from_active_attack,
+                DamageModifierContext {
+                    attack_name: None,
+                    attack_effect: None,
+                },
+            )
+        })
+        .map(|(target, _)| target)
+        .collect();
+
+    if flipping.is_empty() {
+        let targets = targets.to_vec();
+        return Outcomes::single_fn(move |_, state, _| {
+            handle_damage(state, attacking_ref, &targets, is_from_active_attack, None);
+        });
+    }
+
+    // One branch per heads/tails combination; on heads the damage still applies (so on-damage
+    // triggers fire) and the survivor's remaining HP is set to 10 before knockouts resolve.
+    let combos = 1usize << flipping.len();
+    let probabilities = vec![1.0 / combos as f64; combos];
+    let mut mutations: Mutations = vec![];
+    for mask in 0..combos {
+        let survivors: Vec<(usize, usize)> = flipping
+            .iter()
+            .enumerate()
+            .filter(|(bit, _)| (mask >> bit) & 1 == 1)
+            .map(|(_, target)| *target)
+            .collect();
+        let targets = targets.to_vec();
+        mutations.push(Box::new(move |_, state, _| {
+            handle_damage_only(
+                state,
+                attacking_ref,
+                &targets,
+                is_from_active_attack,
+                DamageModifierContext {
+                    attack_name: None,
+                    attack_effect: None,
+                },
+            );
+            for (player, idx) in &survivors {
+                if let Some(pokemon) = state.in_play_pokemon[*player][*idx].as_mut() {
+                    pokemon.set_remaining_hp(10);
+                }
+            }
+            handle_knockouts(state, attacking_ref, is_from_active_attack);
+        }));
+    }
+    Outcomes::from_parts(probabilities, mutations)
+}
+
 fn apply_deterministic_action(state: &mut State, action: &Action) {
     match &action.action {
         SimpleAction::DrawCard { amount } => {
@@ -196,11 +280,6 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
             in_play_idx,
         } => apply_retreat(*player, state, *in_play_idx, true),
         SimpleAction::Retreat(position) => apply_retreat(action.actor, state, *position, false),
-        SimpleAction::ApplyDamage {
-            attacking_ref,
-            targets,
-            is_from_active_attack,
-        } => handle_damage(state, *attacking_ref, targets, *is_from_active_attack, None),
         SimpleAction::ScheduleDelayedSpotDamage {
             target_player,
             target_in_play_idx,

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -393,6 +393,39 @@ fn checkapply_prevent_first_attack(
     false
 }
 
+/// True if the Pokémon at `target` has the Guts ability and `raw_damage` (after modifiers)
+/// would knock it out — i.e. it should flip a Guts survival coin for this damage.
+pub(crate) fn guts_would_flip(
+    state: &State,
+    attacking_ref: (usize, usize),
+    raw_damage: u32,
+    target: (usize, usize),
+    is_from_active_attack: bool,
+    context: DamageModifierContext<'_>,
+) -> bool {
+    if raw_damage == 0 {
+        return false;
+    }
+    let Some(pokemon) = state.in_play_pokemon[target.0][target.1].as_ref() else {
+        return false;
+    };
+    if !matches!(
+        get_ability_mechanic(&pokemon.card),
+        Some(AbilityMechanic::CoinFlipToSurviveKnockOut)
+    ) {
+        return false;
+    }
+    let modified = modify_damage(
+        state,
+        attacking_ref,
+        (raw_damage, target.0, target.1),
+        is_from_active_attack,
+        context,
+    );
+    let remaining = pokemon.get_remaining_hp();
+    remaining > 0 && modified >= remaining
+}
+
 /// This function applies damage (with modifiers and counterattacks) and handles K.O.s
 /// and promotions.
 pub(crate) fn handle_damage(

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -55,15 +55,16 @@ pub(crate) fn forecast_attack(
     let base_outcomes = forecast_attack_inner(state, attack);
 
     if is_sub_attack {
-        apply_copied_attack_modifiers(acting_player, state, base_outcomes).into_outcomes()
+        apply_copied_attack_modifiers(acting_player, state, attack, base_outcomes).into_outcomes()
     } else {
-        apply_attack_common_modifiers(acting_player, state, base_outcomes).into_outcomes()
+        apply_attack_common_modifiers(acting_player, state, attack, base_outcomes).into_outcomes()
     }
 }
 
 fn apply_attack_common_modifiers(
     acting_player: usize,
     state: &State,
+    attack: &Attack,
     base_outcomes: AttackOutcomes,
 ) -> AttackOutcomes {
     let active = state.get_active(acting_player);
@@ -84,15 +85,18 @@ fn apply_attack_common_modifiers(
         outcomes = apply_block_attack_coin_flip(outcomes);
     }
 
-    apply_defender_damage_prevention_if_needed(acting_player, state, outcomes)
+    outcomes = apply_defender_damage_prevention_if_needed(acting_player, state, outcomes);
+    apply_defender_guts_if_needed(acting_player, state, attack, outcomes)
 }
 
 fn apply_copied_attack_modifiers(
     acting_player: usize,
     state: &State,
+    attack: &Attack,
     base_outcomes: AttackOutcomes,
 ) -> AttackOutcomes {
-    apply_defender_damage_prevention_if_needed(acting_player, state, base_outcomes)
+    let outcomes = apply_defender_damage_prevention_if_needed(acting_player, state, base_outcomes);
+    apply_defender_guts_if_needed(acting_player, state, attack, outcomes)
 }
 
 fn apply_defender_damage_prevention_if_needed(
@@ -121,6 +125,41 @@ fn apply_defender_damage_prevention_if_needed(
         return outcomes;
     }
     outcomes.split_with_damage_prevention(&prevented_indices)
+}
+
+/// Apply the defender's Guts ability (e.g. Ursaluna): each opponent in-play Pokémon with the
+/// ability flips a coin when this attack's damage would knock it out; on heads it survives
+/// with its remaining HP set to 10.
+fn apply_defender_guts_if_needed(
+    acting_player: usize,
+    state: &State,
+    attack: &Attack,
+    outcomes: AttackOutcomes,
+) -> AttackOutcomes {
+    let opponent = (acting_player + 1) % 2;
+    let guts_indices: Vec<usize> = state
+        .enumerate_in_play_pokemon(opponent)
+        .filter(|(_, pokemon)| {
+            pokemon
+                .card
+                .get_ability()
+                .and_then(|a| ability_mechanic_from_effect(&a.effect))
+                .map(|m| matches!(m, AbilityMechanic::CoinFlipToSurviveKnockOut))
+                .unwrap_or(false)
+        })
+        .map(|(idx, _)| idx)
+        .collect();
+
+    if guts_indices.is_empty() {
+        return outcomes;
+    }
+    outcomes.split_with_guts_survival(
+        state,
+        acting_player,
+        Some(&attack.title),
+        attack.effect.as_deref(),
+        &guts_indices,
+    )
 }
 
 fn forecast_attack_inner(state: &State, attack: &Attack) -> AttackOutcomes {

--- a/src/actions/attack_outcome.rs
+++ b/src/actions/attack_outcome.rs
@@ -5,7 +5,9 @@ use rand::rngs::StdRng;
 use crate::hooks::{modify_damage, DamageModifierContext};
 use crate::State;
 
-use super::apply_action_helpers::{handle_damage_only, handle_knockouts, Mutation, Probabilities};
+use super::apply_action_helpers::{
+    guts_would_flip, handle_damage_only, handle_knockouts, Mutation, Probabilities,
+};
 use super::outcomes::{generate_sequences_with_heads, CoinPaths, CoinSeq, Outcomes};
 use super::{Action, SimpleAction};
 
@@ -357,6 +359,97 @@ impl AttackOutcomes {
                 outcome
                     .damage
                     .retain(|(_, is_opponent, idx)| !(*is_opponent && prevented_now.contains(idx)));
+                branches.push(AttackBranch {
+                    probability: sub_probability,
+                    outcome,
+                    coin_paths: CoinPaths::None,
+                });
+            }
+        }
+        Self { branches }
+    }
+
+    /// Apply the defender's "if this Pokémon would be Knocked Out by damage from an attack,
+    /// flip a coin; if heads, it is not Knocked Out and its remaining HP becomes 10" ability
+    /// (e.g. Ursaluna's Guts) to each opponent in-play slot in `guts_indices`.
+    ///
+    /// The ability applies independently to each such Pokémon, and only in branches where the
+    /// (modified) damage it takes would knock it out. Each such branch is split into `2^k`
+    /// sub-branches, one per combination of heads/tails. On heads the damage still applies in
+    /// full — so on-damage triggers like Rocky Helmet's counterattack fire normally — and a
+    /// post-damage effect then sets the survivor's remaining HP to exactly 10 before knockouts
+    /// are resolved. Coin metadata is dropped (these are the defender's coins, not the acting
+    /// player's).
+    ///
+    /// Knock outs are forecast with the pre-attack board (like `expected_damage_to`), so damage
+    /// modifiers changed by a branch's own pre-damage effect are not taken into account.
+    pub fn split_with_guts_survival(
+        self,
+        state: &State,
+        acting_player: usize,
+        attack_name: Option<&str>,
+        attack_effect: Option<&str>,
+        guts_indices: &[usize],
+    ) -> Self {
+        let opponent = (acting_player + 1) % 2;
+        let mut branches = vec![];
+        for branch in self.branches {
+            // Only the Guts Pokémon that would be knocked out by this branch's damage flip a coin.
+            let flipping: Vec<usize> = guts_indices
+                .iter()
+                .copied()
+                .filter(|target_idx| {
+                    let raw_total: u32 = branch
+                        .outcome
+                        .damage
+                        .iter()
+                        .filter(|(_, is_opponent, idx)| *is_opponent && idx == target_idx)
+                        .map(|(amount, _, _)| *amount)
+                        .sum();
+                    guts_would_flip(
+                        state,
+                        (acting_player, 0),
+                        raw_total,
+                        (opponent, *target_idx),
+                        true,
+                        DamageModifierContext {
+                            attack_name,
+                            attack_effect,
+                        },
+                    )
+                })
+                .collect();
+
+            if flipping.is_empty() {
+                branches.push(branch);
+                continue;
+            }
+
+            let combos = 1usize << flipping.len();
+            let sub_probability = branch.probability / combos as f64;
+            for mask in 0..combos {
+                // The subset of flipping Pokémon whose coin came up heads (survive at 10 HP).
+                let survivors: Vec<usize> = flipping
+                    .iter()
+                    .enumerate()
+                    .filter(|(bit, _)| (mask >> bit) & 1 == 1)
+                    .map(|(_, idx)| *idx)
+                    .collect();
+                let mut outcome = branch.outcome.clone();
+                if !survivors.is_empty() {
+                    let previous_post = outcome.post_damage_effect.take();
+                    outcome.post_damage_effect = Some(Rc::new(move |rng, state, action| {
+                        let opponent = (action.actor + 1) % 2;
+                        for idx in &survivors {
+                            if let Some(pokemon) = state.in_play_pokemon[opponent][*idx].as_mut() {
+                                pokemon.set_remaining_hp(10);
+                            }
+                        }
+                        if let Some(post) = &previous_post {
+                            post(rng, state, action);
+                        }
+                    }));
+                }
                 branches.push(AttackBranch {
                     probability: sub_probability,
                     outcome,

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -143,7 +143,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "If this Pokémon is in the Active Spot, once during your turn, you may switch in 1 of your opponent's Benched Basic Pokémon to the Active Spot.",
             AbilityMechanic::VictreebelFragranceTrap,
         );
-        // map.insert("If this Pokémon would be Knocked Out by damage from an attack, flip a coin. If heads, this Pokémon is not Knocked Out, and its remaining HP becomes 10.", todo_implementation);
+        map.insert(
+            "If this Pokémon would be Knocked Out by damage from an attack, flip a coin. If heads, this Pokémon is not Knocked Out, and its remaining HP becomes 10.",
+            AbilityMechanic::CoinFlipToSurviveKnockOut,
+        );
         // map.insert("If you have Arceus or Arceus ex in play, attacks used by this Pokémon cost 1 less [C] Energy.", todo_implementation);
         map.insert(
             "If you have Arceus or Arceus ex in play, attacks used by this Pokémon do +30 damage to your opponent's Active Pokémon.",

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -116,6 +116,7 @@ fn can_use_ability_by_mechanic(
             !card.ability_used && !state.decks[(state.current_player + 1) % 2].cards.is_empty()
         }
         AbilityMechanic::CoinFlipToPreventDamage => false, // Passive ability
+        AbilityMechanic::CoinFlipToSurviveKnockOut => false, // Passive ability
         AbilityMechanic::CheckupDamageToOpponentActive { .. } => false, // Passive ability
         AbilityMechanic::CheckupDamageToAllOpponentPokemon { .. } => false, // Passive ability
         AbilityMechanic::BadDreamsEndOfTurn { .. } => false, // Passive ability

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -105,10 +105,15 @@ impl PlayedCard {
     }
 
     pub fn with_remaining_hp(mut self, remaining_hp: u32) -> Self {
+        self.set_remaining_hp(remaining_hp);
+        self
+    }
+
+    /// Set the remaining HP to an exact value (e.g. Ursaluna's Guts leaves it at 10).
+    pub(crate) fn set_remaining_hp(&mut self, remaining_hp: u32) {
         let effective_hp = self.get_effective_total_hp();
         let clamped_remaining = remaining_hp.min(effective_hp);
         self.damage_counters = effective_hp.saturating_sub(clamped_remaining);
-        self
     }
 
     pub fn with_tool(mut self, tool: Card) -> Self {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -168,6 +168,8 @@ mod tepig_stoke_test;
 mod terapagos_ex_test;
 #[path = "pokemon/typhlosion_fire_breath_test.rs"]
 mod typhlosion_fire_breath_test;
+#[path = "pokemon/ursaluna_guts_test.rs"]
+mod ursaluna_guts_test;
 #[path = "pokemon/vanilluxe_test.rs"]
 mod vanilluxe_test;
 #[path = "pokemon/vaporeon_ex_test.rs"]

--- a/tests/pokemon/ursaluna_guts_test.rs
+++ b/tests/pokemon/ursaluna_guts_test.rs
@@ -1,0 +1,210 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Ursaluna's "Guts": "If this Pokémon would be Knocked Out by damage from an attack, flip a
+/// coin. If heads, this Pokémon is not Knocked Out, and its remaining HP becomes 10."
+///
+/// We drive a lethal attack across many RNG seeds and assert that Ursaluna sometimes survives
+/// at exactly 10 HP (heads) and is sometimes Knocked Out (tails).
+#[test]
+fn test_guts_coin_flip_can_survive_lethal_attack_at_10_hp() {
+    let mut saw_survived = false;
+    let mut saw_knocked_out = false;
+
+    for seed in 0..40u64 {
+        // Bulbasaur's Vine Whip (40) is lethal on an Ursaluna at 30 remaining HP.
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+            vec![
+                PlayedCard::from_id(CardId::B3b058Ursaluna).with_remaining_hp(30),
+                PlayedCard::from_id(CardId::A1033Charmander),
+            ],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1001Bulbasaur, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        if state.points[0] > 0 {
+            // Tails: Ursaluna was Knocked Out and the attacker scored a point.
+            saw_knocked_out = true;
+        } else {
+            let ursaluna = state.get_active(1);
+            assert_eq!(ursaluna.get_name(), "Ursaluna", "seed {seed}");
+            assert_eq!(
+                ursaluna.get_remaining_hp(),
+                10,
+                "seed {seed}: Guts survival should leave Ursaluna at exactly 10 HP"
+            );
+            saw_survived = true;
+        }
+    }
+
+    assert!(
+        saw_survived,
+        "expected at least one seed where Guts saved Ursaluna"
+    );
+    assert!(
+        saw_knocked_out,
+        "expected at least one seed where Ursaluna was Knocked Out"
+    );
+}
+
+/// Even when Guts saves Ursaluna, the attack still damaged it — so on-damage triggers like
+/// Rocky Helmet's 20 counterattack damage must fire on every branch (verified in-game: the
+/// helmet damage resolves before the Guts result).
+#[test]
+fn test_guts_survival_still_triggers_rocky_helmet() {
+    let mut saw_survived = false;
+    let mut saw_knocked_out = false;
+
+    for seed in 0..40u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+            vec![
+                PlayedCard::from_id(CardId::B3b058Ursaluna)
+                    .with_tool(get_card_by_enum(CardId::A2148RockyHelmet))
+                    .with_remaining_hp(30),
+                PlayedCard::from_id(CardId::A1033Charmander),
+            ],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1001Bulbasaur, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        assert_eq!(
+            state.get_active(0).get_remaining_hp(),
+            70 - 20,
+            "seed {seed}: Rocky Helmet should hit the attacker whether or not Guts saves Ursaluna"
+        );
+        if state.points[0] > 0 {
+            saw_knocked_out = true;
+        } else {
+            assert_eq!(state.get_active(1).get_remaining_hp(), 10, "seed {seed}");
+            saw_survived = true;
+        }
+    }
+
+    assert!(saw_survived && saw_knocked_out);
+}
+
+/// Mega Kangaskhan ex's Double-Punching Family attacks twice. If Guts saves Ursaluna from the
+/// first hit (80), the second hit (40) is a new knock out threat and triggers its own,
+/// independent Guts coin flip (verified in-game).
+#[test]
+fn test_guts_flips_again_on_kangaskhans_second_punch() {
+    let mut saw_survived_both_hits = false;
+    let mut saw_knocked_out = false;
+
+    for seed in 0..60u64 {
+        // Ursaluna at 80 remaining HP: the first punch is exactly lethal, and after a heads
+        // (10 HP remaining) the 40-damage second punch is lethal again.
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![
+                PlayedCard::from_id(CardId::B2127MegaKangaskhanEx).with_energy(vec![
+                    EnergyType::Colorless,
+                    EnergyType::Colorless,
+                    EnergyType::Colorless,
+                ]),
+            ],
+            vec![
+                PlayedCard::from_id(CardId::B3b058Ursaluna).with_remaining_hp(80),
+                PlayedCard::from_id(CardId::A1033Charmander),
+            ],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B2127MegaKangaskhanEx, 0),
+            is_stack: false,
+        });
+
+        // Resolve the queued follow-ups: the defender's promotion (if Ursaluna was Knocked
+        // Out) and the second punch's ApplyDamage.
+        loop {
+            let (_, choices) = game.get_state_clone().generate_possible_actions();
+            let follow_up = choices.iter().find(|choice| {
+                matches!(
+                    choice.action,
+                    SimpleAction::ApplyDamage { .. } | SimpleAction::Activate { .. }
+                )
+            });
+            match follow_up {
+                Some(action) => {
+                    let action = action.clone();
+                    game.apply_action(&action);
+                }
+                None => break,
+            }
+        }
+
+        let state = game.get_state_clone();
+        if state.points[0] > 0 {
+            saw_knocked_out = true;
+        } else {
+            // Surviving both hits requires two independent heads: 80 -> 10 (first Guts flip),
+            // then 40 vs 10 HP -> 10 (second Guts flip).
+            assert_eq!(state.get_active(1).get_name(), "Ursaluna", "seed {seed}");
+            assert_eq!(state.get_active(1).get_remaining_hp(), 10, "seed {seed}");
+            saw_survived_both_hits = true;
+        }
+    }
+
+    assert!(
+        saw_survived_both_hits,
+        "expected at least one seed where Guts saved Ursaluna from both punches"
+    );
+    assert!(saw_knocked_out);
+}
+
+/// Non-lethal damage must not trigger the Guts coin flip: damage should apply normally on
+/// every seed.
+#[test]
+fn test_guts_does_not_trigger_on_non_lethal_damage() {
+    for seed in 0..10u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::B3b058Ursaluna)],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1001Bulbasaur, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        assert_eq!(
+            state.get_active(1).get_remaining_hp(),
+            160 - 40,
+            "seed {seed}: non-lethal damage should apply normally"
+        );
+    }
+}


### PR DESCRIPTION
Implements **Ursaluna** (B3b 058) and its *Guts* ability: "If this Pokémon would be Knocked Out by damage from an attack, flip a coin. If heads, this Pokémon is not Knocked Out, and its remaining HP becomes 10." (Hammer Arm's effect text was already implemented.)

## Change

Adds a new passive ability `CoinFlipToSurviveKnockOut`, resolved as a **forecast-level branch split** rather than a mutation-time coin (mirroring Meowth's Carefree Steps `split_with_damage_prevention`):

- When an attack's (modified) damage would KO a Guts holder, the outcome splits into heads/tails branches.
- On **heads**, the damage still applies in full — so on-damage triggers like Rocky Helmet's counterattack fire normally — and a post-damage effect then sets the survivor's remaining HP to exactly 10 before knockouts resolve.
- The stack-queued `ApplyDamage` action (e.g. Mega Kangaskhan ex's second punch) gets its own Guts forecast, so a second lethal hit triggers an **independent** flip.

Shared `guts_would_flip` helper + `PlayedCard::set_remaining_hp`.

## Tests

`tests/pokemon/ursaluna_guts_test.rs` (driven across many RNG seeds):
- survives a lethal attack at exactly 10 HP on heads, KO'd on tails;
- **Rocky Helmet still bounces 20** whether or not Guts saves Ursaluna;
- Mega Kangaskhan's second punch triggers a second independent Guts flip;
- non-lethal damage never triggers the flip.

Full suite (28 targets), `cargo fmt`, `cargo clippy --features "tui test-utils" -- -D warnings` all pass; fuzzed 10k games with no panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
