### PR TITLE
Implement Sawk's Brick Break via abilities-as-effects (derive-on-query)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -18,7 +18,10 @@ use crate::{
     },
     combinatorics::generate_combinations,
     effects::{CardEffect, TurnEffect},
-    hooks::{can_evolve_into, contains_energy, get_attack_cost, get_retreat_cost, get_stage},
+    hooks::{
+        can_evolve_into, contains_energy, get_attack_cost, get_retreat_cost, get_stage,
+        DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT,
+    },
     models::{Attack, Card, EnergyType, StatusCondition, TrainerType},
     State,
 };
@@ -85,7 +88,7 @@ fn apply_attack_common_modifiers(
         outcomes = apply_block_attack_coin_flip(outcomes);
     }
 
-    outcomes = apply_defender_damage_prevention_if_needed(acting_player, state, outcomes);
+    outcomes = apply_defender_damage_prevention_if_needed(acting_player, state, attack, outcomes);
     apply_defender_guts_if_needed(acting_player, state, attack, outcomes)
 }
 
@@ -95,28 +98,35 @@ fn apply_copied_attack_modifiers(
     attack: &Attack,
     base_outcomes: AttackOutcomes,
 ) -> AttackOutcomes {
-    let outcomes = apply_defender_damage_prevention_if_needed(acting_player, state, base_outcomes);
+    let outcomes =
+        apply_defender_damage_prevention_if_needed(acting_player, state, attack, base_outcomes);
     apply_defender_guts_if_needed(acting_player, state, attack, outcomes)
 }
 
 fn apply_defender_damage_prevention_if_needed(
     acting_player: usize,
     state: &State,
+    attack: &Attack,
     outcomes: AttackOutcomes,
 ) -> AttackOutcomes {
-    // Collect every opponent in-play Pokémon (Active and Benched) with the CoinFlipToPreventDamage
-    // ability (e.g. Meowth's Carefree Steps). The ability applies independently to each such
-    // Pokémon, and the split only adds a coin flip for the ones that actually take damage.
+    // Attacks like Sawk's Brick Break ignore any effect on the opponent's Active Pokémon, so the
+    // Active never gets a Carefree-Steps prevention flip (it only ever damages the Active).
+    let ignores_active_effects =
+        attack.effect.as_deref() == Some(DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT);
+
+    // Collect every opponent in-play Pokémon (Active and Benched) presenting the
+    // CoinFlipToPreventIncomingDamage effect (e.g. Meowth's Carefree Steps). It applies
+    // independently to each such Pokémon, and the split only adds a coin flip for the ones that
+    // actually take damage.
     let opponent = (acting_player + 1) % 2;
     let prevented_indices: Vec<usize> = state
         .enumerate_in_play_pokemon(opponent)
+        .filter(|(idx, _)| !(ignores_active_effects && *idx == 0))
         .filter(|(_, pokemon)| {
             pokemon
-                .card
-                .get_ability()
-                .and_then(|a| ability_mechanic_from_effect(&a.effect))
-                .map(|m| matches!(m, AbilityMechanic::CoinFlipToPreventDamage))
-                .unwrap_or(false)
+                .get_effective_card_effects()
+                .iter()
+                .any(|e| matches!(e, CardEffect::CoinFlipToPreventIncomingDamage))
         })
         .map(|(idx, _)| idx)
         .collect();
@@ -692,6 +702,9 @@ fn forecast_effect_attack_by_mechanic(
             *extra_damage,
         ),
         Mechanic::DamageUnaffectedByWeakness => active_damage_doutcome(attack.fixed_damage),
+        Mechanic::DamageUnaffectedByOpponentActiveEffects => {
+            active_damage_doutcome(attack.fixed_damage)
+        }
         Mechanic::CoinFlipToBlockAttackNextTurn => {
             coin_flip_to_block_attack_next_turn(attack.fixed_damage)
         }

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -235,6 +235,11 @@ pub enum Mechanic {
         extra_damage: u32,
     },
     DamageUnaffectedByWeakness,
+    /// Sawk's Brick Break: fixed damage whose value "isn't affected by any effects on your
+    /// opponent's Active Pokémon." The bypass itself is handled in `hooks::modify_damage` and the
+    /// defender-prevention path via the attack's effect text; this variant just routes the attack
+    /// as ordinary active damage (like `DamageUnaffectedByWeakness`).
+    DamageUnaffectedByOpponentActiveEffects,
     DelayedSpotDamage {
         amount: u32,
     },

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -5,6 +5,7 @@ use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use crate::actions::abilities::AbilityMechanic;
+use crate::effects::CardEffect;
 use crate::models::{Card, EnergyType};
 
 /// Map from ability effect text to its AbilityMechanic.
@@ -350,7 +351,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
                 amount: 30,
             },
         );
