### PR TITLE
Add flip-until-tails bonus-damage mechanic (completes 16 cards)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -586,6 +586,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::FlipUntilTailsDamage { damage_per_heads } => {
             flip_until_tails_attack(*damage_per_heads)
         }
+        Mechanic::FlipUntilTailsBonusDamage { damage_per_heads } => {
+            flip_until_tails_bonus_attack(attack.fixed_damage, *damage_per_heads)
+        }
         Mechanic::DirectDamageIfDamaged { damage } => direct_damage_if_damaged(*damage),
         Mechanic::AttachEnergyToBenchedBasic { energy_type } => {
             attach_energy_to_benched_basic(state.current_player, *energy_type)
@@ -1988,6 +1991,16 @@ fn flip_until_tails_attack(damage_per_heads: u32) -> AttackOutcomes {
     // Truncate at 8 heads to keep the probability space manageable.
     AttackOutcomes::geometric_until_tails(8, move |heads| {
         active_damage_outcome((heads as u32) * damage_per_heads)
+    })
+}
+
+/// For attacks that deal a base amount and then flip a coin until tails, adding
+/// `damage_per_heads` for each heads (e.g. "does 30 more damage for each heads").
+/// The base is the attack's `fixed_damage`, so it is dealt even on an immediate tails.
+fn flip_until_tails_bonus_attack(base_damage: u32, damage_per_heads: u32) -> AttackOutcomes {
+    // Truncate at 8 heads to keep the probability space manageable.
+    AttackOutcomes::geometric_until_tails(8, move |heads| {
+        active_damage_outcome(base_damage + (heads as u32) * damage_per_heads)
     })
 }
 
@@ -3736,6 +3749,143 @@ mod test {
         // Check probabilities sum to approximately 1
         let sum: f64 = probabilities.iter().sum();
         assert!((sum - 1.0).abs() < 0.001);
+    }
+
+    /// Forecast the given attacker's flip-until-tails attack through the real effect map, apply the
+    /// `heads`-th outcome, and return the damage dealt to a 160-HP receiver (which survives every
+    /// outcome tested here). Exercises the full card -> EFFECT_MECHANIC_MAP -> mechanic pipeline.
+    fn flip_until_tails_map_damage(attacker_id: CardId, heads: usize) -> u32 {
+        let mut rng = StdRng::seed_from_u64(0);
+        let mut state = State::default();
+        let attacker = get_card_by_enum(attacker_id);
+        let receiver = get_card_by_enum(CardId::A1003Venusaur); // 160 HP, no Fire weakness triggered
+        state.in_play_pokemon[0][0] = Some(to_playable_card(&attacker, false));
+        state.in_play_pokemon[1][0] = Some(to_playable_card(&receiver, false));
+        let attack = state
+            .get_active(0)
+            .get_attacks()
+            .iter()
+            .find(|a| {
+                a.effect
+                    .as_deref()
+                    .is_some_and(|e| e.contains("until you get tails"))
+            })
+            .cloned()
+            .expect("attacker should have a flip-until-tails attack");
+        let mechanic = EFFECT_MECHANIC_MAP
+            .get(attack.effect.as_deref().unwrap())
+            .expect("flip-until-tails effect should be mapped");
+        let (_probabilities, mut mutations) =
+            forecast_effect_attack_by_mechanic(&state, &attack, mechanic).into_branches();
+        let action = Action {
+            actor: 0,
+            action: SimpleAction::Attack(attack.clone()),
+            is_stack: false,
+        };
+        mutations.remove(heads)(&mut rng, &mut state, &action);
+        160 - state.get_active(1).get_remaining_hp()
+    }
+
+    #[test]
+    fn test_flip_until_tails_family_effect_map_wiring() {
+        // "N more damage for each heads" -> bonus mechanic (base from fixed_damage);
+        // "N damage for each heads" -> base-less mechanic.
+        assert!(matches!(
+            EFFECT_MECHANIC_MAP.get(
+                "Flip a coin until you get tails. This attack does 30 more damage for each heads."
+            ),
+            Some(Mechanic::FlipUntilTailsBonusDamage {
+                damage_per_heads: 30
+            })
+        ));
+        assert!(matches!(
+            EFFECT_MECHANIC_MAP.get(
+                "Flip a coin until you get tails. This attack does 40 more damage for each heads."
+            ),
+            Some(Mechanic::FlipUntilTailsBonusDamage {
+                damage_per_heads: 40
+            })
+        ));
+        assert!(matches!(
+            EFFECT_MECHANIC_MAP
+                .get("Flip a coin until you get tails. This attack does 40 damage for each heads."),
+            Some(Mechanic::FlipUntilTailsDamage {
+                damage_per_heads: 40
+            })
+        ));
+        assert!(matches!(
+            EFFECT_MECHANIC_MAP
+                .get("Flip a coin until you get tails. This attack does 70 damage for each heads."),
+            Some(Mechanic::FlipUntilTailsDamage {
+                damage_per_heads: 70
+            })
+        ));
+    }
+
+    #[test]
+    fn test_flip_until_tails_bonus_attack_adds_base_and_scales() {
+        // Same geometric shape as the base mechanic: 9 outcomes (0..=8 heads).
+        let (probabilities, _mutations) = flip_until_tails_bonus_attack(50, 30).into_branches();
+        assert_eq!(probabilities.len(), 9);
+
+        // Base is dealt even on an immediate tails; each heads adds `damage_per_heads`.
+        let attacker = get_card_by_enum(CardId::B3a051IronTreads);
+        let receiver = get_card_by_enum(CardId::A1003Venusaur); // 160 HP
+        for (heads, expected_damage) in [(0usize, 50u32), (1, 80), (2, 110)] {
+            let mut rng = StdRng::seed_from_u64(0);
+            let mut state = State::default();
+            state.in_play_pokemon[0][0] = Some(to_playable_card(&attacker, false));
+            state.in_play_pokemon[1][0] = Some(to_playable_card(&receiver, false));
+            let (_probabilities, mut mutations) =
+                flip_until_tails_bonus_attack(50, 30).into_branches();
+            let action = Action {
+                actor: 0,
+                action: SimpleAction::Attack(crate::models::Attack {
+                    energy_required: vec![],
+                    title: String::new(),
+                    fixed_damage: 0,
+                    effect: None,
+                }),
+                is_stack: false,
+            };
+            mutations.remove(heads)(&mut rng, &mut state, &action);
+            assert_eq!(
+                state.get_active(1).get_remaining_hp(),
+                160 - expected_damage,
+                "{heads} heads should deal 50 + {heads}*30"
+            );
+        }
+    }
+
+    #[test]
+    fn test_flip_until_tails_bonus_base_comes_from_card_fixed_damage() {
+        // Iron Treads (50 base) and Rayquaza (70 base) share the exact "30 more" effect text but
+        // different `fixed_damage` -> the base must come from the card, not a constant in the map.
+        assert_eq!(flip_until_tails_map_damage(CardId::B3a051IronTreads, 0), 50);
+        assert_eq!(flip_until_tails_map_damage(CardId::B3a051IronTreads, 1), 80);
+        assert_eq!(flip_until_tails_map_damage(CardId::PA063Rayquaza, 0), 70);
+        assert_eq!(flip_until_tails_map_damage(CardId::PA063Rayquaza, 1), 100);
+        // "40 more" cluster.
+        assert_eq!(
+            flip_until_tails_map_damage(CardId::A2125LickilickyEx, 0),
+            100
+        );
+        assert_eq!(
+            flip_until_tails_map_damage(CardId::A2125LickilickyEx, 1),
+            140
+        );
+
+        // No-base ("N damage for each heads") cards deal nothing on an immediate tails.
+        assert_eq!(flip_until_tails_map_damage(CardId::B1211Wooloo, 0), 0);
+        assert_eq!(flip_until_tails_map_damage(CardId::B1211Wooloo, 1), 40);
+        assert_eq!(
+            flip_until_tails_map_damage(CardId::A3118AlolanDugtrio, 0),
+            0
+        );
+        assert_eq!(
+            flip_until_tails_map_damage(CardId::A3118AlolanDugtrio, 1),
+            70
+        );
     }
 
     #[test]

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -355,6 +355,11 @@ pub enum Mechanic {
     FlipUntilTailsDamage {
         damage_per_heads: u32,
     },
+    /// Like `FlipUntilTailsDamage`, but the attack's `fixed_damage` is dealt as a base and each
+    /// heads adds `damage_per_heads` on top (e.g. "does 30 more damage for each heads").
+    FlipUntilTailsBonusDamage {
+        damage_per_heads: u32,
+    },
     DirectDamageIfDamaged {
         damage: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -657,16 +657,36 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per_heads: 20,
         },
     );
-    // map.insert("Flip a coin until you get tails. This attack does 30 more damage for each heads.", todo_implementation);
-    // map.insert("Flip a coin until you get tails. This attack does 40 damage for each heads.", todo_implementation);
-    // map.insert("Flip a coin until you get tails. This attack does 40 more damage for each heads.", todo_implementation);
+    map.insert(
+        "Flip a coin until you get tails. This attack does 30 more damage for each heads.",
+        Mechanic::FlipUntilTailsBonusDamage {
+            damage_per_heads: 30,
+        },
+    );
+    map.insert(
+        "Flip a coin until you get tails. This attack does 40 damage for each heads.",
+        Mechanic::FlipUntilTailsDamage {
+            damage_per_heads: 40,
+        },
+    );
+    map.insert(
+        "Flip a coin until you get tails. This attack does 40 more damage for each heads.",
+        Mechanic::FlipUntilTailsBonusDamage {
+            damage_per_heads: 40,
+        },
+    );
     map.insert(
         "Flip a coin until you get tails. This attack does 60 damage for each heads.",
         Mechanic::FlipUntilTailsDamage {
             damage_per_heads: 60,
         },
     );
-    // map.insert("Flip a coin until you get tails. This attack does 70 damage for each heads.", todo_implementation);
+    map.insert(
+        "Flip a coin until you get tails. This attack does 70 damage for each heads.",
+        Mechanic::FlipUntilTailsDamage {
+            damage_per_heads: 70,
+        },
+    );
     // map.insert("Flip a coin. If heads, choose 1 of your opponent's Active Pokémon's attacks and use it as this attack.", todo_implementation);
     map.insert(
         "Flip a coin. If heads, discard a random Energy from your opponent's Active Pokémon.",


### PR DESCRIPTION
## Summary

These 16 cards are all the same effect template — "Flip a coin until you get tails. This attack does N (more) damage for each heads." — so one mechanic plus a few `EFFECT_MECHANIC_MAP` entries completes the whole family at once. Because the map keys on the exact effect string, every rarity reprint of a card is covered by a single `map.insert`.

## What changed

The family splits into two shapes that were already partly modeled:

- **"N *more* damage for each heads"** — the attack has a printed base and each heads adds N on top. This needed a new `Mechanic::FlipUntilTailsBonusDamage { damage_per_heads }`, which deals the attack's `fixed_damage` as the base and adds `damage_per_heads` per heads. The base is read from `fixed_damage` at dispatch, so cards that share the same effect string but print different base damage (e.g. Wormadam 50 vs Rayquaza 70, both "30 more") resolve correctly.

  This is why the existing base-less `FlipUntilTailsDamage` couldn't be reused: it computes `heads × damage_per_heads` and deliberately ignores `fixed_damage` (the "N damage for each heads" cards store a spurious `fixed_damage` that must *not* be added), so a new sibling variant was the clean fit.

- **"N damage for each heads"** (no base) — just new map entries pointing at the existing `FlipUntilTailsDamage`.

## Cards completed

| Effect text | Mechanic | Pokémon (incl. rarity reprints) |
|---|---|---|
| `…30 more damage for each heads` | `FlipUntilTailsBonusDamage{30}` | Wormadam, Iron Treads, Rayquaza |
| `…40 more damage for each heads` | `FlipUntilTailsBonusDamage{40}` | Lickilicky ex, Pinsir, Trevenant |
| `…40 damage for each heads` | `FlipUntilTailsDamage{40}` | Wooloo, Qwilfish |
| `…70 damage for each heads` | `FlipUntilTailsDamage{70}` | Alolan Dugtrio, Bouffalant |

12 cards via the new mechanic, 4 via the existing one — 16 total across 10 distinct Pokémon. `card_status` now reports all 16 complete.

## Testing

- **Unit + integration tests** (through the real card → `EFFECT_MECHANIC_MAP` pipeline): effect-map wiring for every string; base-plus-scaling on the mechanic; the base being sourced per-card from `fixed_damage` (Iron Treads 50 vs Rayquaza 70 for the identical "30 more" text); and base-less cards dealing 0 on an immediate tails.
- `cargo clippy --all-targets --features "tui test-utils" -- -D warnings`: clean.
- `card_test` 10k-game fuzz: passes for a representative of every distinct Pokémon above (no panics).
- **Confirmed in the actual game:** on an immediate tails (0 heads), these attacks still deal their printed base damage — e.g. Iron Treads' Roll and Release does 50 with no heads, then +30 per heads. That base-on-zero-heads behavior is the distinction between the "N more" and "N damage" wordings that this PR encodes.
