### PR TITLE
Implement Ho-Oh ex's Phoenix Turbo attack (7 cards)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -245,6 +245,9 @@ fn forecast_effect_attack_by_mechanic(
             energies,
             target_benched_type,
         } => energy_bench_attack(energies.clone(), *target_benched_type, state, attack),
+        Mechanic::AttachEnergiesAnyWayToBenchedBasic { energies } => {
+            attach_energies_any_way_to_benched_basic(attack.fixed_damage, energies.clone())
+        }
         Mechanic::VaporeonHyperWhirlpool => vaporeon_hyper_whirlpool(state, attack.fixed_damage),
         Mechanic::SearchToHandByEnergy { energy_type } => AttackOutcomes::from_effect_outcomes(
             pokemon_search_outcomes_by_type(state, false, *energy_type),
@@ -1364,6 +1367,54 @@ pub(crate) fn energy_bench_attack(
             .move_generation_stack
             .push((action.actor, choices.clone()));
     })
+}
+
+/// Ho-Oh ex's Phoenix Turbo: deal `damage`, then attach each Energy in `energies` to your Benched
+/// Basic Pokémon "in any way you like". Each Energy is placed independently (all on one Pokémon is
+/// allowed), fossils count as Basic (`get_stage == 0`), and if there is no Benched Basic Pokémon
+/// the Energy fizzles — the damage is always dealt.
+fn attach_energies_any_way_to_benched_basic(
+    damage: u32,
+    energies: Vec<EnergyType>,
+) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let basic_indices = state
+            .enumerate_bench_pokemon(action.actor)
+            .filter(|(_, pokemon)| get_stage(pokemon) == 0)
+            .map(|(in_play_idx, _)| in_play_idx)
+            .collect::<Vec<_>>();
+        if basic_indices.is_empty() {
+            return; // No Benched Basic Pokémon; the Energy fizzles (damage already applied).
+        }
+        let mut choices = Vec::new();
+        distribute_energies_across_basics(&basic_indices, &energies, &mut Vec::new(), &mut choices);
+        if !choices.is_empty() {
+            state.move_generation_stack.push((action.actor, choices));
+        }
+    })
+}
+
+/// Recursively enumerate every way to attach `energies[assigned.len()..]` to `basic_indices`, one
+/// Energy at a time, producing one `Attach` action per full distribution.
+fn distribute_energies_across_basics(
+    basic_indices: &[usize],
+    energies: &[EnergyType],
+    assigned: &mut Vec<(u32, EnergyType, usize)>,
+    out: &mut Vec<SimpleAction>,
+) {
+    match energies.split_first() {
+        None => out.push(SimpleAction::Attach {
+            attachments: assigned.clone(),
+            is_turn_energy: false,
+        }),
+        Some((&energy, rest)) => {
+            for &in_play_idx in basic_indices {
+                assigned.push((1, energy, in_play_idx));
+                distribute_energies_across_basics(basic_indices, rest, assigned, out);
+                assigned.pop();
+            }
+        }
+    }
 }
 
 /// Used for attacks that on heads deal extra damage, on tails deal self damage.

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -188,6 +188,13 @@ pub enum Mechanic {
         energies: Vec<EnergyType>,
         target_benched_type: Option<EnergyType>,
     },
+    /// Ho-Oh ex's Phoenix Turbo: deal `fixed_damage`, then attach each of these Energies to your
+    /// Benched Basic Pokémon "in any way you like" (each Energy is placed independently, so all on
+    /// one Pokémon is allowed). Fossils count as Basic. If there is no Benched Basic Pokémon the
+    /// Energy simply fizzles; the damage is still dealt.
+    AttachEnergiesAnyWayToBenchedBasic {
+        energies: Vec<EnergyType>,
+    },
     VaporeonHyperWhirlpool,
     ConditionalBenchDamage {
         required_extra_energy: Vec<EnergyType>,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1278,7 +1278,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             energies: vec![EnergyType::Fire],
         },
     );
