### PR TITLE
Implement Passimian ex's Offload Pass ability (5 cards)

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -97,6 +97,12 @@ pub enum AbilityMechanic {
     /// Ursaluna's Guts: if this Pokémon would be Knocked Out by damage from an attack, flip a
     /// coin. If heads, it is not Knocked Out and its remaining HP becomes 10.
     CoinFlipToSurviveKnockOut,
+    /// Passimian ex's Offload Pass: if this Pokémon is in the Active Spot and is Knocked Out by
+    /// damage from an opponent's attack, move all of its `energy_type` Energy to 1 of your Benched
+    /// Pokémon (your choice). Passive; handled in the `on_knockout` hook.
+    MoveAllTypedEnergyToBenchOnKnockout {
+        energy_type: EnergyType,
+    },
     CheckupDamageToOpponentActive {
         amount: u32,
     },

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -156,6 +156,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::CoinFlipToSurviveKnockOut => {
             panic!("CoinFlipToSurviveKnockOut is a passive ability")
         }
+        AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout { .. } => {
+            panic!("MoveAllTypedEnergyToBenchOnKnockout is a passive ability")
+        }
         AbilityMechanic::CheckupDamageToOpponentActive { .. } => {
             panic!("CheckupDamageToOpponentActive is a passive ability")
         }

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -133,7 +133,12 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
         // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, do 10 damage to each of your opponent's Pokémon.", todo_implementation);
         // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, do 50 damage to the Attacking Pokémon.", todo_implementation);
         // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, flip a coin. If heads, the Attacking Pokémon is Knocked Out.", todo_implementation);
-        // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all [F] Energy from this Pokémon to 1 of your Benched Pokémon.", todo_implementation);
+        map.insert(
+            "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all [F] Energy from this Pokémon to 1 of your Benched Pokémon.",
+            AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout {
+                energy_type: EnergyType::Fighting,
+            },
+        );
         map.insert(
             "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon, do 20 damage to the Attacking Pokémon.",
             AbilityMechanic::CounterattackDamage { amount: 20 },

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -1325,6 +1325,54 @@ pub(crate) fn on_knockout(
             }
         }
     }
