### PR TITLE
Implement Securely Sheltered (Hisuian Goodra) and Guarded Grill (Bastiodon)

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -94,6 +94,13 @@ pub enum AbilityMechanic {
     InfiltratingInspection,
     DiscardTopCardOpponentDeck,
     CoinFlipToPreventDamage,
+    /// Bastiodon's Guarded Grill / Hisuian Goodra's Securely Sheltered: if any damage is done to
+    /// this Pokémon by attacks, flip a coin. If heads, this Pokémon takes `amount` less damage
+    /// from that attack. Passive; handled like `CoinFlipToPreventDamage` via the
+    /// abilities-as-effects pathway.
+    CoinFlipToReduceDamage {
+        amount: u32,
+    },
     /// Ursaluna's Guts: if this Pokémon would be Knocked Out by damage from an attack, flip a
     /// coin. If heads, it is not Knocked Out and its remaining HP becomes 10.
     CoinFlipToSurviveKnockOut,

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -153,6 +153,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::CoinFlipToPreventDamage => {
             panic!("CoinFlipToPreventDamage is a passive ability")
         }
+        AbilityMechanic::CoinFlipToReduceDamage { .. } => {
+            panic!("CoinFlipToReduceDamage is a passive ability")
+        }
         AbilityMechanic::CoinFlipToSurviveKnockOut => {
             panic!("CoinFlipToSurviveKnockOut is a passive ability")
         }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -115,26 +115,32 @@ fn apply_defender_damage_prevention_if_needed(
         attack_effect_ignores_opponent_active_effects(attack.effect.as_deref());
 
     // Collect every opponent in-play Pokémon (Active and Benched) presenting the
-    // CoinFlipToPreventIncomingDamage effect (e.g. Meowth's Carefree Steps). It applies
-    // independently to each such Pokémon, and the split only adds a coin flip for the ones that
-    // actually take damage.
+    // CoinFlipToPreventIncomingDamage effect (e.g. Meowth's Carefree Steps) or the
+    // CoinFlipToReduceIncomingDamage effect (e.g. Hisuian Goodra's Securely Sheltered), paired
+    // with the heads-flip damage reduction (u32::MAX = full prevention). It applies independently
+    // to each such Pokémon, and the split only adds a coin flip for the ones that actually take
+    // damage.
     let opponent = (acting_player + 1) % 2;
-    let prevented_indices: Vec<usize> = state
+    let reductions: Vec<(usize, u32)> = state
         .enumerate_in_play_pokemon(opponent)
         .filter(|(idx, _)| !(ignores_active_effects && *idx == 0))
-        .filter(|(_, pokemon)| {
+        .filter_map(|(idx, pokemon)| {
             pokemon
                 .get_effective_card_effects()
                 .iter()
-                .any(|e| matches!(e, CardEffect::CoinFlipToPreventIncomingDamage))
+                .find_map(|e| match e {
+                    CardEffect::CoinFlipToPreventIncomingDamage => Some(u32::MAX),
+                    CardEffect::CoinFlipToReduceIncomingDamage { amount } => Some(*amount),
+                    _ => None,
+                })
+                .map(|reduction| (idx, reduction))
         })
-        .map(|(idx, _)| idx)
         .collect();
 
-    if prevented_indices.is_empty() {
+    if reductions.is_empty() {
         return outcomes;
     }
-    outcomes.split_with_damage_prevention(&prevented_indices)
+    outcomes.split_with_damage_prevention(&reductions)
 }
 
 /// Apply the defender's Guts ability (e.g. Ursaluna): each opponent in-play Pokémon with the

--- a/src/actions/attack_outcome.rs
+++ b/src/actions/attack_outcome.rs
@@ -313,23 +313,26 @@ impl AttackOutcomes {
     }
 
     /// Apply the defender's "if any damage is done to this Pokémon by attacks, flip a coin; if
-    /// heads, prevent that damage" ability (e.g. Meowth's Carefree Steps) to each opponent
-    /// in-play slot in `prevented_indices`.
+    /// heads, prevent that damage / this Pokémon takes -X damage from that attack" ability
+    /// (e.g. Meowth's Carefree Steps, Bastiodon's Guarded Grill, Hisuian Goodra's Securely
+    /// Sheltered) to each opponent in-play slot in `reductions`. Each entry pairs the slot index
+    /// with the amount subtracted on heads — use `u32::MAX` for full prevention.
     ///
     /// The ability applies independently to each such Pokémon — whether Active or Benched — and
     /// only when it actually takes damage in a given branch. Each branch is therefore split into
     /// `2^k` sub-branches (where `k` is the number of those Pokémon taking damage in that branch),
-    /// one per combination of heads/tails, removing the damage to the Pokémon whose coin came up
-    /// heads while keeping all other damage and all effects. Coin metadata is dropped (these are
-    /// the defender's coins, not the acting player's).
-    pub fn split_with_damage_prevention(self, prevented_indices: &[usize]) -> Self {
+    /// one per combination of heads/tails, reducing (saturating at 0, at which point the damage
+    /// entry is removed) the damage to the Pokémon whose coin came up heads while keeping all
+    /// other damage and all effects. Coin metadata is dropped (these are the defender's coins,
+    /// not the acting player's).
+    pub fn split_with_damage_prevention(self, reductions: &[(usize, u32)]) -> Self {
         let mut branches = vec![];
         for branch in self.branches {
             // Only the protected Pokémon that actually take (>0) opponent damage flip a coin.
-            let flipping: Vec<usize> = prevented_indices
+            let flipping: Vec<(usize, u32)> = reductions
                 .iter()
                 .copied()
-                .filter(|target_idx| {
+                .filter(|(target_idx, _)| {
                     branch
                         .outcome
                         .damage
@@ -348,17 +351,29 @@ impl AttackOutcomes {
             let combos = 1usize << flipping.len();
             let sub_probability = branch.probability / combos as f64;
             for mask in 0..combos {
-                // The subset of flipping Pokémon whose coin came up heads (damage prevented).
-                let prevented_now: Vec<usize> = flipping
+                // The subset of flipping Pokémon whose coin came up heads (damage reduced).
+                let reduced_now: Vec<(usize, u32)> = flipping
                     .iter()
                     .enumerate()
                     .filter(|(bit, _)| (mask >> bit) & 1 == 1)
-                    .map(|(_, idx)| *idx)
+                    .map(|(_, pair)| *pair)
                     .collect();
                 let mut outcome = branch.outcome.clone();
-                outcome
+                outcome.damage = outcome
                     .damage
-                    .retain(|(_, is_opponent, idx)| !(*is_opponent && prevented_now.contains(idx)));
+                    .into_iter()
+                    .filter_map(|(amount, is_opponent, idx)| {
+                        if is_opponent {
+                            if let Some((_, reduction)) =
+                                reduced_now.iter().find(|(r_idx, _)| *r_idx == idx)
+                            {
+                                let reduced = amount.saturating_sub(*reduction);
+                                return (reduced > 0).then_some((reduced, is_opponent, idx));
+                            }
+                        }
+                        Some((amount, is_opponent, idx))
+                    })
+                    .collect();
                 branches.push(AttackBranch {
                     probability: sub_probability,
                     outcome,
@@ -606,7 +621,7 @@ mod tests {
     fn expected_damage_halves_under_active_damage_prevention() {
         let state = state_with_grimer_vs_meowth();
         let outcomes = AttackOutcomes::single(AttackOutcome::damage(vec![(20, true, 0)]))
-            .split_with_damage_prevention(&[0]);
+            .split_with_damage_prevention(&[(0, u32::MAX)]);
         // Heads branch (0.5) prevents the active damage, tails branch (0.5) deals 20.
         let expected = outcomes.expected_damage_to_opponent_active(&state, 0, None, None);
         assert!(

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -124,7 +124,14 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "If any damage is done to this Pokémon by attacks, flip a coin. If heads, prevent that damage.",
             AbilityMechanic::CoinFlipToPreventDamage,
         );
-        // map.insert("If any damage is done to this Pokémon by attacks, flip a coin. If heads, this Pokémon takes -100 damage from that attack.", todo_implementation);
+        map.insert(
+            "If any damage is done to this Pokémon by attacks, flip a coin. If heads, this Pokémon takes -100 damage from that attack.",
+            AbilityMechanic::CoinFlipToReduceDamage { amount: 100 },
+        );
+        map.insert(
+            "If any damage is done to this Pokémon by attacks, flip a coin. If heads, this Pokémon takes -80 damage from that attack.",
+            AbilityMechanic::CoinFlipToReduceDamage { amount: 80 },
+        );
         // map.insert("If this Pokémon has a Pokémon Tool attached, attacks used by this Pokémon cost 1 less [G] Energy.", todo_implementation);
         map.insert(
             "If this Pokémon has any Energy attached, it has no Retreat Cost.",
@@ -546,6 +553,9 @@ pub fn card_effect_from_ability_mechanic(mechanic: &AbilityMechanic) -> Option<C
         AbilityMechanic::PreventDamageWhileBenched => Some(CardEffect::PreventDamageWhileBenched),
         AbilityMechanic::CoinFlipToPreventDamage => {
             Some(CardEffect::CoinFlipToPreventIncomingDamage)
+        }
+        AbilityMechanic::CoinFlipToReduceDamage { amount } => {
+            Some(CardEffect::CoinFlipToReduceIncomingDamage { amount: *amount })
         }
         _ => None,
     }

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -68,6 +68,12 @@ pub enum CardEffect {
     /// (e.g. Meowth's Carefree Steps). Mirrors `CoinFlipToPreventDamage`. Distinct from
     /// `CoinFlipToBlockAttack`, which is an attacker self-debuff on the holder's own attacks.
     CoinFlipToPreventIncomingDamage,
+    /// If any damage is done to this Pokémon by attacks, flip a coin; on heads this Pokémon takes
+    /// `amount` less damage from that attack (e.g. Bastiodon's Guarded Grill, Hisuian Goodra's
+    /// Securely Sheltered). Mirrors `CoinFlipToReduceDamage`.
+    CoinFlipToReduceIncomingDamage {
+        amount: u32,
+    },
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -119,6 +119,7 @@ fn can_use_ability_by_mechanic(
             !card.ability_used && !state.decks[(state.current_player + 1) % 2].cards.is_empty()
         }
         AbilityMechanic::CoinFlipToPreventDamage => false, // Passive ability
+        AbilityMechanic::CoinFlipToReduceDamage { .. } => false, // Passive ability
         AbilityMechanic::CoinFlipToSurviveKnockOut => false, // Passive ability
         AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout { .. } => false, // Passive (on_knockout)
         AbilityMechanic::CheckupDamageToOpponentActive { .. } => false,       // Passive ability

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -74,6 +74,8 @@ mod growlithe_puppy_pile_test;
 mod hatterene_test;
 #[path = "pokemon/heracross_test.rs"]
 mod heracross_test;
+#[path = "pokemon/hisuian_goodra_securely_sheltered_test.rs"]
+mod hisuian_goodra_securely_sheltered_test;
 #[path = "pokemon/hisuian_lilligant_dress_up_test.rs"]
 mod hisuian_lilligant_dress_up_test;
 #[path = "pokemon/hisuian_zoroark_ex_test.rs"]

--- a/tests/pokemon/hisuian_goodra_securely_sheltered_test.rs
+++ b/tests/pokemon/hisuian_goodra_securely_sheltered_test.rs
@@ -1,0 +1,153 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Hisuian Goodra's "Securely Sheltered": "If any damage is done to this Pokémon by attacks,
+/// flip a coin. If heads, this Pokémon takes -80 damage from that attack."
+///
+/// A mirror Hisuian Goodra attacks with Heavy Impact (120 fixed damage). The defending Goodra
+/// (150 HP) either takes the full 120 (tails, 30 HP left) or 120-80=40 (heads, 110 HP left).
+/// Driving the attack across many seeds we must observe both branches, proving the reduction
+/// coin actually fires and reduces (rather than prevents) the damage.
+#[test]
+fn test_securely_sheltered_reduces_damage_on_heads() {
+    let mut saw_reduced = false;
+    let mut saw_full_damage = false;
+
+    for seed in 0..40u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![
+                PlayedCard::from_id(CardId::B3b050HisuianGoodra).with_energy(vec![
+                    EnergyType::Water,
+                    EnergyType::Metal,
+                    EnergyType::Water,
+                ]),
+            ],
+            vec![PlayedCard::from_id(CardId::B3b050HisuianGoodra)],
+        );
+
+        // Heavy Impact: 120 fixed damage, no effect.
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B3b050HisuianGoodra, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        match state.get_active(1).get_remaining_hp() {
+            110 => saw_reduced = true,    // Heads: 120 - 80 = 40 damage.
+            30 => saw_full_damage = true, // Tails: full 120 damage.
+            other => panic!("seed {seed}: unexpected defending Goodra HP {other}"),
+        }
+    }
+
+    assert!(
+        saw_reduced,
+        "expected at least one seed where Securely Sheltered reduced the damage by 80"
+    );
+    assert!(
+        saw_full_damage,
+        "expected at least one seed where the full damage went through"
+    );
+}
+
+/// When the incoming damage is 80 or less, a heads flip reduces it to 0 — but only the damage:
+/// secondary attack effects still land. Grimer's Poison Gas (10 damage + Poison) against
+/// Hisuian Goodra must always poison it, while its HP is either untouched (heads) or -10 (tails).
+#[test]
+fn test_securely_sheltered_floors_at_zero_and_keeps_attack_effects() {
+    let mut saw_no_damage = false;
+    let mut saw_damaged = false;
+
+    for seed in 0..40u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![PlayedCard::from_id(CardId::A1174Grimer).with_energy(vec![EnergyType::Darkness])],
+            vec![PlayedCard::from_id(CardId::B3b050HisuianGoodra)],
+        );
+
+        // Poison Gas: 10 damage and the opponent's Active Pokémon is now Poisoned.
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1174Grimer, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        let goodra = state.get_active(1);
+
+        assert!(
+            goodra.is_poisoned(),
+            "seed {seed}: Goodra should be Poisoned even when its damage is reduced to 0"
+        );
+
+        match goodra.get_remaining_hp() {
+            150 => saw_no_damage = true, // Heads: 10 - 80 floors at 0 damage.
+            140 => saw_damaged = true,   // Tails: 10 damage dealt.
+            other => panic!("seed {seed}: unexpected Goodra HP {other}"),
+        }
+    }
+
+    assert!(
+        saw_no_damage,
+        "expected at least one seed where the damage was reduced to nothing"
+    );
+    assert!(
+        saw_damaged,
+        "expected at least one seed where the damage went through"
+    );
+}
+
+/// Bastiodon's "Guarded Grill" shares the same effect template with -100 instead of -80.
+/// Heavy Impact's 120 becomes 20 on heads (140 HP left of 160) or stays 120 on tails (40 left).
+#[test]
+fn test_guarded_grill_reduces_damage_by_100() {
+    let mut saw_reduced = false;
+    let mut saw_full_damage = false;
+
+    for seed in 0..40u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![
+                PlayedCard::from_id(CardId::B3b050HisuianGoodra).with_energy(vec![
+                    EnergyType::Water,
+                    EnergyType::Metal,
+                    EnergyType::Water,
+                ]),
+            ],
+            vec![PlayedCard::from_id(CardId::A2114Bastiodon)],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B3b050HisuianGoodra, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        match state.get_active(1).get_remaining_hp() {
+            140 => saw_reduced = true,    // Heads: 120 - 100 = 20 damage.
+            40 => saw_full_damage = true, // Tails: full 120 damage.
+            other => panic!("seed {seed}: unexpected Bastiodon HP {other}"),
+        }
+    }
+
+    assert!(
+        saw_reduced,
+        "expected at least one seed where Guarded Grill reduced the damage by 100"
+    );
+    assert!(
+        saw_full_damage,
+        "expected at least one seed where the full damage went through"
+    );
+}


### PR DESCRIPTION
Implements the ability "Securely Sheltered" for Hisuian Goodra (B3b 050): "If any
damage is done to this Pokémon by attacks, flip a coin. If heads, this Pokémon
takes -80 damage from that attack."

Bastiodon (A2 114)'s "Guarded Grill" shares the same effect template with -100,
so this PR implements both.

## Approach

Generalizes the existing Carefree Steps pathway (`CoinFlipToPreventDamage`) into a
new `CoinFlipToReduceDamage { amount }` ability mechanic, exposed as a
`CoinFlipToReduceIncomingDamage` card effect. `split_with_damage_prevention` now
takes per-slot reduction amounts (`u32::MAX` = full prevention, so Meowth's
behavior is unchanged), saturating at 0 and dropping zeroed damage entries.

## Testing

- 3 new Game-level tests in `tests/pokemon/hisuian_goodra_securely_sheltered_test.rs`
  (written before the implementation, TDD per the implement-cards skill): heads/tails
  -80 reduction, floor-at-zero with secondary effects (Poison) still applying, and
  Bastiodon's -100.
- Full suite passes: `cargo test --features "tui test-utils"`
- `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` clean
- `cargo run --bin card_test -- "B3b 050"` and `-- "A2 114"`: 10,000 random games
  each, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017PU9WgvMbkcCu6vjQuDKxE