### PR TITLE
Implement Galarian Cursola's Perish Body ability

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -97,6 +97,11 @@ pub enum AbilityMechanic {
     /// Ursaluna's Guts: if this Pokémon would be Knocked Out by damage from an attack, flip a
     /// coin. If heads, it is not Knocked Out and its remaining HP becomes 10.
     CoinFlipToSurviveKnockOut,
+    /// Galarian Cursola's Perish Body: if this Pokémon is in the Active Spot and is Knocked Out
+    /// by damage from an attack from your opponent's Pokémon, flip a coin. If heads, the
+    /// Attacking Pokémon is Knocked Out. Passive; modeled as probability branches at the
+    /// `AttackOutcomes`/forecast layer (no RNG is available in the knockout hooks).
+    CoinFlipToKnockOutAttackerOnKnockOut,
     /// Passimian ex's Offload Pass: if this Pokémon is in the Active Spot and is Knocked Out by
     /// damage from an opponent's attack, move all of its `energy_type` Energy to 1 of your Benched
     /// Pokémon (your choice). Passive; handled in the `on_knockout` hook.

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -156,6 +156,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::CoinFlipToSurviveKnockOut => {
             panic!("CoinFlipToSurviveKnockOut is a passive ability")
         }
+        AbilityMechanic::CoinFlipToKnockOutAttackerOnKnockOut => {
+            panic!("CoinFlipToKnockOutAttackerOnKnockOut is a passive ability")
+        }
         AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout { .. } => {
             panic!("MoveAllTypedEnergyToBenchOnKnockout is a passive ability")
         }

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -22,7 +22,8 @@ use crate::{
 use super::{
     apply_action_helpers::{
         enumerate_guts_survivor_subsets, forecast_end_turn, guts_flipping_targets, handle_damage,
-        handle_damage_only, handle_knockouts, set_guts_survivors_to_10, Mutation, Mutations,
+        handle_damage_only, handle_knockouts, knock_out_attacker_for_perish_body,
+        perish_body_flips, set_guts_survivors_to_10, Mutation, Mutations,
     },
     apply_attack_action::forecast_attack,
     apply_stadium_action::{self, forecast_use_stadium},
@@ -174,48 +175,73 @@ fn forecast_apply_damage(
     targets: &[(u32, usize, usize)],
     is_from_active_attack: bool,
 ) -> Outcomes {
+    let context = DamageModifierContext {
+        attack_name: None,
+        attack_effect: None,
+    };
     let flipping = guts_flipping_targets(
         state,
         attacking_ref,
         targets,
         is_from_active_attack,
-        DamageModifierContext {
-            attack_name: None,
-            attack_effect: None,
-        },
+        context,
+    );
+    let perish = perish_body_flips(
+        state,
+        attacking_ref,
+        targets,
+        is_from_active_attack,
+        context,
     );
 
-    if flipping.is_empty() {
+    if flipping.is_empty() && !perish {
         let targets = targets.to_vec();
         return Outcomes::single_fn(move |_, state, _| {
             handle_damage(state, attacking_ref, &targets, is_from_active_attack, None);
         });
     }
 
-    // One branch per heads/tails combination; on heads the damage still applies (so on-damage
-    // triggers fire) and the survivor's remaining HP is set to 10 before knockouts resolve.
+    // One branch per heads/tails combination (Guts flips are independent of the defender's
+    // Perish Body flip); on heads the damage still applies (so on-damage triggers fire) and
+    // the Guts survivor's remaining HP is set to 10 before knockouts resolve, while a Perish
+    // Body heads knocks out the attacker after knockouts resolve.
     let subsets = enumerate_guts_survivor_subsets(&flipping);
-    let probabilities = vec![1.0 / subsets.len() as f64; subsets.len()];
-    let mutations: Mutations = subsets
-        .into_iter()
-        .map(|survivors| {
+    let perish_options: &[bool] = if perish { &[true, false] } else { &[false] };
+    let combos = subsets.len() * perish_options.len();
+    let probabilities = vec![1.0 / combos as f64; combos];
+    let mut mutations: Mutations = vec![];
+    for survivors in subsets {
+        for perish_heads in perish_options.iter().copied() {
+            let survivors = survivors.clone();
             let targets = targets.to_vec();
-            Box::new(move |_: &mut StdRng, state: &mut State, _: &Action| {
-                handle_damage_only(
-                    state,
-                    attacking_ref,
-                    &targets,
-                    is_from_active_attack,
-                    DamageModifierContext {
-                        attack_name: None,
-                        attack_effect: None,
-                    },
-                );
-                set_guts_survivors_to_10(state, &survivors);
-                handle_knockouts(state, attacking_ref, is_from_active_attack);
-            }) as Mutation
-        })
-        .collect();
+            mutations.push(
+                Box::new(move |_: &mut StdRng, state: &mut State, _: &Action| {
+                    handle_damage_only(
+                        state,
+                        attacking_ref,
+                        &targets,
+                        is_from_active_attack,
+                        DamageModifierContext {
+                            attack_name: None,
+                            attack_effect: None,
+                        },
+                    );
+                    set_guts_survivors_to_10(state, &survivors);
+                    // Perish Body only fires if the defending Active Pokémon actually got knocked
+                    // out; capture that before `handle_knockouts` discards it.
+                    let defender = (attacking_ref.0 + 1) % 2;
+                    let perish_armed = perish_heads
+                        && state.in_play_pokemon[defender][0]
+                            .as_ref()
+                            .is_some_and(|pokemon| pokemon.is_knocked_out());
+                    handle_knockouts(state, attacking_ref, is_from_active_attack);
+                    if perish_armed {
+                        knock_out_attacker_for_perish_body(state, attacking_ref);
+                    }
+                }) as Mutation,
+            );
+        }
+    }
     Outcomes::from_parts(probabilities, mutations)
 }
 

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -485,6 +485,80 @@ pub(crate) fn set_guts_survivors_to_10(state: &mut State, survivors: &[(usize, u
     }
 }
 
+/// True if the Pokémon in the attacker's opponent's Active Spot has the Perish Body ability
+/// and `raw_damage` (after modifiers) from an opponent's attack would knock it out — i.e. it
+/// should flip a Perish Body coin for this damage.
+fn perish_body_would_flip(
+    state: &State,
+    attacking_ref: (usize, usize),
+    raw_damage: u32,
+    is_from_active_attack: bool,
+    context: DamageModifierContext<'_>,
+) -> bool {
+    if !is_from_active_attack || raw_damage == 0 {
+        return false;
+    }
+    let target = ((attacking_ref.0 + 1) % 2, 0);
+    let Some(pokemon) = state.in_play_pokemon[target.0][target.1].as_ref() else {
+        return false;
+    };
+    if !matches!(
+        get_ability_mechanic(&pokemon.card),
+        Some(AbilityMechanic::CoinFlipToKnockOutAttackerOnKnockOut)
+    ) {
+        return false;
+    }
+    let modified = modify_damage(
+        state,
+        attacking_ref,
+        (raw_damage, target.0, target.1),
+        is_from_active_attack,
+        context,
+    );
+    let remaining = pokemon.get_remaining_hp();
+    remaining > 0 && modified >= remaining
+}
+
+/// Whether `targets` deal lethal attack damage to a Perish Body Pokémon in the attacker's
+/// opponent's Active Spot, requiring a Perish Body coin flip.
+pub(crate) fn perish_body_flips(
+    state: &State,
+    attacking_ref: (usize, usize),
+    targets: &[(u32, usize, usize)], // damage, target_player, in_play_idx
+    is_from_active_attack: bool,
+    context: DamageModifierContext<'_>,
+) -> bool {
+    let defender = (attacking_ref.0 + 1) % 2;
+    let raw_total: u32 = targets
+        .iter()
+        .filter(|(_, player, idx)| *player == defender && *idx == 0)
+        .map(|(damage, _, _)| *damage)
+        .sum();
+    perish_body_would_flip(
+        state,
+        attacking_ref,
+        raw_total,
+        is_from_active_attack,
+        context,
+    )
+}
+
+/// Perish Body heads: knock out the Attacking Pokémon. This is an ability knockout, not
+/// attack damage, so knockouts are resolved with `is_from_active_attack: false` — points,
+/// promotions and win checks run normally, but attack-only triggers (Lucky Egg, Offload
+/// Pass, counterattacks, etc.) do not fire. No-ops if the attacker is already gone (e.g.
+/// a counterattack knocked it out) or the game is already decided.
+pub(crate) fn knock_out_attacker_for_perish_body(state: &mut State, attacking_ref: (usize, usize)) {
+    if state.winner.is_some() {
+        return;
+    }
+    let Some(attacker) = state.in_play_pokemon[attacking_ref.0][attacking_ref.1].as_mut() else {
+        return;
+    };
+    attacker.set_remaining_hp(0);
+    handle_knockouts(state, ((attacking_ref.0 + 1) % 2, 0), false);
+}
+
 /// This function applies damage (with modifiers and counterattacks) and handles K.O.s
 /// and promotions.
 pub(crate) fn handle_damage(

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -89,7 +89,8 @@ fn apply_attack_common_modifiers(
     }
 
     outcomes = apply_defender_damage_prevention_if_needed(acting_player, state, attack, outcomes);
-    apply_defender_guts_if_needed(acting_player, state, attack, outcomes)
+    outcomes = apply_defender_guts_if_needed(acting_player, state, attack, outcomes);
+    apply_defender_perish_body_if_needed(acting_player, state, attack, outcomes)
 }
 
 fn apply_copied_attack_modifiers(
@@ -100,7 +101,8 @@ fn apply_copied_attack_modifiers(
 ) -> AttackOutcomes {
     let outcomes =
         apply_defender_damage_prevention_if_needed(acting_player, state, attack, base_outcomes);
-    apply_defender_guts_if_needed(acting_player, state, attack, outcomes)
+    let outcomes = apply_defender_guts_if_needed(acting_player, state, attack, outcomes);
+    apply_defender_perish_body_if_needed(acting_player, state, attack, outcomes)
 }
 
 fn apply_defender_damage_prevention_if_needed(
@@ -162,6 +164,34 @@ fn apply_defender_guts_if_needed(
         return outcomes;
     }
     outcomes.split_with_guts_survival(
+        state,
+        acting_player,
+        Some(&attack.title),
+        attack.effect.as_deref(),
+    )
+}
+
+/// Apply the defender's Perish Body ability (e.g. Galarian Cursola): if this attack's damage
+/// would knock out the opponent's Active Pokémon and it has the ability, it flips a coin; on
+/// heads the Attacking Pokémon is Knocked Out after the knockout resolves.
+fn apply_defender_perish_body_if_needed(
+    acting_player: usize,
+    state: &State,
+    attack: &Attack,
+    outcomes: AttackOutcomes,
+) -> AttackOutcomes {
+    let opponent = (acting_player + 1) % 2;
+    let has_perish_body = state.in_play_pokemon[opponent][0]
+        .as_ref()
+        .and_then(|pokemon| pokemon.card.get_ability())
+        .and_then(|a| ability_mechanic_from_effect(&a.effect))
+        .map(|m| matches!(m, AbilityMechanic::CoinFlipToKnockOutAttackerOnKnockOut))
+        .unwrap_or(false);
+
+    if !has_perish_body {
+        return outcomes;
+    }
+    outcomes.split_with_perish_body(
         state,
         acting_player,
         Some(&attack.title),

--- a/src/actions/attack_outcome.rs
+++ b/src/actions/attack_outcome.rs
@@ -7,7 +7,8 @@ use crate::State;
 
 use super::apply_action_helpers::{
     enumerate_guts_survivor_subsets, guts_flipping_targets, handle_damage_only, handle_knockouts,
-    set_guts_survivors_to_10, Mutation, Probabilities,
+    knock_out_attacker_for_perish_body, perish_body_flips, set_guts_survivors_to_10, Mutation,
+    Probabilities,
 };
 use super::outcomes::{generate_sequences_with_heads, CoinPaths, CoinSeq, Outcomes};
 use super::{Action, SimpleAction};
@@ -43,6 +44,10 @@ pub struct AttackOutcome {
     /// (their coin came up heads): after damage is applied their remaining HP is set to 10,
     /// before knockouts are resolved. Populated by `split_with_guts_survival`.
     guts_survivors: Vec<usize>,
+    /// Whether the defender's Perish Body coin came up heads in this outcome: after the
+    /// defending Active Pokémon's knockout resolves, the Attacking Pokémon is Knocked Out
+    /// too. Populated by `split_with_perish_body`.
+    perish_body_ko_attacker: bool,
 }
 
 impl AttackOutcome {
@@ -53,6 +58,7 @@ impl AttackOutcome {
             pre_damage_effect: None,
             post_damage_effect: None,
             guts_survivors: vec![],
+            perish_body_ko_attacker: false,
         }
     }
 
@@ -63,6 +69,7 @@ impl AttackOutcome {
             pre_damage_effect: None,
             post_damage_effect: None,
             guts_survivors: vec![],
+            perish_body_ko_attacker: false,
         }
     }
 
@@ -76,6 +83,7 @@ impl AttackOutcome {
             pre_damage_effect: None,
             post_damage_effect: Some(Rc::new(effect)),
             guts_survivors: vec![],
+            perish_body_ko_attacker: false,
         }
     }
 
@@ -89,6 +97,7 @@ impl AttackOutcome {
             pre_damage_effect: Some(Rc::new(effect)),
             post_damage_effect: None,
             guts_survivors: vec![],
+            perish_body_ko_attacker: false,
         }
     }
 
@@ -102,6 +111,7 @@ impl AttackOutcome {
             pre_damage_effect: None,
             post_damage_effect: Some(Rc::new(effect)),
             guts_survivors: vec![],
+            perish_body_ko_attacker: false,
         }
     }
 
@@ -162,7 +172,17 @@ impl AttackOutcome {
             // rely on the catch-all knockout pass in `wrap_with_common_logic`, matching the
             // historical behavior of effect-only outcomes.
             if !resolved.is_empty() {
+                // Perish Body only fires if the defending Active Pokémon actually got knocked
+                // out; capture that before `handle_knockouts` discards it.
+                let opponent = (action.actor + 1) % 2;
+                let perish_armed = self.perish_body_ko_attacker
+                    && state.in_play_pokemon[opponent][0]
+                        .as_ref()
+                        .is_some_and(|pokemon| pokemon.is_knocked_out());
                 handle_knockouts(state, attacking_ref, true);
+                if perish_armed {
+                    knock_out_attacker_for_perish_body(state, attacking_ref);
+                }
             }
         })
     }
@@ -308,6 +328,7 @@ impl AttackOutcomes {
                         pre_damage_effect: None,
                         post_damage_effect: Some(effect),
                         guts_survivors: vec![],
+                        perish_body_ko_attacker: false,
                     },
                     coin_paths,
                 }
@@ -447,6 +468,61 @@ impl AttackOutcomes {
             for survivors in subsets {
                 let mut outcome = branch.outcome.clone();
                 outcome.guts_survivors = survivors.into_iter().map(|(_, idx)| idx).collect();
+                branches.push(AttackBranch {
+                    probability: sub_probability,
+                    outcome,
+                    coin_paths: CoinPaths::None,
+                });
+            }
+        }
+        Self { branches }
+    }
+
+    /// Apply the defender's "if this Pokémon is in the Active Spot and is Knocked Out by
+    /// damage from an attack from your opponent's Pokémon, flip a coin; if heads, the
+    /// Attacking Pokémon is Knocked Out" ability (e.g. Galarian Cursola's Perish Body).
+    ///
+    /// Each branch whose (modified) damage would knock out the defending Active Pokémon is
+    /// split 50/50: on heads the attacker is Knocked Out after the defender's knockout
+    /// resolves (see `into_mutation`). Coin metadata is dropped (these are the defender's
+    /// coins, not the acting player's).
+    pub fn split_with_perish_body(
+        self,
+        state: &State,
+        acting_player: usize,
+        attack_name: Option<&str>,
+        attack_effect: Option<&str>,
+    ) -> Self {
+        let opponent = (acting_player + 1) % 2;
+        let mut branches = vec![];
+        for branch in self.branches {
+            let resolved: Vec<(u32, usize, usize)> = branch
+                .outcome
+                .damage
+                .iter()
+                .filter(|(_, is_opponent, _)| *is_opponent)
+                .map(|(amount, _, idx)| (*amount, opponent, *idx))
+                .collect();
+            let flips = perish_body_flips(
+                state,
+                (acting_player, 0),
+                &resolved,
+                true,
+                DamageModifierContext {
+                    attack_name,
+                    attack_effect,
+                },
+            );
+
+            if !flips {
+                branches.push(branch);
+                continue;
+            }
+
+            let sub_probability = branch.probability / 2.0;
+            for heads in [true, false] {
+                let mut outcome = branch.outcome.clone();
+                outcome.perish_body_ko_attacker = heads;
                 branches.push(AttackBranch {
                     probability: sub_probability,
                     outcome,

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -133,7 +133,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
         // map.insert("If this Pokémon has full HP, it takes -40 damage from attacks from your opponent's Pokémon.", todo_implementation);
         // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, do 10 damage to each of your opponent's Pokémon.", todo_implementation);
         // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, do 50 damage to the Attacking Pokémon.", todo_implementation);
-        // map.insert("If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, flip a coin. If heads, the Attacking Pokémon is Knocked Out.", todo_implementation);
+        map.insert(
+            "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, flip a coin. If heads, the Attacking Pokémon is Knocked Out.",
+            AbilityMechanic::CoinFlipToKnockOutAttackerOnKnockOut,
+        );
         map.insert(
             "If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, move all [F] Energy from this Pokémon to 1 of your Benched Pokémon.",
             AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout {

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -120,6 +120,7 @@ fn can_use_ability_by_mechanic(
         }
         AbilityMechanic::CoinFlipToPreventDamage => false, // Passive ability
         AbilityMechanic::CoinFlipToSurviveKnockOut => false, // Passive ability
+        AbilityMechanic::CoinFlipToKnockOutAttackerOnKnockOut => false, // Passive ability
         AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout { .. } => false, // Passive (on_knockout)
         AbilityMechanic::CheckupDamageToOpponentActive { .. } => false,       // Passive ability
         AbilityMechanic::CheckupDamageToAllOpponentPokemon { .. } => false,   // Passive ability

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -62,6 +62,8 @@ mod emolga_dedenne_ex_tool_damage_test;
 mod flutter_mane_ex_test;
 #[path = "pokemon/flygon_ex_test.rs"]
 mod flygon_ex_test;
+#[path = "pokemon/galarian_cursola_perish_body_test.rs"]
+mod galarian_cursola_perish_body_test;
 #[path = "pokemon/gallade_test.rs"]
 mod gallade_test;
 #[path = "pokemon/gardevoir_psy_turbo_test.rs"]

--- a/tests/pokemon/galarian_cursola_perish_body_test.rs
+++ b/tests/pokemon/galarian_cursola_perish_body_test.rs
@@ -1,0 +1,270 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Galarian Cursola's "Perish Body": "If this Pokémon is in the Active Spot and is Knocked Out
+/// by damage from an attack from your opponent's Pokémon, flip a coin. If heads, the Attacking
+/// Pokémon is Knocked Out."
+///
+/// We drive a lethal attack across many RNG seeds and assert that the attacker is sometimes
+/// Knocked Out in return (heads) and sometimes survives (tails), while Cursola is Knocked Out
+/// and scores for the attacker on every seed.
+#[test]
+fn test_perish_body_flips_on_lethal_active_ko() {
+    let mut saw_attacker_knocked_out = false;
+    let mut saw_attacker_survived = false;
+
+    for seed in 0..40u64 {
+        // Bulbasaur's Vine Whip (40) is lethal on a Cursola at 40 remaining HP.
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![
+                PlayedCard::from_id(CardId::A1001Bulbasaur)
+                    .with_energy(vec![EnergyType::Grass, EnergyType::Colorless]),
+                PlayedCard::from_id(CardId::A1033Charmander),
+            ],
+            vec![
+                PlayedCard::from_id(CardId::A4a035GalarianCursola).with_remaining_hp(40),
+                PlayedCard::from_id(CardId::A4a034GalarianCorsola),
+            ],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1001Bulbasaur, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        // Cursola is Knocked Out on every seed and the attacker scores its point.
+        assert!(
+            state.in_play_pokemon[1][0].is_none(),
+            "seed {seed}: Cursola should be Knocked Out"
+        );
+        assert_eq!(state.points[0], 1, "seed {seed}");
+
+        if state.in_play_pokemon[0][0].is_none() {
+            // Heads: Perish Body Knocked Out the attacking Bulbasaur; the defender scores.
+            assert_eq!(
+                state.points[1], 1,
+                "seed {seed}: defender should score for the attacker's KO"
+            );
+            saw_attacker_knocked_out = true;
+        } else {
+            // Tails: the attacker is untouched (Perish Body deals no damage).
+            let bulbasaur = state.get_active(0);
+            assert_eq!(bulbasaur.get_name(), "Bulbasaur", "seed {seed}");
+            assert_eq!(bulbasaur.get_remaining_hp(), 70, "seed {seed}");
+            assert_eq!(state.points[1], 0, "seed {seed}");
+            saw_attacker_survived = true;
+        }
+    }
+
+    assert!(
+        saw_attacker_knocked_out,
+        "expected at least one seed where Perish Body Knocked Out the attacker"
+    );
+    assert!(
+        saw_attacker_survived,
+        "expected at least one seed where the attacker survived the flip"
+    );
+}
+
+/// Perish Body is passive: it must never be offered as a usable ability action.
+#[test]
+fn test_perish_body_is_passive() {
+    let game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::A4a035GalarianCursola)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::UseAbility { .. })),
+        "Perish Body should never be offered as a UseAbility action"
+    );
+}
+
+/// Perish Body only triggers from the Active Spot: a benched Cursola Knocked Out by spread
+/// damage must not flip, so the attacker survives on every seed.
+#[test]
+fn test_perish_body_does_not_trigger_on_bench_ko() {
+    for seed in 0..20u64 {
+        // Lurantis's Petal Blizzard does 20 to each of the opponent's Pokémon: lethal on the
+        // benched Cursola at 20 HP, non-lethal on the active Charmander.
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![PlayedCard::from_id(CardId::A3015Lurantis).with_energy(vec![EnergyType::Grass])],
+            vec![
+                PlayedCard::from_id(CardId::A1033Charmander),
+                PlayedCard::from_id(CardId::A4a035GalarianCursola).with_remaining_hp(20),
+            ],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A3015Lurantis, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        assert!(
+            state.in_play_pokemon[1][1].is_none(),
+            "seed {seed}: benched Cursola should be Knocked Out"
+        );
+        assert_eq!(state.points[0], 1, "seed {seed}");
+        assert_eq!(
+            state.get_active(1).get_remaining_hp(),
+            60 - 20,
+            "seed {seed}"
+        );
+        // No Perish Body flip from the bench: Lurantis is never Knocked Out.
+        assert!(state.in_play_pokemon[0][0].is_some(), "seed {seed}");
+        assert_eq!(state.points[1], 0, "seed {seed}");
+    }
+}
+
+/// Non-lethal damage must not trigger Perish Body: damage applies normally on every seed and
+/// the attacker is never at risk.
+#[test]
+fn test_perish_body_does_not_trigger_on_non_lethal_damage() {
+    for seed in 0..10u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::A4a035GalarianCursola)],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1001Bulbasaur, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        assert_eq!(
+            state.get_active(1).get_remaining_hp(),
+            80 - 40,
+            "seed {seed}: non-lethal damage should apply normally"
+        );
+        assert_eq!(state.get_active(0).get_remaining_hp(), 70, "seed {seed}");
+        assert_eq!(state.points, [0, 0], "seed {seed}");
+    }
+}
+
+/// Damage queued through the move-generation stack is still "damage from an attack": if
+/// Cursola is promoted after the first punch and then Knocked Out by Mega Kangaskhan ex's
+/// second punch, Perish Body flips — and on heads the Mega KO (3 points) wins the defender
+/// the game.
+#[test]
+fn test_perish_body_flips_on_kangaskhan_second_punch() {
+    let mut saw_attacker_knocked_out = false;
+    let mut saw_attacker_survived = false;
+
+    for seed in 0..40u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![
+                PlayedCard::from_id(CardId::B2127MegaKangaskhanEx).with_energy(vec![
+                    EnergyType::Colorless,
+                    EnergyType::Colorless,
+                    EnergyType::Colorless,
+                ]),
+                PlayedCard::from_id(CardId::A1033Charmander),
+            ],
+            vec![
+                PlayedCard::from_id(CardId::A1033Charmander).with_remaining_hp(30),
+                PlayedCard::from_id(CardId::A4a035GalarianCursola).with_remaining_hp(40),
+                // A spare Pokémon so the game doesn't end when Cursola is Knocked Out.
+                PlayedCard::from_id(CardId::A4a034GalarianCorsola),
+            ],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B2127MegaKangaskhanEx, 0),
+            is_stack: false,
+        });
+
+        // Resolve the queued follow-ups: the defender's promotion (always pick Cursola so the
+        // second punch faces Perish Body) and the second punch's ApplyDamage (which Knocks Out
+        // the promoted Cursola and flips Perish Body).
+        loop {
+            let state = game.get_state_clone();
+            if state.winner.is_some() {
+                break;
+            }
+            let (_, choices) = state.generate_possible_actions();
+            let follow_up = choices
+                .iter()
+                .find(|choice| {
+                    matches!(
+                        choice.action,
+                        SimpleAction::Activate {
+                            player: 1,
+                            in_play_idx: 1,
+                        }
+                    )
+                })
+                .or_else(|| {
+                    choices.iter().find(|choice| {
+                        matches!(
+                            choice.action,
+                            SimpleAction::ApplyDamage { .. } | SimpleAction::Activate { .. }
+                        )
+                    })
+                });
+            match follow_up {
+                Some(action) => {
+                    let action = action.clone();
+                    game.apply_action(&action);
+                }
+                None => break,
+            }
+        }
+
+        let state = game.get_state_clone();
+        // Both punches always land: Charmander then the promoted Cursola are Knocked Out.
+        assert_eq!(state.points[0], 2, "seed {seed}");
+
+        if state.points[1] > 0 {
+            // Heads: Perish Body Knocked Out Mega Kangaskhan ex — worth 3 points, so the
+            // defender wins outright.
+            assert_eq!(state.points[1], 3, "seed {seed}");
+            assert!(state.winner.is_some(), "seed {seed}");
+            saw_attacker_knocked_out = true;
+        } else {
+            assert!(
+                state.in_play_pokemon[0][0].is_some(),
+                "seed {seed}: Kangaskhan should survive a tails flip"
+            );
+            saw_attacker_survived = true;
+        }
+    }
+
+    assert!(
+        saw_attacker_knocked_out,
+        "expected at least one seed where Perish Body Knocked Out Mega Kangaskhan ex"
+    );
+    assert!(
+        saw_attacker_survived,
+        "expected at least one seed where Mega Kangaskhan ex survived both flips"
+    );
+}