+
+    // Passimian ex's Offload Pass: if this Pokémon is Knocked Out in the Active Spot by an
+    // opponent's attack, move all of its typed Energy to 1 of your Benched Pokémon (your choice).
+    if is_opponent_attack && knocked_out_idx == 0 {
+        let offload_energy = state.in_play_pokemon[knocked_out_player][knocked_out_idx]
+            .as_ref()
+            .and_then(|pokemon| match get_ability_mechanic(&pokemon.card) {
+                Some(AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout { energy_type }) => {
+                    Some(*energy_type)
+                }
+                _ => None,
+            });
+        if let Some(energy_type) = offload_energy {
+            let bench_indices: Vec<usize> = state
+                .enumerate_bench_pokemon(knocked_out_player)
+                .map(|(idx, _)| idx)
+                .collect();
+            // With no Benched Pokémon there is nowhere to move the Energy (and the game is about to
+            // end), so leave it to be discarded with this Pokémon.
+            if !bench_indices.is_empty() {
+                // Remove the Energy from the KO'd Pokémon first so it isn't sent to the discard
+                // pile; the chosen Attach below re-attaches it to a Benched Pokémon.
+                let moved = {
+                    let ko_pokemon = state.in_play_pokemon[knocked_out_player][knocked_out_idx]
+                        .as_mut()
+                        .expect("Pokemon should be there if knocked out");
+                    let before = ko_pokemon.attached_energy.len();
+                    ko_pokemon.attached_energy.retain(|&e| e != energy_type);
+                    (before - ko_pokemon.attached_energy.len()) as u32
+                };
+                if moved > 0 {
+                    // One choice per Benched Pokémon; all of the Energy goes to the chosen one.
+                    // Pushed here (before promotion, which is inserted at the bottom of the stack)
+                    // so it resolves while the Bench is still intact.
+                    let choices = bench_indices
+                        .into_iter()
+                        .map(|idx| SimpleAction::Attach {
+                            attachments: vec![(moved, energy_type, idx)],
+                            is_turn_energy: false,
+                        })
+                        .collect::<Vec<_>>();
+                    state
+                        .move_generation_stack
+                        .push((knocked_out_player, choices));
+                }
+            }
+        }
+    }
 }
 
 pub(crate) fn on_attack_knockout(

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -120,9 +120,10 @@ fn can_use_ability_by_mechanic(
         }
         AbilityMechanic::CoinFlipToPreventDamage => false, // Passive ability
         AbilityMechanic::CoinFlipToSurviveKnockOut => false, // Passive ability
-        AbilityMechanic::CheckupDamageToOpponentActive { .. } => false, // Passive ability
-        AbilityMechanic::CheckupDamageToAllOpponentPokemon { .. } => false, // Passive ability
-        AbilityMechanic::BadDreamsEndOfTurn { .. } => false, // Passive ability
+        AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout { .. } => false, // Passive (on_knockout)
+        AbilityMechanic::CheckupDamageToOpponentActive { .. } => false,       // Passive ability
+        AbilityMechanic::CheckupDamageToAllOpponentPokemon { .. } => false,   // Passive ability
+        AbilityMechanic::BadDreamsEndOfTurn { .. } => false,                  // Passive ability
         AbilityMechanic::CoinFlipSleepOpponentActive => !card.ability_used,
         AbilityMechanic::DiscardEnergyToIncreaseTypeDamage { discard_energy, .. } => {
             !card.ability_used && card.attached_energy.contains(discard_energy)

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -140,6 +140,8 @@ mod miraidon_ex_test;
 mod morpeko_test;
 #[path = "pokemon/ninetales_ember_dance_test.rs"]
 mod ninetales_ember_dance_test;
+#[path = "pokemon/passimian_ex_offload_pass_test.rs"]
+mod passimian_ex_offload_pass_test;
 #[path = "pokemon/porygonz_cyberjack_test.rs"]
 mod porygonz_cyberjack_test;
 #[path = "pokemon/psyduck_test.rs"]

--- a/tests/pokemon/passimian_ex_offload_pass_test.rs
+++ b/tests/pokemon/passimian_ex_offload_pass_test.rs
@@ -1,0 +1,90 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game_with_board,
+};
+
+/// Passimian ex's Offload Pass: when it is Knocked Out in the Active Spot by an opponent's attack,
+/// all of its [F] Energy moves to 1 of your Benched Pokémon (your choice); other Energy is lost.
+#[test]
+fn test_passimian_ex_offload_pass_moves_fighting_energy_to_chosen_bench_on_ko() {
+    // Player 0's Active Passimian ex is at 30 HP with 2 [F] + 1 [C]; it has two Benched Pokémon.
+    // Player 1's Bulbasaur (current player) KOs it with Vine Whip (40).
+    let mut game = get_initialized_game_with_board(
+        0,
+        1, // current player = the attacker
+        3,
+        vec![
+            PlayedCard::from_id(CardId::A3104PassimianEx)
+                .with_energy(vec![
+                    EnergyType::Fighting,
+                    EnergyType::Fighting,
+                    EnergyType::Colorless,
+                ])
+                .with_remaining_hp(30),
+            PlayedCard::from_id(CardId::A1115Abra), // Bench idx 1 (Psychic — any type is valid)
+            PlayedCard::from_id(CardId::A1143Machop), // Bench idx 2
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Grass])],
+    );
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::Attack(deckgym::test_support::nth_attack(CardId::A1001Bulbasaur, 0)),
+        is_stack: false,
+    });
+
+    // Passimian ex was Knocked Out and discarded.
+    let state = game.get_state_clone();
+    assert!(state.in_play_pokemon[0][0].is_none());
+
+    // Offload Pass offers Player 0 a choice of which Benched Pokémon receives all 2 [F] Energy.
+    let (actor, actions) = state.generate_possible_actions();
+    assert_eq!(actor, 0);
+    let to_abra = SimpleAction::Attach {
+        attachments: vec![(2, EnergyType::Fighting, 1)],
+        is_turn_energy: false,
+    };
+    let to_machop = SimpleAction::Attach {
+        attachments: vec![(2, EnergyType::Fighting, 2)],
+        is_turn_energy: false,
+    };
+    assert!(actions.iter().any(|a| a.action == to_machop));
+    let choice = actions
+        .into_iter()
+        .find(|a| a.action == to_abra)
+        .expect("Offload Pass should let Player 0 send the [F] Energy to the benched Abra");
+    game.apply_action(&choice);
+
+    // Abra received exactly the 2 [F] Energy; the [C] Energy did not move (it was discarded).
+    let state = game.get_state_clone();
+    let abra = state.in_play_pokemon[0][1].as_ref().unwrap();
+    assert_eq!(
+        abra.attached_energy,
+        vec![EnergyType::Fighting, EnergyType::Fighting]
+    );
+    assert!(!abra.attached_energy.contains(&EnergyType::Colorless));
+}
+
+/// Offload Pass is passive — it is never offered as a `UseAbility` action.
+#[test]
+fn test_passimian_ex_offload_pass_is_passive() {
+    let game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![
+            PlayedCard::from_id(CardId::A3104PassimianEx)
+                .with_energy(vec![EnergyType::Fighting, EnergyType::Fighting]),
+            PlayedCard::from_id(CardId::A1143Machop),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(!actions
+        .iter()
+        .any(|a| matches!(a.action, SimpleAction::UseAbility { in_play_idx: 0 })));
+}


### PR DESCRIPTION
## Summary

Implements Passimian ex's **Offload Pass** ability, completing all 5 rarity reprints (A3 104/187/205, A4b 223, B1 324).

> If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all [F] Energy from this Pokémon to 1 of your Benched Pokémon.

## What changed

Adds a passive `AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout { energy_type }` (never offered as a `UseAbility` action), handled in the `on_knockout` hook alongside Electrical Cord:

- **Triggers only** when the Pokémon is Knocked Out in the Active Spot by an opponent's attack (`is_from_active_attack` and the attacker is the opponent) — not by Poison/Burn between turns, and not by self-inflicted damage.
- Moves **all** of the matching Energy (only [F]; other Energy is discarded with the Pokémon) to **1 Benched Pokémon of any type**.
- The destination is the **player's choice**: the Energy is removed from the KO'd Pokémon (so it isn't sent to the discard pile) and an `Attach` choice is pushed per Benched Pokémon. It's pushed before promotion — which `trigger_promotion_or_declare_winner` inserts at the bottom of the move-generation stack — so it resolves while the Bench is still intact.

## Testing

- **Game-API tests** (`get_initialized_game_with_board`): an opponent's attack KOs an Active Passimian ex holding 2 [F] + 1 [C]; the player picks which of two Benched Pokémon receives exactly the 2 [F] (the [C] does not move); and the ability is never offered as a usable action.
- `cargo fmt --check` / `cargo clippy --all-targets --features "tui test-utils" -- -D warnings`: clean.
- `card_test` 10k-game fuzz: passes for all 5 reprints (no panics).

## In-game verification

Confirmed live: only KO by attack damage triggers it (Poison/Burn does not); only the [F] Energy transfers (other Energy is lost); and it can be sent to any one Benched Pokémon regardless of type.
