### PR TITLE
Implement every ex Pokémon in B4 (Ruler of the Skies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # deckgym-core: Pokémon TCG Pocket Simulator
 
-![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3279_%2F_3761_%2887.2%25%29-green)
+![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3298_%2F_3761_%2887.7%25%29-green)
 
 **deckgym-core** is a high-performance Rust library designed for simulating Pokémon TCG Pocket games. It features a command-line interface (CLI) capable of running 10,000 simulations in approximately 3 seconds. This is the library that powers https://www.deckgym.com.
 

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -65,6 +65,7 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::ApplyEeveeBagDamageBoost
         | SimpleAction::HealAllEeveeEvolutions
         | SimpleAction::DiscardFossil { .. }
+        | SimpleAction::DiscardOwnBenchedThenDamage { .. }
         | SimpleAction::ReturnPokemonToHand { .. }
         | SimpleAction::ShuffleInPlayPokemonIntoDeck { .. }
         | SimpleAction::DiscardToolFromPokemon { .. }
@@ -318,6 +319,10 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
         SimpleAction::DiscardFossil { in_play_idx } => {
             apply_discard_fossil(action.actor, state, *in_play_idx)
         }
+        SimpleAction::DiscardOwnBenchedThenDamage {
+            in_play_idx,
+            damage,
+        } => apply_discard_own_benched_then_damage(action.actor, state, *in_play_idx, *damage),
         SimpleAction::ReturnPokemonToHand { in_play_idx } => {
             apply_return_pokemon_to_hand(action.actor, state, *in_play_idx)
         }
@@ -457,6 +462,26 @@ fn apply_discard_fossil(acting_player: usize, state: &mut State, in_play_idx: us
     if in_play_idx == 0 {
         state.trigger_promotion_or_declare_winner(acting_player);
     }
+}
+
+/// Vespiquen ex's Chase Order: discard the chosen Benched Pokémon, then queue the (boosted)
+/// damage so it goes through the regular damage pipeline as a single application.
+fn apply_discard_own_benched_then_damage(
+    acting_player: usize,
+    state: &mut State,
+    in_play_idx: usize,
+    damage: u32,
+) {
+    state.discard_from_play(acting_player, in_play_idx);
+    let opponent = (acting_player + 1) % 2;
+    state.move_generation_stack.push((
+        acting_player,
+        vec![SimpleAction::ApplyDamage {
+            attacking_ref: (acting_player, 0),
+            targets: vec![(damage, opponent, 0)],
+            is_from_active_attack: true,
+        }],
+    ));
 }
 
 fn apply_return_pokemon_to_hand(acting_player: usize, state: &mut State, in_play_idx: usize) {

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -672,12 +672,14 @@ fn forecast_effect_attack_by_mechanic(
                 *damage_per_trainer,
             )
         }
-        Mechanic::ExtraDamagePerSupporterInDiscard {
-            damage_per_supporter,
-        } => extra_damage_per_supporter_in_discard_attack(
+        Mechanic::ExtraDamagePerTrainerTypeInDiscard {
+            trainer_type,
+            damage_per_card,
+        } => extra_damage_per_trainer_type_in_discard_attack(
             state,
             attack.fixed_damage,
-            *damage_per_supporter,
+            trainer_type.clone(),
+            *damage_per_card,
         ),
         Mechanic::ExtraDamagePerPokemonTypeInDiscard {
             energy_type,
@@ -3575,21 +3577,22 @@ fn extra_damage_per_trainer_in_opponent_deck_attack(
 }
 
 /// Chandelure - Past Friends: Extra damage per Supporter in your discard pile.
-fn extra_damage_per_supporter_in_discard_attack(
+fn extra_damage_per_trainer_type_in_discard_attack(
     state: &State,
     base_damage: u32,
-    damage_per_supporter: u32,
+    trainer_type: TrainerType,
+    damage_per_card: u32,
 ) -> AttackOutcomes {
-    let supporter_count = state.discard_piles[state.current_player]
+    let card_count = state.discard_piles[state.current_player]
         .iter()
         .filter(|card| {
             matches!(
                 card,
-                Card::Trainer(trainer) if trainer.trainer_card_type == TrainerType::Supporter
+                Card::Trainer(trainer) if trainer.trainer_card_type == trainer_type
             )
         })
         .count() as u32;
-    let total_damage = base_damage + (supporter_count * damage_per_supporter);
+    let total_damage = base_damage + (card_count * damage_per_card);
     active_damage_doutcome(total_damage)
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -443,6 +443,14 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::SelfDiscardAllTypeEnergy { energy_type } => {
             discard_all_energy_of_type_attack(attack.fixed_damage, *energy_type)
         }
+        Mechanic::SelfDiscardAllTypesEnergyDamagePerDiscarded {
+            energy_types,
+            damage_per_energy,
+        } => discard_all_energy_of_types_damage_per_discarded_attack(
+            state,
+            energy_types.clone(),
+            *damage_per_energy,
+        ),
         Mechanic::SelfDiscardAllTypeEnergyAndDamageAnyOpponentPokemon {
             energy_type,
             damage,
@@ -2258,6 +2266,35 @@ fn discard_all_energy_of_type_attack(damage: u32, energy_type: EnergyType) -> At
         // Use the state method to properly discard energies
         state.discard_from_active(action.actor, &to_discard);
     })
+}
+
+/// Mega Rayquaza ex - Mega Burst: discard every Energy of `energy_types` from the attacking
+/// Pokémon and deal `damage_per_energy` for each Energy discarded in this way.
+fn discard_all_energy_of_types_damage_per_discarded_attack(
+    state: &State,
+    energy_types: Vec<EnergyType>,
+    damage_per_energy: u32,
+) -> AttackOutcomes {
+    let matching_count = state
+        .get_active(state.current_player)
+        .attached_energy
+        .iter()
+        .filter(|e| energy_types.contains(e))
+        .count() as u32;
+
+    active_damage_effect_doutcome(
+        matching_count * damage_per_energy,
+        move |_, state, action| {
+            let to_discard: Vec<EnergyType> = state
+                .get_active(action.actor)
+                .attached_energy
+                .iter()
+                .filter(|e| energy_types.contains(e))
+                .copied()
+                .collect();
+            state.discard_from_active(action.actor, &to_discard);
+        },
+    )
 }
 
 fn discard_random_global_energy_attack(

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -733,6 +733,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::SelfAsleepAndHeal { amount } => {
             self_asleep_and_heal_attack(*amount, attack.fixed_damage)
         }
+        Mechanic::SelfCureStatusConditions => {
+            self_cure_status_conditions_attack(attack.fixed_damage)
+        }
         Mechanic::FlipCoinsBenchDamagePerHead {
             num_coins,
             bench_damage_per_head,
@@ -2122,6 +2125,15 @@ fn self_asleep_and_heal_attack(heal: u32, damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         state.apply_status_condition(action.actor, 0, StatusCondition::Asleep);
         state.get_active_mut(action.actor).heal(heal);
+    })
+}
+
+/// Wailord ex - Wondrous Waves: the attacking Pokémon recovers from all Special Conditions.
+fn self_cure_status_conditions_attack(damage: u32) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        if let Some(attacker) = state.in_play_pokemon[action.actor][0].as_mut() {
+            attacker.cure_status_conditions();
+        }
     })
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -413,6 +413,12 @@ fn forecast_effect_attack_by_mechanic(
             both_heads_bonus_damage_attack(attack.fixed_damage, *extra_damage)
         }
         Mechanic::DirectDamage { damage, bench_only } => direct_damage(*damage, *bench_only),
+        Mechanic::DirectDamageAndSelfCardEffect {
+            damage,
+            bench_only,
+            effect,
+            duration,
+        } => direct_damage_and_self_card_effect(*damage, *bench_only, effect.clone(), *duration),
         Mechanic::DamageAndTurnEffect { effect, duration } => {
             damage_and_turn_effect_attack(attack.fixed_damage, effect.clone(), *duration)
         }
@@ -1646,30 +1652,42 @@ fn coin_flip_self_charge_active(damage: u32, energies: Vec<EnergyType>) -> Attac
 /// It will queue (via move_generation_stack) for the user to choose a pokemon to damage.
 fn direct_damage(damage: u32, bench_only: bool) -> AttackOutcomes {
     active_damage_effect_doutcome(0, move |_, state, action| {
-        let opponent = (action.actor + 1) % 2;
-        let mut choices = Vec::new();
-        if bench_only {
-            for (in_play_idx, _) in state.enumerate_bench_pokemon(opponent) {
-                choices.push(SimpleAction::ApplyDamage {
-                    attacking_ref: (action.actor, 0),
-                    targets: vec![(damage, opponent, in_play_idx)],
-                    is_from_active_attack: true,
-                });
-            }
-        } else {
-            for (in_play_idx, _) in state.enumerate_in_play_pokemon(opponent) {
-                choices.push(SimpleAction::ApplyDamage {
-                    attacking_ref: (action.actor, 0),
-                    targets: vec![(damage, opponent, in_play_idx)],
-                    is_from_active_attack: true,
-                });
-            }
-        }
-        if choices.is_empty() {
-            return; // do nothing, since we use common_attack_mutation, turn should end, and no damage applied.
-        }
-        state.move_generation_stack.push((action.actor, choices));
+        push_direct_damage_choices(state, action, damage, bench_only);
     })
+}
+
+/// Gigalith ex - Megaton Cannon: direct damage to a chosen opponent Pokémon, plus a card effect
+/// left on the attacking Pokémon (e.g. "During your next turn, this Pokémon can't attack.").
+fn direct_damage_and_self_card_effect(
+    damage: u32,
+    bench_only: bool,
+    effect: CardEffect,
+    duration: u8,
+) -> AttackOutcomes {
+    active_damage_effect_doutcome(0, move |_, state, action| {
+        state
+            .get_active_mut(action.actor)
+            .add_effect(effect.clone(), duration);
+        push_direct_damage_choices(state, action, damage, bench_only);
+    })
+}
+
+/// Queue the "pick which of your opponent's Pokémon takes the damage" decision.
+fn push_direct_damage_choices(state: &mut State, action: &Action, damage: u32, bench_only: bool) {
+    let opponent = (action.actor + 1) % 2;
+    let choices: Vec<SimpleAction> = state
+        .enumerate_in_play_pokemon(opponent)
+        .filter(|(in_play_idx, _)| !bench_only || *in_play_idx != 0)
+        .map(|(in_play_idx, _)| SimpleAction::ApplyDamage {
+            attacking_ref: (action.actor, 0),
+            targets: vec![(damage, opponent, in_play_idx)],
+            is_from_active_attack: true,
+        })
+        .collect();
+    if choices.is_empty() {
+        return; // do nothing, since we use common_attack_mutation, turn should end, and no damage applied.
+    }
+    state.move_generation_stack.push((action.actor, choices));
 }
 
 fn delayed_spot_damage(damage: u32) -> AttackOutcomes {

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -483,6 +483,15 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfUndamaged { extra_damage } => {
             extra_damage_if_undamaged(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::OptionalDiscardBenchedBasicForExtraDamage {
+            energy_type,
+            extra_damage,
+        } => optional_discard_benched_basic_for_extra_damage(
+            state,
+            attack.fixed_damage,
+            *energy_type,
+            *extra_damage,
+        ),
         Mechanic::ExtraDamageIfStage2OnBench { extra_damage } => {
             extra_damage_if_stage2_on_bench(state, attack.fixed_damage, *extra_damage)
         }
@@ -2479,6 +2488,52 @@ fn extra_damage_if_undamaged(state: &State, base: u32, extra: u32) -> AttackOutc
     } else {
         active_damage_doutcome(base + extra)
     }
+}
+
+/// Vespiquen ex - Chase Order: the attacker may discard 1 of its Benched Basic Pokémon of the
+/// given type to boost the damage. The choice is queued as a single action per option so that the
+/// boosted damage is applied in one go (damage modifiers must not run twice).
+fn optional_discard_benched_basic_for_extra_damage(
+    state: &State,
+    base_damage: u32,
+    energy_type: EnergyType,
+    extra_damage: u32,
+) -> AttackOutcomes {
+    if benched_basic_indices_of_type(state, state.current_player, energy_type).is_empty() {
+        return active_damage_doutcome(base_damage);
+    }
+
+    active_damage_effect_doutcome(0, move |_, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        let mut choices = vec![SimpleAction::ApplyDamage {
+            attacking_ref: (action.actor, 0),
+            targets: vec![(base_damage, opponent, 0)],
+            is_from_active_attack: true,
+        }];
+        choices.extend(
+            benched_basic_indices_of_type(state, action.actor, energy_type)
+                .into_iter()
+                .map(|in_play_idx| SimpleAction::DiscardOwnBenchedThenDamage {
+                    in_play_idx,
+                    damage: base_damage + extra_damage,
+                }),
+        );
+        state.move_generation_stack.push((action.actor, choices));
+    })
+}
+
+fn benched_basic_indices_of_type(
+    state: &State,
+    player: usize,
+    energy_type: EnergyType,
+) -> Vec<usize> {
+    state
+        .enumerate_bench_pokemon(player)
+        .filter(|(_, pokemon)| {
+            pokemon.card.is_basic() && pokemon.get_energy_type() == Some(energy_type)
+        })
+        .map(|(in_play_idx, _)| in_play_idx)
+        .collect()
 }
 
 fn extra_damage_if_stage2_on_bench(state: &State, base: u32, extra: u32) -> AttackOutcomes {

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -309,6 +309,13 @@ pub enum Mechanic {
     ExtraDamageIfUndamaged {
         extra_damage: u32,
     },
+    /// Vespiquen ex's Chase Order: "You may discard 1 of your Benched Basic [G] Pokémon. If you
+    /// do, this attack does 70 more damage." The attacker chooses between the plain damage and
+    /// discarding one eligible Benched Basic Pokémon for the boosted damage.
+    OptionalDiscardBenchedBasicForExtraDamage {
+        energy_type: EnergyType,
+        extra_damage: u32,
+    },
     ExtraDamageIfStage2OnBench {
         extra_damage: u32,
     },

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -273,6 +273,13 @@ pub enum Mechanic {
     SelfDiscardAllTypeEnergy {
         energy_type: EnergyType,
     },
+    /// Mega Rayquaza ex's Mega Burst: discard every Energy of the listed types from the attacking
+    /// Pokémon, dealing `damage_per_energy` for each Energy discarded in this way (the attack's
+    /// `fixed_damage` is the per-Energy amount, so it is not added as a base).
+    SelfDiscardAllTypesEnergyDamagePerDiscarded {
+        energy_types: Vec<EnergyType>,
+        damage_per_energy: u32,
+    },
     SelfDiscardAllTypeEnergyAndDamageAnyOpponentPokemon {
         energy_type: EnergyType,
         damage: u32,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -154,6 +154,14 @@ pub enum Mechanic {
         damage: u32,
         bench_only: bool,
     },
+    /// Gigalith ex's Megaton Cannon: `DirectDamage` that additionally leaves a `CardEffect` on the
+    /// attacking Pokémon (e.g. "During your next turn, this Pokémon can't attack.").
+    DirectDamageAndSelfCardEffect {
+        damage: u32,
+        bench_only: bool,
+        effect: CardEffect,
+        duration: u8,
+    },
     DamageAndTurnEffect {
         effect: TurnEffect,
         duration: u8,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -1,6 +1,6 @@
 use crate::{
     effects::{CardEffect, TurnEffect},
-    models::{EnergyType, StatusCondition},
+    models::{EnergyType, StatusCondition, TrainerType},
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -225,8 +225,11 @@ pub enum Mechanic {
     ExtraDamagePerTrainerInOpponentDeck {
         damage_per_trainer: u32,
     },
-    ExtraDamagePerSupporterInDiscard {
-        damage_per_supporter: u32,
+    /// Extra damage for each card of a given Trainer kind in your discard pile (e.g. Chandelure's
+    /// Past Friends counts Supporters, Rotom ex's Junk Spark counts Items).
+    ExtraDamagePerTrainerTypeInDiscard {
+        trainer_type: TrainerType,
+        damage_per_card: u32,
     },
     ExtraDamagePerPokemonTypeInDiscard {
         energy_type: EnergyType,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -411,6 +411,9 @@ pub enum Mechanic {
     SelfAsleepAndHeal {
         amount: u32,
     },
+    /// Wailord ex's Wondrous Waves: after dealing damage, the attacking Pokémon recovers from
+    /// all Special Conditions.
+    SelfCureStatusConditions,
     FlipCoinsBenchDamagePerHead {
         num_coins: usize,
         bench_damage_per_head: u32,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2302,6 +2302,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
 
     // B4 Mechanics
+    // Mega Rayquaza ex - Mega Burst
+    map.insert(
+        "Discard all [R] and [L] Energy from this Pokémon, and this attack does 50 damage for each Energy you discarded in this way.",
+        Mechanic::SelfDiscardAllTypesEnergyDamagePerDiscarded {
+            energy_types: vec![EnergyType::Fire, EnergyType::Lightning],
+            damage_per_energy: 50,
+        },
+    );
     // Wailord ex - Wondrous Waves
     map.insert(
         "This Pokémon recovers from all Special Conditions.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2311,6 +2311,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
 
     // B4 Mechanics
+    // Vespiquen ex - Chase Order
+    map.insert(
+        "You may discard 1 of your Benched Basic [G] Pokémon. If you do, this attack does 70 more damage.",
+        Mechanic::OptionalDiscardBenchedBasicForExtraDamage {
+            energy_type: EnergyType::Grass,
+            extra_damage: 70,
+        },
+    );
     // Mega Rayquaza ex - Mega Burst
     map.insert(
         "Discard all [R] and [L] Energy from this Pokémon, and this attack does 50 damage for each Energy you discarded in this way.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1942,7 +1942,16 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     // map.insert("This attack also does 30 damage to each of your opponent's Benched Pokémon that has damage on it.", todo_implementation);
-    // map.insert("This attack does 140 damage to 1 of your opponent's Pokémon. During your next turn, this Pokémon can't attack.", todo_implementation);
+    // Gigalith ex - Megaton Cannon
+    map.insert(
+        "This attack does 140 damage to 1 of your opponent's Pokémon. During your next turn, this Pokémon can't attack.",
+        Mechanic::DirectDamageAndSelfCardEffect {
+            damage: 140,
+            bench_only: false,
+            effect: CardEffect::CannotAttack,
+            duration: 2,
+        },
+    );
     map.insert(
         "This attack does 20 more damage for each Supporter card in your discard pile.",
         Mechanic::ExtraDamagePerTrainerTypeInDiscard {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2299,5 +2299,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             extra_damage_by_heads: vec![0, 20, 50, 120],
         },
     );
+
+    // B4 Mechanics
+    // Mega Metagross ex - Gatling Slug
+    map.insert(
+        "This attack does 10 more damage for each [M] Energy attached to this Pokémon.",
+        Mechanic::ExtraDamagePerSpecificEnergy {
+            energy_type: EnergyType::Metal,
+            damage_per_energy: 10,
+        },
+    );
     map
 });

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2302,6 +2302,11 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
 
     // B4 Mechanics
+    // Wailord ex - Wondrous Waves
+    map.insert(
+        "This Pokémon recovers from all Special Conditions.",
+        Mechanic::SelfCureStatusConditions,
+    );
     // Rotom ex - Junk Spark
     map.insert(
         "This attack does 10 more damage for each Item card in your discard pile.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -7,7 +7,7 @@ use std::sync::LazyLock;
 use crate::{
     actions::attacks::{BenchSide, CopyAttackSource, Mechanic},
     effects::{CardEffect, TurnEffect},
-    models::{EnergyType, StatusCondition},
+    models::{EnergyType, StatusCondition, TrainerType},
 };
 
 /// Map from attack effect text to its implementation.
@@ -1945,8 +1945,9 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("This attack does 140 damage to 1 of your opponent's Pokémon. During your next turn, this Pokémon can't attack.", todo_implementation);
     map.insert(
         "This attack does 20 more damage for each Supporter card in your discard pile.",
-        Mechanic::ExtraDamagePerSupporterInDiscard {
-            damage_per_supporter: 20,
+        Mechanic::ExtraDamagePerTrainerTypeInDiscard {
+            trainer_type: TrainerType::Supporter,
+            damage_per_card: 20,
         },
     );
     // map.insert("This attack does 70 damage to 1 of your opponent's Benched Pokémon.", todo_implementation);
@@ -2301,6 +2302,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
 
     // B4 Mechanics
+    // Rotom ex - Junk Spark
+    map.insert(
+        "This attack does 10 more damage for each Item card in your discard pile.",
+        Mechanic::ExtraDamagePerTrainerTypeInDiscard {
+            trainer_type: TrainerType::Item,
+            damage_per_card: 10,
+        },
+    );
     // Mega Metagross ex - Gatling Slug
     map.insert(
         "This attack does 10 more damage for each [M] Energy attached to this Pokémon.",

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -137,6 +137,14 @@ pub enum SimpleAction {
     DiscardFossil {
         in_play_idx: usize,
     },
+    /// Vespiquen ex's Chase Order: discard 1 of your own Benched Pokémon, then deal the attack's
+    /// boosted damage to the opponent's Active Pokémon. The two halves are one action so that the
+    /// boosted damage is applied once — splitting it would apply Weakness (and other damage
+    /// modifiers) to each half.
+    DiscardOwnBenchedThenDamage {
+        in_play_idx: usize,
+        damage: u32,
+    },
     /// Use an activated stadium effect (once per turn per player)
     UseStadium,
     /// Return a Pokemon in play to your hand (e.g., Ilima).
@@ -309,6 +317,12 @@ impl fmt::Display for SimpleAction {
             }
             SimpleAction::DiscardFossil { in_play_idx } => {
                 write!(f, "DiscardFossil({in_play_idx})")
+            }
+            SimpleAction::DiscardOwnBenchedThenDamage {
+                in_play_idx,
+                damage,
+            } => {
+                write!(f, "DiscardOwnBenchedThenDamage({in_play_idx}, {damage})")
             }
             SimpleAction::ReturnPokemonToHand { in_play_idx } => {
                 write!(f, "ReturnPokemonToHand({in_play_idx})")

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -69,6 +69,8 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::ApplyEeveeBagDamageBoost => 5,
         SimpleAction::HealAllEeveeEvolutions => 5,
         SimpleAction::DiscardFossil { .. } => 1, // Low weight to discard fossils
+        SimpleAction::DiscardOwnBenchedThenDamage { .. } => 5, // Trading a Benched Pokemon for damage
+
         SimpleAction::ReturnPokemonToHand { .. } => 5,
         SimpleAction::ShuffleInPlayPokemonIntoDeck { .. } => 5,
         SimpleAction::DiscardToolFromPokemon { .. } => 5,

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -160,6 +160,8 @@ mod psyduck_test;
 mod rampardos_head_smash_test;
 #[path = "pokemon/roaring_moon_test.rs"]
 mod roaring_moon_test;
+#[path = "pokemon/rotom_ex_junk_spark_test.rs"]
+mod rotom_ex_junk_spark_test;
 #[path = "pokemon/salamence_test.rs"]
 mod salamence_test;
 #[path = "pokemon/sawk_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -198,6 +198,8 @@ mod vanilluxe_test;
 mod vaporeon_ex_test;
 #[path = "pokemon/vulpix_tail_whip_test.rs"]
 mod vulpix_tail_whip_test;
+#[path = "pokemon/wailord_ex_wondrous_waves_test.rs"]
+mod wailord_ex_wondrous_waves_test;
 #[path = "pokemon/wailord_test.rs"]
 mod wailord_test;
 #[path = "pokemon/xerneas_geoburst_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -132,6 +132,8 @@ mod mega_diancie_ex_test;
 mod mega_kangaskhan_double_punching_family_test;
 #[path = "pokemon/mega_medicham_ex_test.rs"]
 mod mega_medicham_ex_test;
+#[path = "pokemon/mega_metagross_ex_gatling_slug_test.rs"]
+mod mega_metagross_ex_gatling_slug_test;
 #[path = "pokemon/mega_sceptile_terminating_tail_test.rs"]
 mod mega_sceptile_terminating_tail_test;
 #[path = "pokemon/mega_steelix_adamantine_rolling_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -66,6 +66,8 @@ mod flygon_ex_test;
 mod gallade_test;
 #[path = "pokemon/gardevoir_psy_turbo_test.rs"]
 mod gardevoir_psy_turbo_test;
+#[path = "pokemon/gigalith_ex_megaton_cannon_test.rs"]
+mod gigalith_ex_megaton_cannon_test;
 #[path = "pokemon/grovyle_slicing_snipe_test.rs"]
 mod grovyle_slicing_snipe_test;
 #[path = "pokemon/growlithe_puppy_pile_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -200,6 +200,8 @@ mod ursaluna_guts_test;
 mod vanilluxe_test;
 #[path = "pokemon/vaporeon_ex_test.rs"]
 mod vaporeon_ex_test;
+#[path = "pokemon/vespiquen_ex_chase_order_test.rs"]
+mod vespiquen_ex_chase_order_test;
 #[path = "pokemon/vulpix_tail_whip_test.rs"]
 mod vulpix_tail_whip_test;
 #[path = "pokemon/wailord_ex_wondrous_waves_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -134,6 +134,8 @@ mod mega_kangaskhan_double_punching_family_test;
 mod mega_medicham_ex_test;
 #[path = "pokemon/mega_metagross_ex_gatling_slug_test.rs"]
 mod mega_metagross_ex_gatling_slug_test;
+#[path = "pokemon/mega_rayquaza_ex_mega_burst_test.rs"]
+mod mega_rayquaza_ex_mega_burst_test;
 #[path = "pokemon/mega_sceptile_terminating_tail_test.rs"]
 mod mega_sceptile_terminating_tail_test;
 #[path = "pokemon/mega_steelix_adamantine_rolling_test.rs"]

--- a/tests/pokemon/gigalith_ex_megaton_cannon_test.rs
+++ b/tests/pokemon/gigalith_ex_megaton_cannon_test.rs
@@ -1,0 +1,100 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+const VENUSAUR_EX_MAX_HP: u32 = 190;
+
+fn gigalith_ex_board() -> deckgym::Game<'static> {
+    get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4229GigalithEx).with_energy(vec![
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+            ]),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1004VenusaurEx),
+            PlayedCard::from_id(CardId::A1004VenusaurEx),
+        ],
+    )
+}
+
+/// Gigalith ex's Megaton Cannon lets the attacker pick any of the opponent's Pokémon —
+/// including a Benched one — and does 140 damage to it.
+#[test]
+fn test_gigalith_ex_megaton_cannon_hits_chosen_benched_pokemon() {
+    let mut game = gigalith_ex_board();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4229GigalithEx, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(choices
+        .iter()
+        .all(|choice| matches!(choice.action, SimpleAction::ApplyDamage { .. })));
+
+    let bench_target = choices
+        .iter()
+        .find(|choice| {
+            matches!(&choice.action, SimpleAction::ApplyDamage { targets, .. }
+                if targets.iter().any(|(_, _, in_play_idx)| *in_play_idx == 1))
+        })
+        .expect("Megaton Cannon should be able to target a Benched Pokémon")
+        .clone();
+    game.apply_action(&bench_target);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), VENUSAUR_EX_MAX_HP);
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("Benched Venusaur ex should still be in play")
+            .get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 140
+    );
+}
+
+/// After using Megaton Cannon, Gigalith ex can't attack during its next turn.
+#[test]
+fn test_gigalith_ex_cannot_attack_the_turn_after_megaton_cannon() {
+    let mut game = gigalith_ex_board();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4229GigalithEx, 0),
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    game.apply_action(&choices[0].clone());
+
+    // Pass through the opponent's turn to get back to Gigalith ex's next turn.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    let (actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        !actions
+            .iter()
+            .any(|action| matches!(action.action, SimpleAction::Attack(_))),
+        "Gigalith ex should not be able to attack the turn after Megaton Cannon"
+    );
+}

--- a/tests/pokemon/mega_metagross_ex_gatling_slug_test.rs
+++ b/tests/pokemon/mega_metagross_ex_gatling_slug_test.rs
@@ -1,0 +1,68 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+const VENUSAUR_EX_MAX_HP: u32 = 190;
+
+/// Mega Metagross ex's Gatling Slug does 100 damage plus 10 more for each [M] Energy
+/// attached to it.
+#[test]
+fn test_mega_metagross_ex_gatling_slug_scales_with_metal_energy() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4109MegaMetagrossEx).with_energy(vec![
+                EnergyType::Metal,
+                EnergyType::Metal,
+                EnergyType::Metal,
+            ]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+
+    // 3 [M] Energy attached → 100 + 10 × 3 = 130 damage.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4109MegaMetagrossEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 130
+    );
+}
+
+/// Gatling Slug only counts [M] Energy, even though its cost is 3 [C] and can be paid
+/// with any Energy.
+#[test]
+fn test_mega_metagross_ex_gatling_slug_ignores_non_metal_energy() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4109MegaMetagrossEx).with_energy(vec![
+                EnergyType::Metal,
+                EnergyType::Water,
+                EnergyType::Water,
+            ]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+
+    // Only 1 [M] Energy attached → 100 + 10 × 1 = 110 damage.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4109MegaMetagrossEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 110
+    );
+}

--- a/tests/pokemon/mega_rayquaza_ex_mega_burst_test.rs
+++ b/tests/pokemon/mega_rayquaza_ex_mega_burst_test.rs
@@ -1,0 +1,69 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+const VENUSAUR_EX_MAX_HP: u32 = 190;
+
+fn mega_rayquaza_ex_board(energy: Vec<EnergyType>) -> deckgym::Game<'static> {
+    get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4120MegaRayquazaEx).with_energy(energy)],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    )
+}
+
+/// Mega Rayquaza ex's Mega Burst discards all [R] and [L] Energy attached to it and does
+/// 50 damage for each Energy discarded that way.
+#[test]
+fn test_mega_rayquaza_ex_mega_burst_damage_per_discarded_energy() {
+    let mut game = mega_rayquaza_ex_board(vec![
+        EnergyType::Fire,
+        EnergyType::Fire,
+        EnergyType::Lightning,
+    ]);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4120MegaRayquazaEx, 0),
+        is_stack: false,
+    });
+
+    // 2 [R] + 1 [L] discarded → 50 × 3 = 150 damage.
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 150
+    );
+    assert!(state.get_active(0).attached_energy.is_empty());
+    assert_eq!(state.discard_energies[0].len(), 3);
+}
+
+/// Mega Burst leaves Energy of other types attached, and they do not add damage.
+#[test]
+fn test_mega_rayquaza_ex_mega_burst_only_discards_fire_and_lightning() {
+    let mut game = mega_rayquaza_ex_board(vec![
+        EnergyType::Fire,
+        EnergyType::Lightning,
+        EnergyType::Water,
+        EnergyType::Water,
+    ]);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4120MegaRayquazaEx, 0),
+        is_stack: false,
+    });
+
+    // 1 [R] + 1 [L] discarded → 50 × 2 = 100 damage; both [W] stay attached.
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 100
+    );
+    assert_eq!(
+        state.get_active(0).attached_energy,
+        vec![EnergyType::Water, EnergyType::Water]
+    );
+}