-    // map.insert("Take a [R], [W], and [L] Energy from your Energy Zone and attach them to your Benched Basic Pokémon in any way you like.", todo_implementation);
+    map.insert(
+        "Take a [R], [W], and [L] Energy from your Energy Zone and attach them to your Benched Basic Pokémon in any way you like.",
+        Mechanic::AttachEnergiesAnyWayToBenchedBasic {
+            energies: vec![EnergyType::Fire, EnergyType::Water, EnergyType::Lightning],
+        },
+    );
     map.insert(
         "Take a [W] Energy from your Energy Zone and attach it to 1 of your Benched Basic Pokémon.",
         Mechanic::AttachEnergyToBenchedBasic {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -80,6 +80,8 @@ mod hisuian_lilligant_dress_up_test;
 mod hisuian_zoroark_ex_test;
 #[path = "pokemon/hitmonchan_ex_test.rs"]
 mod hitmonchan_ex_test;
+#[path = "pokemon/ho_oh_ex_phoenix_turbo_test.rs"]
+mod ho_oh_ex_phoenix_turbo_test;
 #[path = "pokemon/honchkrow_evil_admonition_test.rs"]
 mod honchkrow_evil_admonition_test;
 #[path = "pokemon/houndstone_last_respects_test.rs"]

--- a/tests/pokemon/ho_oh_ex_phoenix_turbo_test.rs
+++ b/tests/pokemon/ho_oh_ex_phoenix_turbo_test.rs
@@ -1,0 +1,172 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+fn phoenix_turbo(actor: usize) -> Action {
+    Action {
+        actor,
+        action: attack_action(CardId::A4034HoOhEx, 0),
+        is_stack: false,
+    }
+}
+
+/// Phoenix Turbo: 80 damage, then attach one [R], [W], and [L] to your Benched Basic Pokémon in
+/// any way you like (each Energy independently; all on one Pokémon is allowed).
+#[test]
+fn test_ho_oh_ex_phoenix_turbo_distributes_energy_across_benched_basics() {
+    // Active Ho-Oh ex (Fire) attacks a Chansey (not weak to Fire, so 80 is exact). Two benched
+    // Basics at idx 1 (Bulbasaur) and idx 2 (Abra).
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A4034HoOhEx).with_energy(vec![
+                EnergyType::Fire,
+                EnergyType::Fire,
+                EnergyType::Fire,
+            ]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1115Abra),
+        ],
+        vec![PlayedCard::from_id(CardId::A1202Chansey)], // 120 HP
+    );
+
+    game.apply_action(&phoenix_turbo(0));
+
+    let state = game.get_state_clone();
+    // 80 damage was dealt (regardless of the energy distribution that follows).
+    assert_eq!(
+        state.in_play_pokemon[1][0]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        40
+    );
+
+    let (_actor, actions) = state.generate_possible_actions();
+    // 2 benched Basics ^ 3 Energies = 8 possible distributions.
+    let distributions = actions
+        .iter()
+        .filter(|a| matches!(a.action, SimpleAction::Attach { .. }))
+        .count();
+    assert_eq!(distributions, 8);
+
+    // "All on one" is allowed: all three Energies onto Bulbasaur (idx 1).
+    let all_on_bulbasaur = SimpleAction::Attach {
+        attachments: vec![
+            (1, EnergyType::Fire, 1),
+            (1, EnergyType::Water, 1),
+            (1, EnergyType::Lightning, 1),
+        ],
+        is_turn_energy: false,
+    };
+    // A genuine split is also offered ([R]+[W] on Bulbasaur, [L] on Abra).
+    let split = SimpleAction::Attach {
+        attachments: vec![
+            (1, EnergyType::Fire, 1),
+            (1, EnergyType::Water, 1),
+            (1, EnergyType::Lightning, 2),
+        ],
+        is_turn_energy: false,
+    };
+    assert!(actions.iter().any(|a| a.action == split));
+
+    let choice = actions
+        .into_iter()
+        .find(|a| a.action == all_on_bulbasaur)
+        .expect("should be able to pile all three Energies onto one Benched Basic");
+    game.apply_action(&choice);
+
+    let state = game.get_state_clone();
+    let bulbasaur = state.in_play_pokemon[0][1].as_ref().unwrap();
+    assert_eq!(bulbasaur.attached_energy.len(), 3);
+    for energy in [EnergyType::Fire, EnergyType::Water, EnergyType::Lightning] {
+        assert!(bulbasaur.attached_energy.contains(&energy));
+    }
+    // The other Basic received nothing.
+    assert!(state.in_play_pokemon[0][2]
+        .as_ref()
+        .unwrap()
+        .attached_energy
+        .is_empty());
+}
+
+/// A played Fossil counts as a Benched Basic Pokémon and is a valid target.
+#[test]
+fn test_ho_oh_ex_phoenix_turbo_can_target_benched_fossil() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A4034HoOhEx).with_energy(vec![
+                EnergyType::Fire,
+                EnergyType::Fire,
+                EnergyType::Fire,
+            ]),
+            PlayedCard::from_id(CardId::A1216HelixFossil), // Fossil, counts as Basic
+        ],
+        vec![PlayedCard::from_id(CardId::A1202Chansey)],
+    );
+
+    game.apply_action(&phoenix_turbo(0));
+
+    // The only Basic is the Fossil at idx 1, so all three Energies must go to it.
+    let all_on_fossil = SimpleAction::Attach {
+        attachments: vec![
+            (1, EnergyType::Fire, 1),
+            (1, EnergyType::Water, 1),
+            (1, EnergyType::Lightning, 1),
+        ],
+        is_turn_energy: false,
+    };
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    let choice = actions
+        .into_iter()
+        .find(|a| a.action == all_on_fossil)
+        .expect("a played Fossil should be a valid Benched Basic target");
+    game.apply_action(&choice);
+
+    let fossil = game.get_state_clone().in_play_pokemon[0][1]
+        .as_ref()
+        .unwrap()
+        .clone();
+    assert_eq!(fossil.attached_energy.len(), 3);
+}
+
+/// With no Benched Basic Pokémon, Phoenix Turbo still deals 80 and the Energy fizzles.
+#[test]
+fn test_ho_oh_ex_phoenix_turbo_deals_damage_with_no_benched_basic() {
+    // The only benched Pokémon is an evolved (Stage 1) Ivysaur, which is not a valid target.
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A4034HoOhEx).with_energy(vec![
+                EnergyType::Fire,
+                EnergyType::Fire,
+                EnergyType::Fire,
+            ]),
+            PlayedCard::from_id(CardId::A1002Ivysaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1202Chansey)],
+    );
+
+    game.apply_action(&phoenix_turbo(0));
+
+    let state = game.get_state_clone();
+    // Damage is still dealt...
+    assert_eq!(
+        state.in_play_pokemon[1][0]
+            .as_ref()
+            .unwrap()
+            .get_remaining_hp(),
+        40
+    );
+    // ...no distribution choice was offered, and the evolved bench Pokémon got no Energy.
+    let (_actor, actions) = state.generate_possible_actions();
+    assert!(!actions
+        .iter()
+        .any(|a| matches!(a.action, SimpleAction::Attach { .. })));
+    assert!(state.in_play_pokemon[0][1]
+        .as_ref()
+        .unwrap()
+        .attached_energy
+        .is_empty());
+}


