### PR TITLE
Implement Kubfu's Training self-charge attack (2 cards)

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1214,6 +1214,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     map.insert(
+        "Take a [C] Energy from your Energy Zone and attach it to this Pokémon.",
+        Mechanic::SelfChargeActive {
+            energies: vec![EnergyType::Colorless],
+        },
+    );
+    map.insert(
         "Take a [G] Energy from your Energy Zone and attach it to 1 of your Benched [G] Pokémon.",
         Mechanic::ChargeBench {
             energies: vec![EnergyType::Grass],
@@ -2253,7 +2259,6 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per: 20,
         },
     );
-    // map.insert("Take a [C] Energy from your Energy Zone and attach it to this Pokémon.", todo_implementation);
     // map.insert("The Defending Pokémon loses all Abilities. This effect lasts until the Defending Pokémon leaves the Active Spot.", todo_implementation);
     map.insert(
         "This attack does 30 damage for each of your Benched [D] Pokémon.",

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -104,6 +104,8 @@ mod jolteon_ex_test;
 mod klefki_dismantling_keys_test;
 #[path = "pokemon/kommo_o_clanging_scales_test.rs"]
 mod kommo_o_clanging_scales_test;
+#[path = "pokemon/kubfu_training_test.rs"]
+mod kubfu_training_test;
 #[path = "pokemon/legacy_ability_logic_test.rs"]
 mod legacy_ability_logic_test;
 #[path = "pokemon/lucario_b3_test.rs"]

--- a/tests/pokemon/kubfu_training_test.rs
+++ b/tests/pokemon/kubfu_training_test.rs
@@ -1,0 +1,51 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Kubfu's "Training": "Take a [C] Energy from your Energy Zone and attach it to
+/// this Pokémon." It deals no damage and attaches one Energy to Kubfu itself.
+/// The `[C]` (any-type) attach is modeled with `EnergyType::Colorless`, mirroring
+/// the already-merged benched `[C]` mapping used by Delcatty's "Energy Assist" and
+/// Regigigas's "Giga Turbo".
+fn assert_training_attaches_one_energy(kubfu_id: CardId) {
+    // Kubfu starts with one Fighting Energy so it can pay Training's [C] cost.
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(kubfu_id).with_energy(vec![EnergyType::Fighting])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    // Seed the Energy Zone so we can prove Training pulls a *new* Energy rather than
+    // consuming this turn's manual attachment.
+    let mut state = game.get_state_clone();
+    state.energy_zone[0].current = Some(EnergyType::Fighting);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(kubfu_id, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+
+    // The [C] cost Energy stays attached; Training appends exactly one more Energy.
+    assert_eq!(
+        state.get_active(0).attached_energy,
+        vec![EnergyType::Fighting, EnergyType::Colorless]
+    );
+    // Training does not consume the turn's Energy Zone (it generates its own Energy).
+    assert_eq!(state.energy_zone[0].current, Some(EnergyType::Fighting));
+}
+
+#[test]
+fn test_kubfu_b3_097_training_attaches_one_energy_to_self() {
+    assert_training_attaches_one_energy(CardId::B3097Kubfu);
+}
+
+#[test]
+fn test_kubfu_b3_172_reprint_training_attaches_one_energy_to_self() {
+    assert_training_attaches_one_energy(CardId::B3172Kubfu);
+}


### PR DESCRIPTION
## What

Implements the **Training** attack — _"Take a [C] Energy from your Energy Zone and attach it to this Pokémon."_ — which was previously unmapped (using it panicked with `No implementation found for attack effect`).

One `EFFECT_MECHANIC_MAP` insert clears **both** Kubfu prints, which share the identical attack:

| Card | Attack | Effect |
|------|--------|--------|
| `B3 097` Kubfu | Training | Take a [C] Energy from your Energy Zone and attach it to this Pokémon. |
| `B3 172` Kubfu (reprint) | Training | _(identical)_ |

## Approach

Reuses the existing `Mechanic::SelfChargeActive` (attach N Energy to the active Pokémon), so this is a map-only change:

```rust
map.insert(
    "Take a [C] Energy from your Energy Zone and attach it to this Pokémon.",
    Mechanic::SelfChargeActive { energies: vec![EnergyType::Colorless] },
);
```

The `[C]` (any-type) attach is modeled with `EnergyType::Colorless`, mirroring the already-merged **benched** `[C]` mapping used by Delcatty's "Energy Assist" (`A3 130`) and Regigigas's "Giga Turbo" (`B3 134`), which map `"...attach it to 1 of your Benched Pokémon."` to `ChargeBench { energies: vec![EnergyType::Colorless] }`. Keeping the same convention for the active-self variant.

Also removes the now-obsolete `// map.insert(... todo_implementation)` placeholder for this effect text.

## Tests

`tests/pokemon/kubfu_training_test.rs` — one focused test per print (`B3 097` and `B3 172`), driven through the real card → `EFFECT_MECHANIC_MAP` pipeline at the public `Game` API level. Each asserts:

- Training attaches exactly one Energy to the active Kubfu (the `[C]` cost Energy stays; one more is appended).
- Training deals no damage and does **not** consume the turn's Energy Zone (it generates its own Energy — `is_turn_energy = false`).

`cargo test --features test-utils` and `cargo clippy --features "tui test-utils" --all-targets` are green.