--- a/tests/pokemon/rotom_ex_junk_spark_test.rs
+++ b/tests/pokemon/rotom_ex_junk_spark_test.rs
@@ -1,0 +1,81 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+const VENUSAUR_EX_MAX_HP: u32 = 190;
+
+fn rotom_ex_board() -> deckgym::Game<'static> {
+    get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4055RotomEx)
+                .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    )
+}
+
+/// Rotom ex's Junk Spark does 30 damage plus 10 more for each Item card in your
+/// discard pile.
+#[test]
+fn test_rotom_ex_junk_spark_scales_with_items_in_discard() {
+    let mut game = rotom_ex_board();
+
+    let mut state = game.get_state_clone();
+    state.discard_piles[0] = vec![
+        get_card_by_enum(CardId::PA005PokeBall),
+        get_card_by_enum(CardId::PA005PokeBall),
+        get_card_by_enum(CardId::A2146PokemonCommunication),
+    ];
+    game.set_state(state);
+
+    // 3 Item cards in the discard pile → 30 + 10 × 3 = 60 damage.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4055RotomEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 60
+    );
+}
+
+/// Only Item cards count: Supporters, Tools and Pokémon in the discard pile are ignored,
+/// and the opponent's discard pile is irrelevant.
+#[test]
+fn test_rotom_ex_junk_spark_ignores_non_item_cards() {
+    let mut game = rotom_ex_board();
+
+    let mut state = game.get_state_clone();
+    state.discard_piles[0] = vec![
+        get_card_by_enum(CardId::PA005PokeBall),
+        get_card_by_enum(CardId::A1219Erika),
+        get_card_by_enum(CardId::A2148RockyHelmet),
+        get_card_by_enum(CardId::A1001Bulbasaur),
+    ];
+    state.discard_piles[1] = vec![
+        get_card_by_enum(CardId::PA005PokeBall),
+        get_card_by_enum(CardId::PA005PokeBall),
+    ];
+    game.set_state(state);
+
+    // Only the single Poké Ball counts → 30 + 10 × 1 = 40 damage.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4055RotomEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 40
+    );
+}