### PR DESCRIPTION
Implements Galarian Cursola (A4a 035). The card and its pre-evolution were already in the database, and both attacks are plain fixed damage, so the work is the ability: **Perish Body** — *"If this Pokémon is in the Active Spot and is Knocked Out by damage from an attack from your opponent's Pokémon, flip a coin. If heads, the Attacking Pokémon is Knocked Out."*

**Stacked on #336** (base branch is `claude/guts-ability-refactor-0ox4fa`): the coin flip cannot run in the knockout hooks (no RNG there), so it is modeled as probability branches at the `AttackOutcomes`/forecast layer using the machinery that PR consolidated.

## What's in here

- New passive `AbilityMechanic::CoinFlipToKnockOutAttackerOnKnockOut`, wired to the exact effect text (previously a commented-out stub), with the standard passive plumbing (`panic!` in `forecast_ability_by_mechanic`, `false` in `can_use_ability_by_mechanic`).
- `perish_body_flips` (apply_action_helpers): detects at forecast time that the branch's modified damage is lethal to a Perish Body Pokémon in the attacker's opponent's Active Spot.
- `knock_out_attacker_for_perish_body`: zeroes the attacker's HP and re-runs `handle_knockouts` with `is_from_active_attack: false` — the KO is an ability effect, not attack damage, so points/promotions/win checks run normally while attack-only triggers (Lucky Egg, Offload Pass, counterattacks, Iris bonus) correctly don't fire. No-ops if the attacker is already gone (e.g. Rocky Helmet) or the game is already decided.
- `AttackOutcomes::split_with_perish_body` splits qualifying branches 50/50, storing the result as a `perish_body_ko_attacker` data field on `AttackOutcome` (same pattern as `guts_survivors`). Runs after damage prevention and Guts in both the common and copied attack modifier chains. `into_mutation` verifies the defending Active was actually knocked out before KO'ing the attacker.
- `forecast_apply_damage` enumerates the Perish Body flip alongside Guts survivor subsets, so queued attack damage (e.g. Mega Kangaskhan ex's second punch hitting a promoted Cursola) also triggers it.

## Tests

Five Game-level tests in `tests/pokemon/galarian_cursola_perish_body_test.rs`:
- heads/tails split on a lethal active KO (attacker KO'd + defender scores vs. attacker untouched),
- the ability is never offered as a usable action,
- benched Cursola KO'd by spread damage never flips (Active-Spot requirement),
- non-lethal damage never flips,
- the ApplyDamage path via Kangaskhan's second punch, where a heads KO of the Mega (3 points) wins the defender the game.

Full suite passes (existing Guts/prevention tests untouched), clippy and fmt clean, and `cargo run --bin card_test -- "A4a 035"` completes 333 simulated games without panics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DieWrETiS5b1FhpqTdBDBQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01DieWrETiS5b1FhpqTdBDBQ)_