### PR TITLE
Refactor Guts ability to share logic between Attack and ApplyDamage paths

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -21,8 +21,8 @@ use crate::{
 
 use super::{
     apply_action_helpers::{
-        forecast_end_turn, guts_would_flip, handle_damage, handle_damage_only, handle_knockouts,
-        Mutations,
+        enumerate_guts_survivor_subsets, forecast_end_turn, guts_flipping_targets, handle_damage,
+        handle_damage_only, handle_knockouts, set_guts_survivors_to_10, Mutation, Mutations,
     },
     apply_attack_action::forecast_attack,
     apply_stadium_action::{self, forecast_use_stadium},
@@ -174,28 +174,16 @@ fn forecast_apply_damage(
     targets: &[(u32, usize, usize)],
     is_from_active_attack: bool,
 ) -> Outcomes {
-    // Sum raw damage per target (mirroring handle_damage_only) to find the Guts coin flips.
-    let mut damage_map: HashMap<(usize, usize), u32> = HashMap::new();
-    for (damage, player, idx) in targets {
-        *damage_map.entry((*player, *idx)).or_insert(0) += damage;
-    }
-    let flipping: Vec<(usize, usize)> = damage_map
-        .into_iter()
-        .filter(|(target, raw_total)| {
-            guts_would_flip(
-                state,
-                attacking_ref,
-                *raw_total,
-                *target,
-                is_from_active_attack,
-                DamageModifierContext {
-                    attack_name: None,
-                    attack_effect: None,
-                },
-            )
-        })
-        .map(|(target, _)| target)
-        .collect();
+    let flipping = guts_flipping_targets(
+        state,
+        attacking_ref,
+        targets,
+        is_from_active_attack,
+        DamageModifierContext {
+            attack_name: None,
+            attack_effect: None,
+        },
+    );
 
     if flipping.is_empty() {
         let targets = targets.to_vec();
@@ -206,36 +194,28 @@ fn forecast_apply_damage(
 
     // One branch per heads/tails combination; on heads the damage still applies (so on-damage
     // triggers fire) and the survivor's remaining HP is set to 10 before knockouts resolve.
-    let combos = 1usize << flipping.len();
-    let probabilities = vec![1.0 / combos as f64; combos];
-    let mut mutations: Mutations = vec![];
-    for mask in 0..combos {
-        let survivors: Vec<(usize, usize)> = flipping
-            .iter()
-            .enumerate()
-            .filter(|(bit, _)| (mask >> bit) & 1 == 1)
-            .map(|(_, target)| *target)
-            .collect();
-        let targets = targets.to_vec();
-        mutations.push(Box::new(move |_, state, _| {
-            handle_damage_only(
-                state,
-                attacking_ref,
-                &targets,
-                is_from_active_attack,
-                DamageModifierContext {
-                    attack_name: None,
-                    attack_effect: None,
-                },
-            );
-            for (player, idx) in &survivors {
-                if let Some(pokemon) = state.in_play_pokemon[*player][*idx].as_mut() {
-                    pokemon.set_remaining_hp(10);
-                }
-            }
-            handle_knockouts(state, attacking_ref, is_from_active_attack);
-        }));
-    }
+    let subsets = enumerate_guts_survivor_subsets(&flipping);
+    let probabilities = vec![1.0 / subsets.len() as f64; subsets.len()];
+    let mutations: Mutations = subsets
+        .into_iter()
+        .map(|survivors| {
+            let targets = targets.to_vec();
+            Box::new(move |_: &mut StdRng, state: &mut State, _: &Action| {
+                handle_damage_only(
+                    state,
+                    attacking_ref,
+                    &targets,
+                    is_from_active_attack,
+                    DamageModifierContext {
+                        attack_name: None,
+                        attack_effect: None,
+                    },
+                );
+                set_guts_survivors_to_10(state, &survivors);
+                handle_knockouts(state, attacking_ref, is_from_active_attack);
+            }) as Mutation
+        })
+        .collect();
     Outcomes::from_parts(probabilities, mutations)
 }
 

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -395,7 +395,7 @@ fn checkapply_prevent_first_attack(
 
 /// True if the Pokémon at `target` has the Guts ability and `raw_damage` (after modifiers)
 /// would knock it out — i.e. it should flip a Guts survival coin for this damage.
-pub(crate) fn guts_would_flip(
+fn guts_would_flip(
     state: &State,
     attacking_ref: (usize, usize),
     raw_damage: u32,
@@ -424,6 +424,65 @@ pub(crate) fn guts_would_flip(
     );
     let remaining = pokemon.get_remaining_hp();
     remaining > 0 && modified >= remaining
+}
+
+/// Sum raw damage per (player, idx) target and return the targets that must flip a Guts
+/// survival coin, sorted for deterministic branch ordering.
+pub(crate) fn guts_flipping_targets(
+    state: &State,
+    attacking_ref: (usize, usize),
+    targets: &[(u32, usize, usize)], // damage, target_player, in_play_idx
+    is_from_active_attack: bool,
+    context: DamageModifierContext<'_>,
+) -> Vec<(usize, usize)> {
+    // Sum raw damage per target (mirroring handle_damage_only) to find the Guts coin flips.
+    let mut damage_map: HashMap<(usize, usize), u32> = HashMap::new();
+    for (damage, player, idx) in targets {
+        *damage_map.entry((*player, *idx)).or_insert(0) += damage;
+    }
+    let mut flipping: Vec<(usize, usize)> = damage_map
+        .into_iter()
+        .filter(|(target, raw_total)| {
+            guts_would_flip(
+                state,
+                attacking_ref,
+                *raw_total,
+                *target,
+                is_from_active_attack,
+                context,
+            )
+        })
+        .map(|(target, _)| target)
+        .collect();
+    flipping.sort_unstable();
+    flipping
+}
+
+/// All `2^k` equally likely survivor subsets of `flipping` (`k = flipping.len()`), in mask
+/// order (bit `i` of the mask set => `flipping[i]` survives its Guts coin flip).
+pub(crate) fn enumerate_guts_survivor_subsets<T: Copy>(flipping: &[T]) -> Vec<Vec<T>> {
+    let combos = 1usize << flipping.len();
+    (0..combos)
+        .map(|mask| {
+            flipping
+                .iter()
+                .enumerate()
+                .filter(|(bit, _)| (mask >> bit) & 1 == 1)
+                .map(|(_, target)| *target)
+                .collect()
+        })
+        .collect()
+}
+
+/// Set each Guts survivor's remaining HP to exactly 10. Must run after damage application
+/// (so on-damage triggers like Rocky Helmet's counterattack fired) and before knockouts
+/// are resolved.
+pub(crate) fn set_guts_survivors_to_10(state: &mut State, survivors: &[(usize, usize)]) {
+    for (player, idx) in survivors {
+        if let Some(pokemon) = state.in_play_pokemon[*player][*idx].as_mut() {
+            pokemon.set_remaining_hp(10);
+        }
+    }
 }
 
 /// This function applies damage (with modifiers and counterattacks) and handles K.O.s

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -147,20 +147,18 @@ fn apply_defender_guts_if_needed(
     outcomes: AttackOutcomes,
 ) -> AttackOutcomes {
     let opponent = (acting_player + 1) % 2;
-    let guts_indices: Vec<usize> = state
+    let any_guts = state
         .enumerate_in_play_pokemon(opponent)
-        .filter(|(_, pokemon)| {
+        .any(|(_, pokemon)| {
             pokemon
                 .card
                 .get_ability()
                 .and_then(|a| ability_mechanic_from_effect(&a.effect))
                 .map(|m| matches!(m, AbilityMechanic::CoinFlipToSurviveKnockOut))
                 .unwrap_or(false)
-        })
-        .map(|(idx, _)| idx)
-        .collect();
+        });
 
-    if guts_indices.is_empty() {
+    if !any_guts {
         return outcomes;
     }
     outcomes.split_with_guts_survival(
@@ -168,7 +166,6 @@ fn apply_defender_guts_if_needed(
         acting_player,
         Some(&attack.title),
         attack.effect.as_deref(),
-        &guts_indices,
     )
 }
 

--- a/src/actions/attack_outcome.rs
+++ b/src/actions/attack_outcome.rs
@@ -6,7 +6,8 @@ use crate::hooks::{modify_damage, DamageModifierContext};
 use crate::State;
 
 use super::apply_action_helpers::{
-    guts_would_flip, handle_damage_only, handle_knockouts, Mutation, Probabilities,
+    enumerate_guts_survivor_subsets, guts_flipping_targets, handle_damage_only, handle_knockouts,
+    set_guts_survivors_to_10, Mutation, Probabilities,
 };
 use super::outcomes::{generate_sequences_with_heads, CoinPaths, CoinSeq, Outcomes};
 use super::{Action, SimpleAction};
@@ -38,6 +39,10 @@ pub struct AttackOutcome {
     pre_damage_effect: Option<SharedEffect>,
     /// Effect that runs after damage is applied (the common case: status, energy moves, etc.).
     post_damage_effect: Option<SharedEffect>,
+    /// Opponent in-play indices of Guts Pokémon that survive this outcome's lethal damage
+    /// (their coin came up heads): after damage is applied their remaining HP is set to 10,
+    /// before knockouts are resolved. Populated by `split_with_guts_survival`.
+    guts_survivors: Vec<usize>,
 }
 
 impl AttackOutcome {
@@ -47,6 +52,7 @@ impl AttackOutcome {
             damage: vec![],
             pre_damage_effect: None,
             post_damage_effect: None,
+            guts_survivors: vec![],
         }
     }
 
@@ -56,6 +62,7 @@ impl AttackOutcome {
             damage: targets,
             pre_damage_effect: None,
             post_damage_effect: None,
+            guts_survivors: vec![],
         }
     }
 
@@ -68,6 +75,7 @@ impl AttackOutcome {
             damage: targets,
             pre_damage_effect: None,
             post_damage_effect: Some(Rc::new(effect)),
+            guts_survivors: vec![],
         }
     }
 
@@ -80,6 +88,7 @@ impl AttackOutcome {
             damage: targets,
             pre_damage_effect: Some(Rc::new(effect)),
             post_damage_effect: None,
+            guts_survivors: vec![],
         }
     }
 
@@ -92,6 +101,7 @@ impl AttackOutcome {
             damage: vec![],
             pre_damage_effect: None,
             post_damage_effect: Some(Rc::new(effect)),
+            guts_survivors: vec![],
         }
     }
 
@@ -108,7 +118,8 @@ impl AttackOutcome {
     }
 
     /// Convert this structured outcome into a `Mutation` that applies it to the state:
-    /// pre-effect, then damage (with modifiers/counterattacks), then post-effect, then knockouts.
+    /// pre-effect, then damage (with modifiers/counterattacks), then Guts survival,
+    /// then post-effect, then knockouts.
     fn into_mutation(self) -> Mutation {
         Box::new(move |rng, state, action| {
             let attacking_ref = (action.actor, 0);
@@ -130,6 +141,17 @@ impl AttackOutcome {
                         attack_effect: attack_metadata.effect.as_deref(),
                     },
                 );
+            }
+
+            if !self.guts_survivors.is_empty() {
+                debug_assert!(!resolved.is_empty(), "Guts survivors require lethal damage");
+                let opponent = (action.actor + 1) % 2;
+                let survivors: Vec<(usize, usize)> = self
+                    .guts_survivors
+                    .iter()
+                    .map(|idx| (opponent, *idx))
+                    .collect();
+                set_guts_survivors_to_10(state, &survivors);
             }
 
             if let Some(post) = &self.post_damage_effect {
@@ -285,6 +307,7 @@ impl AttackOutcomes {
                         damage: vec![],
                         pre_damage_effect: None,
                         post_damage_effect: Some(effect),
+                        guts_survivors: vec![],
                     },
                     coin_paths,
                 }
@@ -389,67 +412,41 @@ impl AttackOutcomes {
         acting_player: usize,
         attack_name: Option<&str>,
         attack_effect: Option<&str>,
-        guts_indices: &[usize],
     ) -> Self {
         let opponent = (acting_player + 1) % 2;
         let mut branches = vec![];
         for branch in self.branches {
-            // Only the Guts Pokémon that would be knocked out by this branch's damage flip a coin.
-            let flipping: Vec<usize> = guts_indices
+            // Only the Guts Pokémon that would be knocked out by this branch's damage flip a
+            // coin. Guts applies to the defender here, so only opponent-side damage is
+            // considered (unlike the ApplyDamage path, which supports arbitrary targets).
+            let resolved: Vec<(u32, usize, usize)> = branch
+                .outcome
+                .damage
                 .iter()
-                .copied()
-                .filter(|target_idx| {
-                    let raw_total: u32 = branch
-                        .outcome
-                        .damage
-                        .iter()
-                        .filter(|(_, is_opponent, idx)| *is_opponent && idx == target_idx)
-                        .map(|(amount, _, _)| *amount)
-                        .sum();
-                    guts_would_flip(
-                        state,
-                        (acting_player, 0),
-                        raw_total,
-                        (opponent, *target_idx),
-                        true,
-                        DamageModifierContext {
-                            attack_name,
-                            attack_effect,
-                        },
-                    )
-                })
+                .filter(|(_, is_opponent, _)| *is_opponent)
+                .map(|(amount, _, idx)| (*amount, opponent, *idx))
                 .collect();
+            let flipping = guts_flipping_targets(
+                state,
+                (acting_player, 0),
+                &resolved,
+                true,
+                DamageModifierContext {
+                    attack_name,
+                    attack_effect,
+                },
+            );
 
             if flipping.is_empty() {
                 branches.push(branch);
                 continue;
             }
 
-            let combos = 1usize << flipping.len();
-            let sub_probability = branch.probability / combos as f64;
-            for mask in 0..combos {
-                // The subset of flipping Pokémon whose coin came up heads (survive at 10 HP).
-                let survivors: Vec<usize> = flipping
-                    .iter()
-                    .enumerate()
-                    .filter(|(bit, _)| (mask >> bit) & 1 == 1)
-                    .map(|(_, idx)| *idx)
-                    .collect();
+            let subsets = enumerate_guts_survivor_subsets(&flipping);
+            let sub_probability = branch.probability / subsets.len() as f64;
+            for survivors in subsets {
                 let mut outcome = branch.outcome.clone();
-                if !survivors.is_empty() {
-                    let previous_post = outcome.post_damage_effect.take();
-                    outcome.post_damage_effect = Some(Rc::new(move |rng, state, action| {
-                        let opponent = (action.actor + 1) % 2;
-                        for idx in &survivors {
-                            if let Some(pokemon) = state.in_play_pokemon[opponent][*idx].as_mut() {
-                                pokemon.set_remaining_hp(10);
-                            }
-                        }
-                        if let Some(post) = &previous_post {
-                            post(rng, state, action);
-                        }
-                    }));
-                }
+                outcome.guts_survivors = survivors.into_iter().map(|(_, idx)| idx).collect();
                 branches.push(AttackBranch {
                     probability: sub_probability,
                     outcome,

--- a/tests/pokemon/ursaluna_guts_test.rs
+++ b/tests/pokemon/ursaluna_guts_test.rs
@@ -180,6 +180,54 @@ fn test_guts_flips_again_on_kangaskhans_second_punch() {
     assert!(saw_knocked_out);
 }
 
+/// Guts flips independently for each Pokémon facing lethal damage in the same attack:
+/// Lurantis's Petal Blizzard (20 to each of the opponent's Pokémon) against two Ursalunas at
+/// 20 HP must produce every survivor count (0, 1 and 2), with each survivor at exactly 10 HP.
+#[test]
+fn test_guts_flips_independently_for_each_pokemon_in_spread_attack() {
+    let mut seen_survivor_counts = [false; 3];
+
+    for seed in 0..60u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![PlayedCard::from_id(CardId::A3015Lurantis).with_energy(vec![EnergyType::Grass])],
+            vec![
+                PlayedCard::from_id(CardId::B3b058Ursaluna).with_remaining_hp(20),
+                PlayedCard::from_id(CardId::B3b058Ursaluna).with_remaining_hp(20),
+            ],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A3015Lurantis, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        let survivors: Vec<_> = state.enumerate_in_play_pokemon(1).collect();
+        for (idx, pokemon) in &survivors {
+            assert_eq!(
+                pokemon.get_remaining_hp(),
+                10,
+                "seed {seed}: surviving Ursaluna at slot {idx} should be at exactly 10 HP"
+            );
+        }
+        assert_eq!(
+            state.points[0] as usize,
+            2 - survivors.len(),
+            "seed {seed}: each Knocked Out Ursaluna should award a point"
+        );
+        seen_survivor_counts[survivors.len()] = true;
+    }
+
+    assert!(
+        seen_survivor_counts.iter().all(|seen| *seen),
+        "expected seeds where 0, 1 and 2 Ursalunas survive, saw {seen_survivor_counts:?}"
+    );
+}
+
 /// Non-lethal damage must not trigger the Guts coin flip: damage should apply normally on
 /// every seed.
 #[test]


### PR DESCRIPTION
Both forecast_apply_damage and split_with_guts_survival duplicated the
per-target flip detection, the 2^k heads/tails survivor-subset
enumeration, and the set-survivors-to-10-HP step. Extract these into
shared helpers in apply_action_helpers (guts_flipping_targets,
enumerate_guts_survivor_subsets, set_guts_survivors_to_10) and make
guts_would_flip private to that module.

The Attack path now records survivors as an explicit guts_survivors
field on AttackOutcome instead of a prepended post_damage_effect
closure, so into_mutation runs the same named sequence as the
ApplyDamage path: handle_damage_only -> set_guts_survivors_to_10 ->
handle_knockouts. split_with_guts_survival becomes a purely structural
transform (symmetric with split_with_damage_prevention) and no longer
needs the pre-collected guts_indices; its call site only does a boolean
any-Guts early-exit.

Add a multi-Guts regression test: Lurantis's Petal Blizzard against two
Ursalunas at 20 HP, asserting independent flips produce every survivor
count with survivors at exactly 10 HP.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01DieWrETiS5b1FhpqTdBDBQ