--- a/tests/pokemon/vespiquen_ex_chase_order_test.rs
+++ b/tests/pokemon/vespiquen_ex_chase_order_test.rs
@@ -1,0 +1,104 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+const VENUSAUR_EX_MAX_HP: u32 = 190;
+
+fn vespiquen_ex_board(bench: Vec<PlayedCard>) -> deckgym::Game<'static> {
+    let mut player_board = vec![PlayedCard::from_id(CardId::B4011VespiquenEx)
+        .with_energy(vec![EnergyType::Grass, EnergyType::Grass])];
+    player_board.extend(bench);
+    get_test_game_with_board(
+        player_board,
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    )
+}
+
+fn use_chase_order(game: &mut deckgym::Game<'static>) {
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4011VespiquenEx, 0),
+        is_stack: false,
+    });
+}
+
+/// Discarding a Benched Basic [G] Pokémon makes Chase Order do 70 more damage, and the
+/// discarded Pokémon leaves play.
+#[test]
+fn test_vespiquen_ex_chase_order_discard_boosts_damage() {
+    let mut game = vespiquen_ex_board(vec![PlayedCard::from_id(CardId::A1001Bulbasaur)]);
+    use_chase_order(&mut game);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let discard_choice = choices
+        .iter()
+        .find(|choice| {
+            matches!(
+                choice.action,
+                SimpleAction::DiscardOwnBenchedThenDamage { in_play_idx: 1, .. }
+            )
+        })
+        .expect("Chase Order should offer discarding the Benched Basic [G] Bulbasaur")
+        .clone();
+    game.apply_action(&discard_choice);
+
+    // The boosted damage is queued as a single follow-up application.
+    let (actor, follow_up) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(follow_up.len(), 1);
+    game.apply_action(&follow_up[0].clone());
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 140
+    );
+    assert!(state.in_play_pokemon[0][1].is_none());
+    assert_eq!(state.discard_piles[0].len(), 1);
+    assert_eq!(state.discard_piles[0][0].get_name(), "Bulbasaur");
+}
+
+/// The discard is optional: declining it keeps the Bench intact and deals only the base damage.
+#[test]
+fn test_vespiquen_ex_chase_order_can_decline_the_discard() {
+    let mut game = vespiquen_ex_board(vec![PlayedCard::from_id(CardId::A1001Bulbasaur)]);
+    use_chase_order(&mut game);
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    let keep_bench_choice = choices
+        .iter()
+        .find(|choice| matches!(choice.action, SimpleAction::ApplyDamage { .. }))
+        .expect("Chase Order should offer attacking without discarding")
+        .clone();
+    game.apply_action(&keep_bench_choice);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 70
+    );
+    assert!(state.in_play_pokemon[0][1].is_some());
+}
+
+/// Only Benched Basic [G] Pokémon can be discarded: an evolved [G] Pokémon and a Basic of
+/// another type are both ineligible, so no choice is offered at all.
+#[test]
+fn test_vespiquen_ex_chase_order_ignores_ineligible_bench() {
+    let mut game = vespiquen_ex_board(vec![
+        PlayedCard::from_id(CardId::A1002Ivysaur),
+        PlayedCard::from_id(CardId::A1033Charmander),
+    ]);
+    use_chase_order(&mut game);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 70
+    );
+    assert!(state.in_play_pokemon[0][1].is_some());
+    assert!(state.in_play_pokemon[0][2].is_some());
+}