### PR DESCRIPTION
## Summary

Implements Ho-Oh ex's **Phoenix Turbo** attack, completing all 7 rarity reprints (A4 034/187/210/240, A4b 068/362, B2 226). One mechanic + a single map entry covers every reprint. (B1 032 "Ho-Oh" is a different attack, Blessed Burn, and is untouched.)

> 80 damage. Take a [R], [W], and [L] Energy from your Energy Zone and attach them to your Benched Basic Pokémon in any way you like.

## What changed

Adds `Mechanic::AttachEnergiesAnyWayToBenchedBasic { energies }`: deal the attack's fixed damage, then attach each Energy in `energies` to your Benched Basic Pokémon "in any way you like" — each Energy is placed independently, so piling all of them onto one Pokémon is allowed.

- The [R], [W], and [L] are generated regardless of the deck's registered Energy types (the mechanic carries the fixed type list), matching Moltres ex's Inferno Dance behavior.
- Targets are filtered by `get_stage == 0`, so **played Fossils** (which the engine treats as "basic for stage purposes") are valid targets, matching the game.
- If there is no Benched Basic Pokémon the Energy fizzles; the 80 damage is still dealt.

The existing `ChargeBench`/`energy_bench_attack` couldn't be reused: it attaches all energies to a single chosen Pokémon and filters by energy type, whereas Phoenix Turbo distributes distinct-typed energies freely across benched Basics.

## Testing

- **Game-API tests** (`get_test_game_with_board`): 80 damage plus all 8 distributions for two benched Basics (both "all on one" and a split, with the Energy landing correctly); a played **Fossil** accepted as a Benched Basic target; and 80 damage still dealt with no Benched Basic (the Energy fizzles).
- `cargo fmt --check` / `cargo clippy --all-targets --features "tui test-utils" -- -D warnings`: clean.
- `card_test` 10k-game fuzz: passes for all 7 reprints (no panics).

## In-game verification

Confirmed live: the attack generates exactly one Fire + one Water + one Lightning regardless of the deck's Energy types; all three can be piled onto a single benched Basic; played Fossils count as Basic and can receive the Energy; and with no benched Basic it still deals 80 ("No basic pokemon on bench").
