### PR TITLE
Implement Mega Medicham ex's Chakra Fist (and Medicham's Psykick)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -19,8 +19,8 @@ use crate::{
     combinatorics::generate_combinations,
     effects::{CardEffect, TurnEffect},
     hooks::{
-        can_evolve_into, contains_energy, get_attack_cost, get_retreat_cost, get_stage,
-        DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT,
+        attack_effect_ignores_opponent_active_effects, can_evolve_into, contains_energy,
+        get_attack_cost, get_retreat_cost, get_stage,
     },
     models::{Attack, Card, EnergyType, StatusCondition, TrainerType},
     State,
@@ -112,7 +112,7 @@ fn apply_defender_damage_prevention_if_needed(
     // Attacks like Sawk's Brick Break ignore any effect on the opponent's Active Pokémon, so the
     // Active never gets a Carefree-Steps prevention flip (it only ever damages the Active).
     let ignores_active_effects =
-        attack.effect.as_deref() == Some(DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT);
+        attack_effect_ignores_opponent_active_effects(attack.effect.as_deref());
 
     // Collect every opponent in-play Pokémon (Active and Benched) presenting the
     // CoinFlipToPreventIncomingDamage effect (e.g. Meowth's Carefree Steps). It applies
@@ -705,6 +705,15 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::DamageUnaffectedByOpponentActiveEffects => {
             active_damage_doutcome(attack.fixed_damage)
         }
+        Mechanic::ExtraDamageIfSelfHasTypeEnergy {
+            energy_type,
+            extra_damage,
+        } => extra_damage_if_self_has_type_energy(
+            state,
+            attack.fixed_damage,
+            *energy_type,
+            *extra_damage,
+        ),
         Mechanic::CoinFlipToBlockAttackNextTurn => {
             coin_flip_to_block_attack_next_turn(attack.fixed_damage)
         }
@@ -2552,6 +2561,25 @@ fn extra_damage_per_specific_energy_all_yours(
         .count() as u32;
     let damage = base_damage + matching_energy_count * damage_per_energy;
     active_damage_doutcome(damage)
+}
+
+/// Medicham's "Psykick" / Mega Medicham ex's "Chakra Fist": extra damage if the attacking active
+/// Pokémon has any Energy of `energy_type` attached.
+fn extra_damage_if_self_has_type_energy(
+    state: &State,
+    base_damage: u32,
+    energy_type: EnergyType,
+    extra_damage: u32,
+) -> AttackOutcomes {
+    let has_energy = state
+        .get_active(state.current_player)
+        .attached_energy
+        .contains(&energy_type);
+    if has_energy {
+        active_damage_doutcome(base_damage + extra_damage)
+    } else {
+        active_damage_doutcome(base_damage)
+    }
 }
 
 fn extra_damage_if_type_energy_in_play_attack(

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -136,6 +136,14 @@ pub enum Mechanic {
         minimum_count: usize,
         extra_damage: u32,
     },
+    /// Medicham's "Psykick" / Mega Medicham ex's "Chakra Fist": extra damage if the attacking
+    /// Pokémon has any Energy of `energy_type` attached. (Chakra Fist additionally shares Sawk's
+    /// "isn't affected by any effects on your opponent's Active Pokémon" clause, which is detected
+    /// separately from the attack's effect text in `hooks::modify_damage`.)
+    ExtraDamageIfSelfHasTypeEnergy {
+        energy_type: EnergyType,
+        extra_damage: u32,
+    },
     ExtraDamageIfStadiumInPlay {
         extra_damage: u32,
     },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1897,7 +1897,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "If the amount of Energy attached to both Active Pokémon is 5 or more, this attack does 60 more damage.",
         Mechanic::ExtraDamageIfCombinedActiveEnergyAtLeast { threshold: 5, extra_damage: 60 },
     );
-    // map.insert("If this Pokémon has any [P] Energy attached, this attack does 50 more damage.", todo_implementation);
+    map.insert(
+        "If this Pokémon has any [P] Energy attached, this attack does 50 more damage.",
+        Mechanic::ExtraDamageIfSelfHasTypeEnergy {
+            energy_type: EnergyType::Psychic,
+            extra_damage: 50,
+        },
+    );
     // map.insert("If this Pokémon has more Energy attached than your opponent's Active Pokémon, this attack does 50 more damage.", todo_implementation);
     map.insert(
         "If this Pokémon moved from your Bench to the Active Spot this turn, this attack does 40 more damage.",
@@ -2032,7 +2038,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
 
     // Promo-B
-    // map.insert("If this Pokémon has any [P] Energy attached, this attack does 40 more damage. This attack's damage isn't affected by any effects on your opponent's Active Pokémon.", todo_implementation);
+    map.insert(
+        "If this Pokémon has any [P] Energy attached, this attack does 40 more damage. This attack's damage isn't affected by any effects on your opponent's Active Pokémon.",
+        Mechanic::ExtraDamageIfSelfHasTypeEnergy {
+            energy_type: EnergyType::Psychic,
+            extra_damage: 40,
+        },
+    );
 
     // B2b
     map.insert(

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -800,11 +800,19 @@ enum WeaknessApplication {
 const DAMAGE_UNAFFECTED_BY_WEAKNESS_EFFECT: &str =
     "This attack's damage isn't affected by Weakness.";
 
-/// Sawk's Brick Break (and any card sharing this text): the attack's damage ignores every effect
+/// Sawk's Brick Break (and any card sharing this clause): the attack's damage ignores every effect
 /// on the opponent's Active Pokémon — ability-derived reductions/preventions, stored CardEffects,
 /// and damage-reducing Tools alike. See `attack_ignores_opponent_active_effects`.
 pub(crate) const DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT: &str =
     "This attack's damage isn't affected by any effects on your opponent's Active Pokémon.";
+
+/// Whether an attack's effect text carries the "isn't affected by any effects on your opponent's
+/// Active Pokémon" clause. This is a substring match (not equality) so attacks that combine it with
+/// another clause — e.g. Mega Medicham ex's "Chakra Fist" (the [P]-Energy damage bonus plus this
+/// clause) — share Sawk's bypass behavior.
+pub(crate) fn attack_effect_ignores_opponent_active_effects(effect: Option<&str>) -> bool {
+    effect.is_some_and(|e| e.contains(DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT))
+}
 
 #[derive(Clone, Copy, Default)]
 pub(crate) struct DamageModifierContext<'a> {
@@ -819,7 +827,7 @@ fn attack_effect_ignores_weakness(context: DamageModifierContext<'_>) -> bool {
 }
 
 fn attack_ignores_opponent_active_effects(context: DamageModifierContext<'_>) -> bool {
-    context.attack_effect == Some(DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT)
+    attack_effect_ignores_opponent_active_effects(context.attack_effect)
 }
 
 fn get_weakness_application(

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -5,6 +5,7 @@ mod core;
 mod counterattack;
 mod retreat;
 
+pub(crate) use core::attack_effect_ignores_opponent_active_effects;
 pub(crate) use core::can_evolve_into;
 pub(crate) use core::can_play_item;
 pub(crate) use core::can_play_support;
@@ -23,7 +24,6 @@ pub(crate) use core::on_evolve;
 pub(crate) use core::on_knockout;
 pub use core::to_playable_card;
 pub(crate) use core::DamageModifierContext;
-pub(crate) use core::DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT;
 pub(crate) use counterattack::get_counterattack_damage;
 pub(crate) use counterattack::should_poison_attacker;
 pub(crate) use retreat::can_retreat;

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -128,6 +128,8 @@ mod mega_camerupt_ex_test;
 mod mega_diancie_ex_test;
 #[path = "pokemon/mega_kangaskhan_double_punching_family_test.rs"]
 mod mega_kangaskhan_double_punching_family_test;
+#[path = "pokemon/mega_medicham_ex_test.rs"]
+mod mega_medicham_ex_test;
 #[path = "pokemon/mega_sceptile_terminating_tail_test.rs"]
 mod mega_sceptile_terminating_tail_test;
 #[path = "pokemon/mega_steelix_adamantine_rolling_test.rs"]

--- a/tests/pokemon/mega_medicham_ex_test.rs
+++ b/tests/pokemon/mega_medicham_ex_test.rs
@@ -82,3 +82,32 @@ fn test_mega_medicham_chakra_fist_bypasses_cloyster_shell_armor() {
     // Cloyster has 120 HP; Shell Armor would leave it at 30. Chakra Fist ignores it → 20.
     assert_eq!(state.get_active(1).get_remaining_hp(), 20);
 }
+
+/// Oricorio's "Safeguard" (`PreventAllDamageFromEx`) normally blocks all damage from a Pokémon ex
+/// (see `test_oricorio_safeguard_prevents_damage_from_ex_attack`). Mega Medicham ex is a Pokémon
+/// ex, but Chakra Fist ignores effects on the opponent's Active Pokémon, so Safeguard is bypassed
+/// and Oricorio (70 HP) still gets Knocked Out by the 100 damage — earning player 0 a point.
+#[test]
+fn test_mega_medicham_chakra_fist_damages_oricorio_through_safeguard() {
+    let mut game = get_test_game_with_board(
+        vec![medicham_with(vec![
+            EnergyType::Fighting,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+        ])],
+        // Bench a backup so the Knock Out doesn't end the game.
+        vec![
+            PlayedCard::from_id(CardId::A3066Oricorio),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&chakra_fist());
+
+    let state = game.get_state_clone();
+    // If Safeguard had prevented the damage, Oricorio would survive and no point would be scored.
+    assert_eq!(
+        state.points[0], 1,
+        "Chakra Fist must bypass Safeguard and Knock Out Oricorio"
+    );
+}

--- a/tests/pokemon/mega_medicham_ex_test.rs
+++ b/tests/pokemon/mega_medicham_ex_test.rs
@@ -1,0 +1,84 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+// Mega Medicham ex's "Chakra Fist" (base 100 damage):
+// "If this Pokémon has any [P] Energy attached, this attack does 40 more damage. This attack's
+// damage isn't affected by any effects on your opponent's Active Pokémon."
+//
+// The second clause is the same effect Sawk's "Brick Break" has, so Chakra Fist shares the
+// "ignore effects on the opponent's Active Pokémon" behavior. These tests drive the attack through
+// the public `Game` API and assert on the resulting HP.
+
+fn medicham_with(energy: Vec<EnergyType>) -> PlayedCard {
+    PlayedCard::from_id(CardId::PB029MegaMedichamEx).with_energy(energy)
+}
+
+fn chakra_fist() -> Action {
+    Action {
+        actor: 0,
+        action: attack_action(CardId::PB029MegaMedichamEx, 0),
+        is_stack: false,
+    }
+}
+
+/// With a [P] Energy attached, Chakra Fist does 100 + 40 = 140.
+#[test]
+fn test_mega_medicham_chakra_fist_psychic_bonus() {
+    let mut game = get_test_game_with_board(
+        vec![medicham_with(vec![
+            EnergyType::Fighting,
+            EnergyType::Colorless,
+            EnergyType::Psychic,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+
+    game.apply_action(&chakra_fist());
+
+    let state = game.get_state_clone();
+    // Venusaur ex has 190 HP (not weak to Fighting); 190 - 140 = 50.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 50);
+}
+
+/// Without any [P] Energy attached, Chakra Fist does its base 100.
+#[test]
+fn test_mega_medicham_chakra_fist_no_psychic_bonus() {
+    let mut game = get_test_game_with_board(
+        vec![medicham_with(vec![
+            EnergyType::Fighting,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+
+    game.apply_action(&chakra_fist());
+
+    let state = game.get_state_clone();
+    // 190 - 100 = 90.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 90);
+}
+
+/// Like Sawk's Brick Break, Chakra Fist ignores effects on the opponent's Active Pokémon.
+/// Cloyster's "Shell Armor" (`ReduceDamageFromAttacks{10}`) is bypassed: it takes the full 100.
+#[test]
+fn test_mega_medicham_chakra_fist_bypasses_cloyster_shell_armor() {
+    let mut game = get_test_game_with_board(
+        vec![medicham_with(vec![
+            EnergyType::Fighting,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1067Cloyster)],
+    );
+
+    game.apply_action(&chakra_fist());
+
+    let state = game.get_state_clone();
+    // Cloyster has 120 HP; Shell Armor would leave it at 30. Chakra Fist ignores it → 20.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 20);
+}


### PR DESCRIPTION
Chakra Fist does its base 100 damage, +40 more if the attacking Pokémon
has any [P] Energy attached, and its damage isn't affected by any effects
on the opponent's Active Pokémon.

The last clause is the same effect as Sawk's Brick Break, so the two share
the bypass path: the effect-text detection in `hooks` becomes a substring
match (via `attack_effect_ignores_opponent_active_effects`) instead of an
exact equality, letting Chakra Fist's combined effect text trigger it.

The [P]-Energy damage bonus is a new reusable `ExtraDamageIfSelfHasTypeEnergy`
mechanic, which also completes Medicham's (B2 084) "Psykick" attack.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01H7X5mDxuweV3kw68mXDjN3