### PR TITLE
Implement Lunala ex's Psychic Connect ability (7 cards)

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -30,6 +30,13 @@ pub enum AbilityMechanic {
     MoveTypedEnergyFromBenchToActive {
         energy_type: EnergyType,
     },
+    /// Lunala ex's Psychic Connect: "Once during your turn, you may move all [energy_type] Energy
+    /// from 1 of your Benched [energy_type] Pokémon to your Active Pokémon." Unlike
+    /// `MoveTypedEnergyFromBenchToActive`, all of the chosen Pokémon's matching Energy moves at
+    /// once, it is once per turn, and the Active Pokémon may be any type.
+    MoveAllTypedEnergyFromBenchToActive {
+        energy_type: EnergyType,
+    },
     AttachEnergyFromZoneToActiveTypedPokemon {
         energy_type: EnergyType,
     },

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -66,6 +66,12 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::MoveTypedEnergyFromBenchToActive { .. } => {
             Outcomes::single_fn(vaporeon_wash_out)
         }
+        AbilityMechanic::MoveAllTypedEnergyFromBenchToActive { energy_type } => {
+            let energy_type = *energy_type;
+            Outcomes::single_fn(move |_rng, state, action| {
+                move_all_typed_energy_from_bench_to_active(state, action, energy_type);
+            })
+        }
         AbilityMechanic::AttachEnergyFromZoneToActiveTypedPokemon { energy_type } => {
             attach_energy_from_zone_to_active_typed_outcome(*energy_type)
         }
@@ -749,6 +755,41 @@ fn vaporeon_wash_out(_: &mut StdRng, state: &mut State, action: &Action) {
         .collect::<Vec<_>>();
     if possible_moves.is_empty() {
         return; // No benched Water Pokémon with Water Energy
+    }
+    state
+        .move_generation_stack
+        .push((acting_player, possible_moves));
+}
+
+/// Lunala ex's Psychic Connect: move all `energy_type` Energy from 1 chosen Benched `energy_type`
+/// Pokémon to the Active Pokémon (any type). The player picks which benched Pokémon to drain.
+fn move_all_typed_energy_from_bench_to_active(
+    state: &mut State,
+    action: &Action,
+    energy_type: EnergyType,
+) {
+    let acting_player = action.actor;
+    let possible_moves = state
+        .enumerate_bench_pokemon(acting_player)
+        .filter_map(|(in_play_idx, pokemon)| {
+            if pokemon.card.get_type() != Some(energy_type) {
+                return None;
+            }
+            let amount = pokemon
+                .attached_energy
+                .iter()
+                .filter(|&&energy| energy == energy_type)
+                .count() as u32;
+            (amount > 0).then_some(SimpleAction::MoveEnergy {
+                from_in_play_idx: in_play_idx,
+                to_in_play_idx: 0, // Active spot
+                energy_type,
+                amount,
+            })
+        })
+        .collect::<Vec<_>>();
+    if possible_moves.is_empty() {
+        return; // No benched Pokémon of this type with matching Energy
     }
     state
         .move_generation_stack

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -258,7 +258,12 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             AbilityMechanic::BurnOpponentActive,
         );
         // map.insert("Once during your turn, you may move all [D] Energy from each of your Pokémon to this Pokémon.", todo_implementation);
-        // map.insert("Once during your turn, you may move all [P] Energy from 1 of your Benched [P] Pokémon to your Active Pokémon.", todo_implementation);
+        map.insert(
+            "Once during your turn, you may move all [P] Energy from 1 of your Benched [P] Pokémon to your Active Pokémon.",
+            AbilityMechanic::MoveAllTypedEnergyFromBenchToActive {
+                energy_type: EnergyType::Psychic,
+            },
+        );
         // map.insert("Once during your turn, you may put a random Pokémon Tool card from your deck into your hand.", todo_implementation);
         map.insert(
             "Once during your turn, you may put a random Pokémon from your deck into your hand.",

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -77,6 +77,9 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::MoveTypedEnergyFromBenchToActive { .. } => {
             can_use_vaporeon_wash_out(state)
         }
+        AbilityMechanic::MoveAllTypedEnergyFromBenchToActive { energy_type } => {
+            !card.ability_used && has_benched_typed_pokemon_with_typed_energy(state, *energy_type)
+        }
         AbilityMechanic::AttachEnergyFromZoneToActiveTypedPokemon { energy_type } => {
             can_use_attach_energy_from_zone_to_active_typed(state, card, *energy_type)
         }
@@ -317,6 +320,17 @@ fn can_use_vaporeon_wash_out(state: &State) -> bool {
         .any(|(_, pokemon)| {
             pokemon.card.get_type() == Some(EnergyType::Water)
                 && pokemon.attached_energy.contains(&EnergyType::Water)
+        })
+}
+
+/// True if the current player has a benched Pokémon of `energy_type` that has at least one
+/// `energy_type` Energy attached (a valid source for Lunala ex's Psychic Connect).
+fn has_benched_typed_pokemon_with_typed_energy(state: &State, energy_type: EnergyType) -> bool {
+    state
+        .enumerate_bench_pokemon(state.current_player)
+        .any(|(_, pokemon)| {
+            pokemon.card.get_type() == Some(energy_type)
+                && pokemon.attached_energy.contains(&energy_type)
         })
 }
 

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -110,6 +110,8 @@ mod legacy_ability_logic_test;
 mod lucario_b3_test;
 #[path = "pokemon/lucario_fighting_coach_test.rs"]
 mod lucario_fighting_coach_test;
+#[path = "pokemon/lunala_ex_test.rs"]
+mod lunala_ex_test;
 #[path = "pokemon/magneton_test.rs"]
 mod magneton_test;
 #[path = "pokemon/magnezone_mirror_shot_test.rs"]

--- a/tests/pokemon/lunala_ex_test.rs
+++ b/tests/pokemon/lunala_ex_test.rs
@@ -1,0 +1,90 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_test_game_with_board,
+};
+
+/// Lunala ex's Psychic Connect: "Once during your turn, you may move all [P] Energy from 1 of your
+/// Benched [P] Pokémon to your Active Pokémon." The Active may be any type, only [P] Energy moves,
+/// and it can be used only once per turn.
+#[test]
+fn test_lunala_ex_psychic_connect_moves_all_psychic_energy_to_any_active() {
+    // Active is a Grass Pokémon (not Psychic) to confirm the destination is not type-restricted.
+    // Lunala ex is benched at idx 1; the benched Abra at idx 2 holds 2 [P] + 1 [C].
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A3087LunalaEx),
+            PlayedCard::from_id(CardId::A1115Abra).with_energy(vec![
+                EnergyType::Psychic,
+                EnergyType::Psychic,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1002Ivysaur)],
+    );
+
+    // Use Lunala ex's ability from the Bench.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 1 },
+        is_stack: false,
+    });
+
+    // The only offered move drains both [P] Energy from Abra (idx 2) into the Active (idx 0).
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    let move_energy = actions
+        .into_iter()
+        .find(|a| {
+            matches!(
+                a.action,
+                SimpleAction::MoveEnergy {
+                    from_in_play_idx: 2,
+                    to_in_play_idx: 0,
+                    energy_type: EnergyType::Psychic,
+                    amount: 2,
+                }
+            )
+        })
+        .expect("Psychic Connect should offer moving both [P] Energy from Abra to the Active");
+    game.apply_action(&move_energy);
+
+    let state = game.get_state_clone();
+    // The Grass Active received both [P] Energy (destination is not type-restricted).
+    let active = state.in_play_pokemon[0][0].as_ref().unwrap();
+    assert_eq!(
+        active
+            .attached_energy
+            .iter()
+            .filter(|&&e| e == EnergyType::Psychic)
+            .count(),
+        2,
+    );
+    // Only the [P] Energy moved; Abra kept its [C] Energy.
+    let abra = state.in_play_pokemon[0][2].as_ref().unwrap();
+    assert_eq!(abra.attached_energy, vec![EnergyType::Colorless]);
+
+    // Once per turn: Lunala ex's ability is no longer offered after use.
+    let (_actor, actions) = state.generate_possible_actions();
+    assert!(!actions
+        .iter()
+        .any(|a| matches!(a.action, SimpleAction::UseAbility { in_play_idx: 1 })));
+}
+
+/// Psychic Connect is unavailable when no benched [P] Pokémon has [P] Energy to move.
+#[test]
+fn test_lunala_ex_psychic_connect_unavailable_without_psychic_energy_source() {
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A3087LunalaEx),
+            PlayedCard::from_id(CardId::A1115Abra), // benched [P] Pokémon but no Energy attached
+        ],
+        vec![PlayedCard::from_id(CardId::A1002Ivysaur)],
+    );
+
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(!actions
+        .iter()
+        .any(|a| matches!(a.action, SimpleAction::UseAbility { in_play_idx: 0 })));
+}