-        // map.insert("This Pokémon takes -10 damage from attacks.", todo_implementation);
+        map.insert(
+            "This Pokémon takes -10 damage from attacks.",
+            AbilityMechanic::ReduceDamageFromAttacks { amount: 10 },
+        );
         // map.insert("This Pokémon takes -20 damage from attacks from [R] or [W] Pokémon.", todo_implementation);
         map.insert(
             "This Pokémon takes -20 damage from attacks.",
@@ -522,4 +526,27 @@ pub fn get_ability_mechanic(card: &Card) -> Option<&'static AbilityMechanic> {
 
 pub fn has_ability_mechanic(card: &Card, mechanic: &AbilityMechanic) -> bool {
     get_ability_mechanic(card) == Some(mechanic)
+}
+
+/// Translate a *self-scoped defensive* passive ability mechanic into the `CardEffect` it presents
+/// as while the holder is in play. This is the core of the "abilities-as-effects" model: rather
+/// than scanning the board for these abilities, damage code reads a Pokémon's effect list (see
+/// `PlayedCard::get_effective_card_effects`), which merges stored effects with the effects derived
+/// here. Returns `None` for mechanics that are not effects-on-this-Pokémon (activated abilities,
+/// opponent-restrictions like Gengar/Snorlax, auras like Serperior, lifecycle triggers, etc.).
+pub fn card_effect_from_ability_mechanic(mechanic: &AbilityMechanic) -> Option<CardEffect> {
+    match mechanic {
+        AbilityMechanic::ReduceDamageFromAttacks { amount } => {
+            Some(CardEffect::ReduceDamageFromAttacks { amount: *amount })
+        }
+        AbilityMechanic::ReduceOpponentActiveDamage { amount } => {
+            Some(CardEffect::ReduceOpponentActiveDamage { amount: *amount })
+        }
+        AbilityMechanic::PreventAllDamageFromEx => Some(CardEffect::PreventAllDamageFromEx),
+        AbilityMechanic::PreventDamageWhileBenched => Some(CardEffect::PreventDamageWhileBenched),
+        AbilityMechanic::CoinFlipToPreventDamage => {
+            Some(CardEffect::CoinFlipToPreventIncomingDamage)
+        }
+        _ => None,
+    }
 }

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1700,7 +1700,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "This attack's damage isn't affected by Weakness.",
         Mechanic::DamageUnaffectedByWeakness,
     );
-    // map.insert("This attack's damage isn't affected by any effects on your opponent's Active Pokémon.", todo_implementation);
+    map.insert(
+        "This attack's damage isn't affected by any effects on your opponent's Active Pokémon.",
+        Mechanic::DamageUnaffectedByOpponentActiveEffects,
+    );
     // map.insert("Until this Pokémon leaves the Active Spot, this Pokémon's Rolling Frenzy attack does +30 damage. This effect stacks.", todo_implementation);
     // map.insert("You can use this attack only if you have Uxie and Azelf on your Bench. Discard all Energy from this Pokémon.", todo_implementation);
     // map.insert("You may discard any number of your Benched [W] Pokémon. This attack does 40 more damage for each Benched Pokémon you discarded in this way.", todo_implementation);

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use apply_action_helpers::handle_damage_only;
 pub(crate) use apply_action_helpers::handle_knockouts;
 pub use apply_trainer_action::may_effect;
 pub use effect_ability_mechanic_map::ability_mechanic_from_effect;