--- a/tests/pokemon/wailord_ex_wondrous_waves_test.rs
+++ b/tests/pokemon/wailord_ex_wondrous_waves_test.rs
@@ -1,0 +1,70 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard, StatusCondition},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+const VENUSAUR_EX_MAX_HP: u32 = 190;
+
+fn wailord_ex_board() -> deckgym::Game<'static> {
+    get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4037WailordEx).with_energy(vec![
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Water,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    )
+}
+
+/// Wailord ex's Wondrous Waves does 100 damage and clears every Special Condition
+/// affecting Wailord ex itself.
+#[test]
+fn test_wailord_ex_wondrous_waves_cures_own_special_conditions() {
+    let mut game = wailord_ex_board();
+
+    let mut state = game.get_state_clone();
+    state.apply_status_condition(0, 0, StatusCondition::Poisoned);
+    state.apply_status_condition(0, 0, StatusCondition::Burned);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4037WailordEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let wailord = state.get_active(0);
+    assert!(!wailord.is_poisoned());
+    assert!(!wailord.is_burned());
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 100
+    );
+}
+
+/// Wondrous Waves only heals Wailord ex; the Defending Pokémon keeps its Special Conditions.
+#[test]
+fn test_wailord_ex_wondrous_waves_leaves_opponent_conditions_alone() {
+    let mut game = wailord_ex_board();
+
+    let mut state = game.get_state_clone();
+    state.apply_status_condition(0, 0, StatusCondition::Poisoned);
+    state.apply_status_condition(1, 0, StatusCondition::Poisoned);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4037WailordEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(!state.get_active(0).is_poisoned());
+    assert!(state.get_active(1).is_poisoned());
+}