### PR DESCRIPTION
## Summary

Implements Lunala ex's **Psychic Connect** ability, completing all 7 rarity reprints (A3 087/186/204/238, A4b 184/367, B1a 099). Because the ability map keys on the exact effect string, one implementation covers every reprint.

> Once during your turn, you may move all [P] Energy from 1 of your Benched [P] Pokémon to your Active Pokémon.

## What changed

Adds `AbilityMechanic::MoveAllTypedEnergyFromBenchToActive { energy_type }`. The player chooses which benched [P] Pokémon to drain, and all of that Pokémon's [P] Energy moves to the Active at once.

This is a sibling to the existing `MoveTypedEnergyFromBenchToActive` (Vaporeon's Wash Out) rather than a reuse of it, because the two differ on three axes:

| | Wash Out (existing) | Psychic Connect (new) |
|---|---|---|
| Amount | one energy per use | **all** matching energy from the chosen Pokémon |
| Frequency | as often as you like | **once per turn** (gated by `ability_used`) |
| Destination | Active must be same type | Active may be **any type** |

Only [P] Energy moves — any other Energy on the source Pokémon stays put.

## Testing

- **Game-API tests** (`get_test_game_with_board`): using the ability from the Bench moves both [P] Energy from a benched Abra onto a **Grass** Active (confirming the destination is not type-restricted and that the [C] Energy stays behind); the ability is no longer offered after one use (once per turn); and it is unavailable when no benched [P] Pokémon has [P] Energy to move.
- `cargo clippy --all-targets --features "tui test-utils" -- -D warnings`: clean.
- `card_test` 10k-game fuzz: passes for A3 087, B1a 099, A4b 184 (no panics).

## In-game verification

Confirmed live that the Active receiving the energy can be **any type** (not just Psychic), and that only the **[P]** Energy transfers — other Energy types on the benched Pokémon are left behind.