+pub(crate) use effect_ability_mechanic_map::card_effect_from_ability_mechanic;
 pub(crate) use effect_ability_mechanic_map::get_ability_mechanic;
 pub use effect_ability_mechanic_map::has_ability_mechanic;
 pub use effect_ability_mechanic_map::EFFECT_ABILITY_MECHANIC_MAP;

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -39,6 +39,35 @@ pub enum CardEffect {
     Counterattack {
         amount: u32,
     },
+    // ---------------------------------------------------------------------------------------------
+    // Ability-derived effects. These are not added via `add_effect`; they are *derived* on the fly
+    // from a Pokémon's passive ability by `PlayedCard::get_effective_card_effects` (see
+    // `card_effect_from_ability_mechanic`). Modeling passive abilities as `CardEffect`s lets damage
+    // code check a single "effects on this Pokémon" list instead of scanning the board for
+    // abilities, and lets attacks like Sawk's Brick Break ignore *all* effects on the opponent's
+    // Active Pokémon uniformly. They have no turn duration — they are present exactly while the
+    // ability-holder is in play.
+    // ---------------------------------------------------------------------------------------------
+    /// This Pokémon takes `amount` less damage from attacks (e.g. Cloyster's Shell Armor).
+    /// Applies whether the holder is Active or Benched, mirroring `ReduceDamageFromAttacks`.
+    ReduceDamageFromAttacks {
+        amount: u32,
+    },
+    /// While this Pokémon is the Active Spot defender, attacks against it do `amount` less damage
+    /// (e.g. Arbok's Intimidating Fang). Mirrors `ReduceOpponentActiveDamage`.
+    ReduceOpponentActiveDamage {
+        amount: u32,
+    },
+    /// Prevent all damage done to this Pokémon by attacks from the opponent's Pokémon ex
+    /// (e.g. Oricorio's Safeguard). Mirrors `PreventAllDamageFromEx`.
+    PreventAllDamageFromEx,
+    /// Prevent all damage done to this Pokémon by attacks while it is on the Bench
+    /// (e.g. Wartortle's Shell Shield). Mirrors `PreventDamageWhileBenched`.
+    PreventDamageWhileBenched,
+    /// If any damage is done to this Pokémon by attacks, flip a coin; on heads prevent that damage
+    /// (e.g. Meowth's Carefree Steps). Mirrors `CoinFlipToPreventDamage`. Distinct from
+    /// `CoinFlipToBlockAttack`, which is an attacker self-debuff on the holder's own attacks.
+    CoinFlipToPreventIncomingDamage,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -549,31 +549,35 @@ fn get_intimidating_fang_reduction(
     let defenders_active = state.in_play_pokemon[target_player][0]
         .as_ref()
         .expect("Defending Pokemon should be there when checking Intimidating Fang");
-    if matches!(
-        get_ability_mechanic(&defenders_active.card),
-        Some(AbilityMechanic::ReduceOpponentActiveDamage { amount: 20 })
-    ) {
-        debug!("Intimidating Fang: Reducing opponent's attack damage by 20");
-        return 20;
-    }
-    0
+    // Reads the unified effect list: Intimidating Fang (a passive ability) presents as a
+    // `ReduceOpponentActiveDamage` effect on the Active defender.
+    defenders_active
+        .get_effective_card_effects()
+        .iter()
+        .filter_map(|effect| match effect {
+            CardEffect::ReduceOpponentActiveDamage { amount } => Some(*amount),
+            _ => None,
+        })
+        .sum()
 }
 
 fn get_ability_damage_reduction(
     receiving_pokemon: &crate::models::PlayedCard,
     is_from_active_attack: bool,
 ) -> u32 {
-    if let Some(ability) = receiving_pokemon.card.get_ability() {
-        if let Some(AbilityMechanic::ReduceDamageFromAttacks { amount }) =
-            ability_mechanic_from_effect(&ability.effect)
-        {
-            if is_from_active_attack {
-                debug!("ReduceDamageFromAttacks: Reducing damage by {}", amount);
-                return *amount;
-            }
-        }
+    if !is_from_active_attack {
+        return 0;
     }
-    0
+    // Reads the unified effect list, so Cloyster's Shell Armor (a passive ability) is handled the
+    // same way as any stored effect.
+    receiving_pokemon
+        .get_effective_card_effects()
+        .iter()
+        .filter_map(|effect| match effect {
+            CardEffect::ReduceDamageFromAttacks { amount } => Some(*amount),
+            _ => None,
+        })
+        .sum()
 }
 
 fn get_ability_damage_increase(
@@ -796,6 +800,12 @@ enum WeaknessApplication {
 const DAMAGE_UNAFFECTED_BY_WEAKNESS_EFFECT: &str =
     "This attack's damage isn't affected by Weakness.";
 
+/// Sawk's Brick Break (and any card sharing this text): the attack's damage ignores every effect
+/// on the opponent's Active Pokémon — ability-derived reductions/preventions, stored CardEffects,
+/// and damage-reducing Tools alike. See `attack_ignores_opponent_active_effects`.
+pub(crate) const DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT: &str =
+    "This attack's damage isn't affected by any effects on your opponent's Active Pokémon.";
+
 #[derive(Clone, Copy, Default)]
 pub(crate) struct DamageModifierContext<'a> {
     pub(crate) attack_name: Option<&'a str>,
@@ -806,6 +816,10 @@ fn attack_effect_ignores_weakness(context: DamageModifierContext<'_>) -> bool {
     // TODO: If more attack text needs to alter damage-modifier stages, replace this
     // effect-string check with a typed attack metadata/damage-modifier capability.
     context.attack_effect == Some(DAMAGE_UNAFFECTED_BY_WEAKNESS_EFFECT)
+}
+
+fn attack_ignores_opponent_active_effects(context: DamageModifierContext<'_>) -> bool {
+    context.attack_effect == Some(DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT)
 }
 
 fn get_weakness_application(
@@ -882,20 +896,38 @@ pub(crate) fn modify_damage(
         .as_ref()
         .expect("Receiving Pokemon should be there when modifying damage");
 
-    // Check for Safeguard ability (prevents all damage from opponent's Pokémon ex)
-    if matches!(
-        get_ability_mechanic(&receiving_pokemon.card),
-        Some(AbilityMechanic::PreventAllDamageFromEx)
-    ) && is_from_active_attack
+    // "Effects on the opponent's Active Pokémon" (Sawk's Brick Break) — when this attack ignores
+    // them, treat the receiver's effect list as empty for every defensive stage below, and also
+    // bypass its damage-reducing Tools. Only the opponent's Active is targeted by such attacks.
+    let skip_target_effects = attack_ignores_opponent_active_effects(context)
+        && is_from_active_attack
+        && target_idx == 0
+        && attacking_player != target_player;
+
+    // The unified "effects on this Pokémon" list: stored CardEffects plus any derived from the
+    // receiver's passive ability (Cloyster's Shell Armor, Oricorio's Safeguard, Meowth's Carefree
+    // Steps, ...). Damage code checks this single list instead of scanning the board for abilities.
+    let target_effects: Vec<CardEffect> = if skip_target_effects {
+        Vec::new()
+    } else {
+        receiving_pokemon.get_effective_card_effects()
+    };
+
+    // Safeguard (Oricorio): prevent all damage from the opponent's Pokémon ex.
+    if target_effects
+        .iter()
+        .any(|e| matches!(e, CardEffect::PreventAllDamageFromEx))
+        && is_from_active_attack
         && attacking_pokemon.card.is_ex()
     {
         debug!("Safeguard: Preventing all damage from opponent's Pokémon ex");
         return 0;
     }
-    if matches!(
-        get_ability_mechanic(&receiving_pokemon.card),
-        Some(AbilityMechanic::PreventDamageWhileBenched)
-    ) && is_from_active_attack
+    // Shell Shield (Wartortle): prevent all damage while benched.
+    if target_effects
+        .iter()
+        .any(|e| matches!(e, CardEffect::PreventDamageWhileBenched))
+        && is_from_active_attack
         && target_idx != 0
     {
         debug!("Shell Shield: Preventing all damage to benched Wartortle");
@@ -903,14 +935,16 @@ pub(crate) fn modify_damage(
     }
 
     // Protective Poncho: prevent all damage to benched Pokémon with this tool attached
-    if target_idx != 0 && has_tool(receiving_pokemon, CardId::B2147ProtectivePoncho) {
+    if target_idx != 0
+        && !skip_target_effects
+        && has_tool(receiving_pokemon, CardId::B2147ProtectivePoncho)
+    {
         debug!("Protective Poncho: Preventing all damage to benched Pokémon");
         return 0;
     }
 
     // Check for PreventAllDamageAndEffects (Shinx's Hide)
-    if receiving_pokemon
-        .get_active_effects()
+    if target_effects
         .iter()
         .any(|effect| matches!(effect, CardEffect::PreventAllDamageAndEffects))
     {
@@ -920,8 +954,7 @@ pub(crate) fn modify_damage(
 
     // Check for PreventDamageFromBasic (Carracosta's Blocking Shell)
     if attacking_pokemon.card.is_basic()
-        && receiving_pokemon
-            .get_active_effects()
+        && target_effects
             .iter()
             .any(|effect| matches!(effect, CardEffect::PreventDamageFromBasic))
     {
@@ -934,19 +967,38 @@ pub(crate) fn modify_damage(
     let target_is_ex = receiving_pokemon.card.is_ex();
     let attacker_is_eevee_evolution = attacking_pokemon.evolved_from("Eevee");
 
-    let intimidating_fang_reduction =
-        get_intimidating_fang_reduction(state, attacking_ref, target_ref, is_from_active_attack);
-    let heavy_helmet_reduction = get_heavy_helmet_reduction(state, (target_player, target_idx));
-    let metal_core_barrier_reduction =
-        get_metal_core_barrier_reduction(state, (target_player, target_idx), is_from_active_attack);
-    let steel_apron_reduction = get_steel_apron_reduction(
-        state,
-        attacking_player,
-        (target_player, target_idx),
-        is_from_active_attack,
-    );
-    let ability_damage_reduction =
-        get_ability_damage_reduction(receiving_pokemon, is_from_active_attack);
+    // Every damage-reducing effect/tool below sits on the *target*, so an attack that ignores
+    // effects on the opponent's Active Pokémon (Sawk) zeroes all of them.
+    let intimidating_fang_reduction = if skip_target_effects {
+        0
+    } else {
+        get_intimidating_fang_reduction(state, attacking_ref, target_ref, is_from_active_attack)
+    };
+    let heavy_helmet_reduction = if skip_target_effects {
+        0
+    } else {
+        get_heavy_helmet_reduction(state, (target_player, target_idx))
+    };
+    let metal_core_barrier_reduction = if skip_target_effects {
+        0
+    } else {
+        get_metal_core_barrier_reduction(state, (target_player, target_idx), is_from_active_attack)
+    };
+    let steel_apron_reduction = if skip_target_effects {
+        0
+    } else {
+        get_steel_apron_reduction(
+            state,
+            attacking_player,
+            (target_player, target_idx),
+            is_from_active_attack,
+        )
+    };
+    let ability_damage_reduction = if skip_target_effects {
+        0
+    } else {
+        get_ability_damage_reduction(receiving_pokemon, is_from_active_attack)
+    };
     let ability_damage_increase = get_ability_damage_increase(
         state,
         attacking_player,
@@ -965,17 +1017,29 @@ pub(crate) fn modify_damage(
         is_active_to_active,
         context.attack_name,
     );
-    let reduced_card_effect_modifiers =
-        get_reduced_card_effect_modifiers(state, is_active_to_active, target_player);
-    let increased_vulnerability_modifiers =
-        get_increased_vulnerability_modifiers(state, is_active_to_active, target_player);
-    let reduced_turn_effect_modifiers = get_turn_effect_damage_reduction(
-        state,
-        target_player,
-        receiving_pokemon,
-        attacking_player,
-        is_from_active_attack,
-    );
+    // Reductions and vulnerability are both "effects on the target"; ignore *any* of them (whether
+    // they help or hurt the attacker) when the attack bypasses opponent-active effects.
+    let reduced_card_effect_modifiers = if skip_target_effects {
+        0
+    } else {
+        get_reduced_card_effect_modifiers(state, is_active_to_active, target_player)
+    };
+    let increased_vulnerability_modifiers = if skip_target_effects {
+        0
+    } else {
+        get_increased_vulnerability_modifiers(state, is_active_to_active, target_player)
+    };
+    let reduced_turn_effect_modifiers = if skip_target_effects {
+        0
+    } else {
+        get_turn_effect_damage_reduction(
+            state,
+            target_player,
+            receiving_pokemon,
+            attacking_player,
+            is_from_active_attack,
+        )
+    };
     let weakness_application = get_weakness_application(
         state,
         is_active_to_active,
@@ -1057,8 +1121,7 @@ pub(crate) fn modify_damage(
     };
 
     // Threshold-based prevention (e.g. Cascoon's Harden): prevent all damage if it is low enough.
-    let prevented_by_threshold = receiving_pokemon
-        .get_active_effects()
+    let prevented_by_threshold = target_effects
         .iter()
         .any(|effect| matches!(effect, CardEffect::PreventDamageIfLessOrEqual { threshold } if final_damage <= *threshold));
     if prevented_by_threshold {

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -23,6 +23,7 @@ pub(crate) use core::on_evolve;
 pub(crate) use core::on_knockout;
 pub use core::to_playable_card;
 pub(crate) use core::DamageModifierContext;
+pub(crate) use core::DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT;
 pub(crate) use counterattack::get_counterattack_damage;
 pub(crate) use counterattack::should_poison_attacker;
 pub(crate) use retreat::can_retreat;

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use super::State;
 use crate::{
-    actions::{abilities::AbilityMechanic, has_ability_mechanic},
+    actions::{
+        abilities::AbilityMechanic, card_effect_from_ability_mechanic, get_ability_mechanic,
+        has_ability_mechanic,
+    },
     card_ids::CardId,
     database::get_card_by_enum,
     effects::CardEffect,
@@ -291,6 +294,22 @@ impl PlayedCard {
             .iter()
             .map(|(effect, _)| effect.clone())
             .collect()
+    }
+
+    /// All effects currently on this Pokémon: the stored (turn-duration) effects from
+    /// `add_effect`, plus effects *derived* from its passive ability (the "abilities-as-effects"
+    /// model — see `card_effect_from_ability_mechanic`). Damage code should query this instead of
+    /// separately scanning for defensive abilities, so a passive like Cloyster's Shell Armor and a
+    /// stored effect like Carracosta's Blocking Shell are handled through one list. Derived effects
+    /// are present exactly while the ability-holder is in play (no turn duration).
+    pub(crate) fn get_effective_card_effects(&self) -> Vec<CardEffect> {
+        let mut effects = self.get_active_effects();
+        if let Some(mechanic) = get_ability_mechanic(&self.card) {
+            if let Some(derived) = card_effect_from_ability_mechanic(mechanic) {
+                effects.push(derived);
+            }
+        }
+        effects
     }
 
     pub(crate) fn get_effects(&self) -> &Vec<(CardEffect, u8)> {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -156,6 +156,8 @@ mod rampardos_head_smash_test;
 mod roaring_moon_test;
 #[path = "pokemon/salamence_test.rs"]
 mod salamence_test;
+#[path = "pokemon/sawk_test.rs"]
+mod sawk_test;
 #[path = "pokemon/shinx_hide_test.rs"]
 mod shinx_hide_test;
 #[path = "pokemon/slither_wing_test.rs"]

--- a/tests/pokemon/sawk_test.rs
+++ b/tests/pokemon/sawk_test.rs
@@ -1,0 +1,165 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    effects::CardEffect,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board, get_test_game_with_board},
+};
+
+// Sawk's "Brick Break": "This attack's damage isn't affected by any effects on your opponent's
+// Active Pokémon." Brick Break does a fixed 30 damage.
+//
+// These tests drive the attack through the public `Game` API and assert on the resulting HP,
+// checking that every flavor of "effect on the opponent's Active Pokémon" (ability-derived
+// damage reduction, a stored CardEffect, a damage-reducing Tool, and a coin-flip prevention
+// ability) is ignored — while Weakness (a card property, not an effect) still applies.
+
+fn sawk_active() -> PlayedCard {
+    PlayedCard::from_id(CardId::B3086Sawk).with_energy(vec![EnergyType::Fighting])
+}
+
+fn brick_break() -> Action {
+    Action {
+        actor: 0,
+        action: attack_action(CardId::B3086Sawk, 0),
+        is_stack: false,
+    }
+}
+
+/// Cloyster's "Shell Armor" (`ReduceDamageFromAttacks{10}`) is bypassed: Cloyster takes the full 30.
+#[test]
+fn test_sawk_bypasses_cloyster_shell_armor() {
+    let mut game = get_test_game_with_board(
+        vec![sawk_active()],
+        vec![PlayedCard::from_id(CardId::A1067Cloyster)],
+    );
+
+    game.apply_action(&brick_break());
+
+    let state = game.get_state_clone();
+    // Cloyster has 120 HP; Shell Armor would leave it at 110. Brick Break ignores it → 90.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 90);
+}
+
+/// Control: a vanilla Basic Fighting attacker (Mankey, Low Kick 20) IS reduced by Shell Armor,
+/// proving the ability is real and the bypass — not a broken ability — is responsible above.
+#[test]
+fn test_cloyster_shell_armor_reduces_normal_attacker() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1141Mankey).with_energy(vec![EnergyType::Fighting])],
+        vec![PlayedCard::from_id(CardId::A1067Cloyster)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1141Mankey, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // 20 damage - 10 Shell Armor = 10 dealt; 120 - 10 = 110.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 110);
+}
+
+/// A stored `CardEffect::PreventDamageFromBasic` (Carracosta's Blocking Shell) on the opponent's
+/// active is bypassed: Sawk is Basic, yet Brick Break still deals its full 30.
+#[test]
+fn test_sawk_bypasses_prevent_damage_from_basic() {
+    let mut defender = PlayedCard::from_id(CardId::A1004VenusaurEx);
+    defender.add_effect(CardEffect::PreventDamageFromBasic, 1);
+
+    let mut game = get_test_game_with_board(vec![sawk_active()], vec![defender]);
+
+    game.apply_action(&brick_break());
+
+    let state = game.get_state_clone();
+    // Venusaur ex has 190 HP; without the bypass a Basic attacker deals 0. With bypass → 30.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 160);
+}
+
+/// Control: a vanilla Basic attacker IS blocked by PreventDamageFromBasic (0 damage dealt).
+#[test]
+fn test_prevent_damage_from_basic_blocks_normal_basic_attacker() {
+    let mut defender = PlayedCard::from_id(CardId::A1004VenusaurEx);
+    defender.add_effect(CardEffect::PreventDamageFromBasic, 1);
+
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1141Mankey).with_energy(vec![EnergyType::Fighting])],
+        vec![defender],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1141Mankey, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 190);
+}
+
+/// A damage-reducing Tool (Heavy Helmet, -20 to a Pokémon with retreat cost ≥ 3) on the
+/// opponent's active is bypassed. Cloyster has a retreat cost of 3 and (with the helmet) would
+/// otherwise stack -10 (Shell Armor) and -20 (Heavy Helmet); Brick Break ignores both.
+#[test]
+fn test_sawk_bypasses_heavy_helmet_and_ability() {
+    let cloyster = PlayedCard::from_id(CardId::A1067Cloyster)
+        .with_tool(get_card_by_enum(CardId::B1219HeavyHelmet));
+
+    let mut game = get_test_game_with_board(vec![sawk_active()], vec![cloyster]);
+
+    game.apply_action(&brick_break());
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 90);
+}
+
+/// Meowth's "Carefree Steps" (`CoinFlipToPreventDamage`) is bypassed: no prevention coin is
+/// flipped against Brick Break. Meowth (50 HP, Weak to Fighting) always takes 30 + 20 Weakness =
+/// 50 and is Knocked Out on every RNG seed. Without the bypass, a heads flip would prevent the
+/// damage and leave Meowth alive at 50 HP.
+#[test]
+fn test_sawk_bypasses_meowth_carefree_steps() {
+    for seed in 0..30u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![sawk_active()],
+            // Bench a second Pokémon so the Knock Out doesn't end the game.
+            vec![
+                PlayedCard::from_id(CardId::B2124Meowth),
+                PlayedCard::from_id(CardId::A1001Bulbasaur),
+            ],
+        );
+
+        game.apply_action(&brick_break());
+
+        let state = game.get_state_clone();
+        // If Carefree Steps had prevented the damage, Meowth would still be Active at full HP.
+        let prevented = state.in_play_pokemon[1][0]
+            .as_ref()
+            .is_some_and(|p| p.get_name() == "Meowth" && p.get_remaining_hp() == 50);
+        assert!(
+            !prevented,
+            "seed {seed}: Carefree Steps must not prevent Brick Break's damage"
+        );
+    }
+}
+
+/// Regression: Weakness is a card property, not an "effect on the Pokémon", so Brick Break is
+/// still affected by it. Meowth (A1 196) is Weak to Fighting: 30 + 20 = 50.
+#[test]
+fn test_sawk_still_affected_by_weakness() {
+    let mut game = get_test_game_with_board(
+        vec![sawk_active()],
+        vec![PlayedCard::from_id(CardId::A1196Meowth)],
+    );
+
+    game.apply_action(&brick_break());
+
+    let state = game.get_state_clone();
+    // Meowth has 60 HP; 30 + 20 Weakness = 50 dealt → 10 remaining.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 10);
+}


### PR DESCRIPTION
Sawk's Brick Break ("This attack's damage isn't affected by any effects on
your opponent's Active Pokémon") must ignore every defensive thing on the
opponent's active — abilities, stored CardEffects, damage-reducing Tools, and
coin-flip prevention alike. Those lived in three separate representations
checked at scattered sites across two damage paths, making a uniform "ignore
all effects" hard to express.

Model passive self-scoped defensive abilities as effects, derived on query:

- Add CardEffect variants mirroring the abilities: ReduceDamageFromAttacks,
  ReduceOpponentActiveDamage, PreventAllDamageFromEx, PreventDamageWhileBenched,
  CoinFlipToPreventIncomingDamage.
- card_effect_from_ability_mechanic maps the self-scoped passive mechanics to
  those effects; PlayedCard::get_effective_card_effects merges stored effects
  with the ability-derived ones. Nothing is stored on enter/leave, so the card
  stays the source of truth (no lifecycle seams, State stays hashable).
- Route the damage-path checks (Cloyster Shell Armor, Intimidating Fang,
  Oricorio Safeguard, Wartortle Shell Shield in modify_damage; Meowth Carefree
  Steps in the attack-forecast path) through the unified effect list instead of
  scanning the board for abilities. Gating preserved.
- Enable Cloyster A1 067 "-10 damage" Shell Armor mapping (was unimplemented).

Sawk on top: register Mechanic::DamageUnaffectedByOpponentActiveEffects, and in
both damage paths bypass the target's effects (and its Tools) when Brick Break
hits the opponent's active. Weakness (a card property, not an effect) still
applies.

Opponent-restriction abilities (Gengar, Snorlax) and aura abilities (Serperior,
type boosts) are intentionally left as-is: they are not effects on the holder
and folding them into a per-Pokemon effect list would be incorrect.

Tests at the Game public API level cover each bypass (Cloyster, PreventDamage-
FromBasic, Heavy Helmet, Meowth), controls proving the effects are real, and a
Weakness regression.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MDcbQR8QA82W3GFsWM6M4F