### PR DESCRIPTION
Implements the attack effects of all six ex Pokémon in B4 that were still missing implementations. Each card is its own commit so they can be reviewed independently.

| Commit | Card | Attack | Approach |
| --- | --- | --- | --- |
| `d4c9d20` | Mega Metagross ex (B4 109/187/200) | Gatling Slug | Map-only — reuses `ExtraDamagePerSpecificEnergy` |
| `ba198f5` | Rotom ex (B4 055/184/202) | Junk Spark | Generalizes `ExtraDamagePerSupporterInDiscard` → `ExtraDamagePerTrainerTypeInDiscard` |
| `d924616` | Wailord ex (B4 037/183/197) | Wondrous Waves | New `SelfCureStatusConditions` mechanic |
| `2e329f4` | Mega Rayquaza ex (B4 120/188/203) | Mega Burst | New `SelfDiscardAllTypesEnergyDamagePerDiscarded` mechanic |
| `6aec9b1` | Gigalith ex (B4 229, plus B2 087/187/200) | Megaton Cannon | New `DirectDamageAndSelfCardEffect` mechanic |
| `569fa46` | Vespiquen ex (B4 011/180/194) | Chase Order | New `OptionalDiscardBenchedBasicForExtraDamage` mechanic + `DiscardOwnBenchedThenDamage` action |

After this, `card_status` reports every `ex` in B4 as ✓ Complete. Overall implemented cards go from 3279 to 3298 (87.2% → 87.7%); the badge is updated in a final separate commit.

## Notes on the two less obvious ones

**Rotom ex — Junk Spark.** "10 more damage for each Item card in your discard pile." Rather than adding a near-duplicate of the Supporter variant, the existing mechanic is generalized to take a `TrainerType`. Following the existing `item_search_outcomes` convention in `shared_mutations.rs`, Pokémon Tools are *not* counted as Item cards — worth a second opinion if that convention is meant to differ here.

**Vespiquen ex — Chase Order.** "You may discard 1 of your Benched Basic [G] Pokémon. If you do, this attack does 70 more damage." The choice changes the damage, so the boosted damage cannot be dealt as a separate second application — Weakness and other modifiers in `modify_damage` would be applied twice. The attack therefore deals no damage itself and instead queues one action per option: a plain `ApplyDamage` for declining, or a new `DiscardOwnBenchedThenDamage` that discards the chosen Benched Pokémon and then queues the boosted damage through the normal `ApplyDamage` pipeline (so Guts, Rocky Helmet and knockouts all still work). When no eligible Benched Basic [G] Pokémon is in play, no choice is offered and the attack simply deals its base damage.

## Testing

TDD throughout — tests were written and observed failing before each implementation. All are at the `Game` public API level under `tests/pokemon/`, driving behavior through `apply_action` / `generate_possible_actions`:

- `mega_metagross_ex_gatling_slug_test.rs` (2 tests)
- `rotom_ex_junk_spark_test.rs` (2 tests)
- `wailord_ex_wondrous_waves_test.rs` (2 tests)
- `mega_rayquaza_ex_mega_burst_test.rs` (2 tests)
- `gigalith_ex_megaton_cannon_test.rs` (2 tests)
- `vespiquen_ex_chase_order_test.rs` (3 tests)

`cargo test --features "tui test-utils"`, `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` all pass.

`cargo run --bin card_test` ran clean (10,000 games each) for B4 011, B4 037, B4 055, B4 120 and B4 229. It could **not** be run for Mega Metagross ex: the generated temp deck pulls in its evolution line, and Beldum's (B4 106) "Conductive Body" ability is not yet implemented, so the simulation panics in move generation. That is a pre-existing gap unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZTC6iqU3LZakWh2jrZRhZ

---
_Generated by [Claude Code](https://claude.ai/code/session_012ZTC6iqU3LZakWh2jrZRhZ)_