### PR TITLE
Implement every Item and Stadium card in B4 (Ruler of the Skies)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # deckgym-core: Pokémon TCG Pocket Simulator
 
-![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3298_%2F_3761_%2887.7%25%29-green)
+![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3302_%2F_3761_%2887.8%25%29-green)
 
 **deckgym-core** is a high-performance Rust library designed for simulating Pokémon TCG Pocket games. It features a command-line interface (CLI) capable of running 10,000 simulations in approximately 3 seconds. This is the library that powers https://www.deckgym.com.
 

--- a/src/actions/apply_stadium_action.rs
+++ b/src/actions/apply_stadium_action.rs
@@ -8,6 +8,7 @@ use crate::{
     models::{Card, EnergyType, TrainerType},
     stadiums::{
         is_area_zero_active, is_fragrant_forest_active, is_kids_room_active, is_mesagoza_active,
+        is_rainbow_cave_active,
     },
     State,
 };
@@ -33,7 +34,27 @@ pub(crate) fn forecast_use_stadium(state: &State, acting_player: usize) -> Outco
     if is_kids_room_active(state) {
         return forecast_kids_room_effect(state, acting_player);
     }
+    if is_rainbow_cave_active(state) {
+        return forecast_rainbow_cave_effect();
+    }
     Outcomes::single_fn(|_, _, _| {})
+}
+
+/// Rainbow Cave: Once during each player's turn, that player may discard the Energy that has been
+/// generated in their Energy Zone. If they do, the next Energy is produced.
+fn forecast_rainbow_cave_effect() -> Outcomes {
+    Outcomes::single_fn(|rng, state, action| {
+        let player = action.actor;
+        state.has_used_stadium[player] = true;
+        // The generated Energy is discarded like any other Energy, so it lands in the
+        // player's Energy discard pile (reachable by cards such as Professor Sada).
+        if let Some(discarded) = state.energy_zone[player].current {
+            state.discard_energies[player].push(discarded);
+            debug!("Rainbow Cave: Discarded {discarded:?} from the Energy Zone");
+        }
+        // Promote the previewed `next` Energy into `current` and queue a fresh one behind it.
+        state.rotate_energy_zone(player, rng);
+    })
 }
 
 /// Area Zero: Once during each player's turn, that player may shuffle a Basic Pokémon from their

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -26,7 +26,7 @@ use crate::{
 };
 
 use super::{
-    apply_action_helpers::Mutations,
+    apply_action_helpers::{Mutation, Mutations},
     outcomes::{CoinSeq, Outcomes},
     Action, SimpleAction,
 };
@@ -214,6 +214,7 @@ pub fn forecast_trainer_action(
             puppy_loving_girl_effect(acting_player, state)
         }
         CardId::B3b068Wallace | CardId::B3b085Wallace => wallace_effect(acting_player, state),
+        CardId::B4145OrderPad => order_pad_outcomes(acting_player, state),
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -469,6 +470,22 @@ fn arven_outcomes(acting_player: usize, state: &State) -> Outcomes {
 
     Outcomes::from_coin_branches(branches)
         .expect("arven_outcomes should produce valid coin branches")
+}
+
+// Order Pad: "Flip a coin. If heads, put a random Item card from your deck into your hand."
+fn order_pad_outcomes(acting_player: usize, state: &State) -> Outcomes {
+    let (item_probs, item_mutations) = item_search_outcomes(acting_player, state).into_branches();
+
+    let mut branches: Vec<(f64, Mutation, Vec<CoinSeq>)> = Vec::with_capacity(item_probs.len() + 1);
+    for (p, m) in item_probs.into_iter().zip(item_mutations) {
+        branches.push((p * 0.5, m, vec![CoinSeq(vec![true])]));
+    }
+    let tails_mutation: Mutation = Box::new(|_, _, _| debug!("Order Pad: Flipped tails"));
+    branches.push((0.5, tails_mutation, vec![CoinSeq(vec![false])]));
+
+    // Not `binary_coin`: heads fans out into many equally-weighted search outcomes (one per
+    // distinct Item card in the deck), not a single mutation.
+    Outcomes::from_coin_branches(branches).expect("Order Pad coin branches should be valid")
 }
 
 fn team_effect(rng: &mut StdRng, state: &mut State, action: &Action) {

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -13,7 +13,7 @@ use crate::{
     models::{Card, EnergyType, PlayedCard, TrainerCard, TrainerType, BASIC_STAGE},
     stadiums::{
         get_arena_of_antiquity_damage_bonus, get_training_area_damage_bonus,
-        is_bounded_field_active, is_hiking_trail_active,
+        is_bounded_field_active, is_hiking_trail_active, is_soothing_shore_active,
     },
     tools::has_tool,
     State,
@@ -389,7 +389,26 @@ pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
         }
     }
 
+    apply_soothing_shore_healing(player_ending_turn, state);
+
     apply_bad_dreams_damage(state);
+}
+
+/// Soothing Shore: At the end of each player's turn, that player heals 20 damage from each of
+/// their Pokémon that has any [W] Energy attached.
+fn apply_soothing_shore_healing(player_ending_turn: usize, state: &mut State) {
+    if !is_soothing_shore_active(state) {
+        return;
+    }
+    for pokemon in state.in_play_pokemon[player_ending_turn]
+        .iter_mut()
+        .flatten()
+    {
+        if pokemon.attached_energy.contains(&EnergyType::Water) {
+            debug!("Soothing Shore: Healing 20 from {}", pokemon.get_name());
+            pokemon.heal(20);
+        }
+    }
 }
 
 /// Apply Bad Dreams ability damage: for each player's Darkrai in play, if that player's

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -391,7 +391,34 @@ pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
 
     apply_soothing_shore_healing(player_ending_turn, state);
 
+    apply_deceptive_needle_damage(player_ending_turn, state);
+
     apply_bad_dreams_damage(state);
+}
+
+/// Deceptive Needle: At the end of your turn, if the [D] Pokémon this card is attached to is in
+/// the Active Spot, do 10 damage to your opponent's Active Pokémon.
+fn apply_deceptive_needle_damage(player_ending_turn: usize, state: &mut State) {
+    let Some(active) = state.maybe_get_active(player_ending_turn) else {
+        return;
+    };
+    if !has_tool(active, CardId::B4148DeceptiveNeedle)
+        || active.get_energy_type() != Some(EnergyType::Darkness)
+    {
+        return;
+    }
+    let opponent = (player_ending_turn + 1) % 2;
+    if state.in_play_pokemon[opponent][0].is_none() {
+        return;
+    }
+    debug!("Deceptive Needle: Doing 10 damage to opponent's Active Pokémon");
+    crate::actions::handle_damage(
+        state,
+        (player_ending_turn, 0),
+        &[(10, opponent, 0)],
+        false,
+        None,
+    );
 }
 
 /// Soothing Shore: At the end of each player's turn, that player heals 20 damage from each of

--- a/src/move_generation/mod.rs
+++ b/src/move_generation/mod.rs
@@ -7,6 +7,7 @@ use crate::hooks::{can_evolve_into, can_retreat, contains_energy, get_retreat_co
 use crate::models::Card;
 use crate::stadiums::{
     can_use_area_zero, can_use_fragrant_forest, can_use_kids_room, can_use_mesagoza,
+    can_use_rainbow_cave,
 };
 use crate::state::State;
 
@@ -116,6 +117,7 @@ pub fn generate_possible_actions(state: &State) -> (usize, Vec<Action>) {
         || can_use_fragrant_forest(state, current_player)
         || can_use_area_zero(state, current_player)
         || can_use_kids_room(state, current_player)
+        || can_use_rainbow_cave(state, current_player)
     {
         actions.push(SimpleAction::UseStadium);
     }

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -246,6 +246,7 @@ pub fn trainer_move_generation_implementation(
             can_play_trainer(state, trainer_card)
         }
         CardId::B3b068Wallace | CardId::B3b085Wallace => can_play_wallace(state, trainer_card),
+        CardId::B4145OrderPad => can_play_trainer(state, trainer_card),
         _ => None,
     }
 }

--- a/src/stadiums.rs
+++ b/src/stadiums.rs
@@ -52,6 +52,8 @@ static KIDS_ROOM_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3b069KidsRoom));
 static SOOTHING_SHORE_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B4154SoothingShore));
+static RAINBOW_CAVE_EFFECT: LazyLock<String> =
+    LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B4155RainbowCave));
 
 pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
     ensure_stadium_trainer(trainer_card);
@@ -69,6 +71,7 @@ pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == AREA_ZERO_EFFECT.as_str()
             || e == KIDS_ROOM_EFFECT.as_str()
             || e == SOOTHING_SHORE_EFFECT.as_str()
+            || e == RAINBOW_CAVE_EFFECT.as_str()
     )
 }
 
@@ -189,6 +192,18 @@ pub fn can_use_area_zero(state: &State, player: usize) -> bool {
 
 pub fn is_soothing_shore_active(state: &State) -> bool {
     has_stadium(state, CardId::B4154SoothingShore)
+}
+
+pub fn is_rainbow_cave_active(state: &State) -> bool {
+    has_stadium(state, CardId::B4155RainbowCave)
+}
+
+/// Returns true if the player can use Rainbow Cave's effect (stadium is active, not used this
+/// turn, and there is an Energy currently generated in their Energy Zone to discard).
+pub fn can_use_rainbow_cave(state: &State, player: usize) -> bool {
+    is_rainbow_cave_active(state)
+        && !state.has_used_stadium[player]
+        && state.energy_zone[player].current.is_some()
 }
 
 pub fn is_kids_room_active(state: &State) -> bool {

--- a/src/stadiums.rs
+++ b/src/stadiums.rs
@@ -50,6 +50,8 @@ static AREA_ZERO_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3a074AreaZero));
 static KIDS_ROOM_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B3b069KidsRoom));
+static SOOTHING_SHORE_EFFECT: LazyLock<String> =
+    LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B4154SoothingShore));
 
 pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
     ensure_stadium_trainer(trainer_card);
@@ -66,6 +68,7 @@ pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == FRAGRANT_FOREST_EFFECT.as_str()
             || e == AREA_ZERO_EFFECT.as_str()
             || e == KIDS_ROOM_EFFECT.as_str()
+            || e == SOOTHING_SHORE_EFFECT.as_str()
     )
 }
 
@@ -182,6 +185,10 @@ pub fn can_use_area_zero(state: &State, player: usize) -> bool {
         return false;
     }
     state.hands[player].iter().any(|card| card.is_basic())
+}
+
+pub fn is_soothing_shore_active(state: &State) -> bool {
+    has_stadium(state, CardId::B4154SoothingShore)
 }
 
 pub fn is_kids_room_active(state: &State) -> bool {

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -62,6 +62,8 @@ static SMALL_BALLOON_EFFECT: LazyLock<String> =
     LazyLock::new(|| tool_effect_text_from_card_id(CardId::B3b064SmallBalloon));
 static ELEGANT_CAPE_EFFECT: LazyLock<String> =
     LazyLock::new(|| tool_effect_text_from_card_id(CardId::B3b065ElegantCape));
+static DECEPTIVE_NEEDLE_EFFECT: LazyLock<String> =
+    LazyLock::new(|| tool_effect_text_from_card_id(CardId::B4148DeceptiveNeedle));
 
 pub fn tool_effects_equal(trainer_card: &TrainerCard, reference_tool_id: CardId) -> bool {
     ensure_tool_trainer(trainer_card);
@@ -114,5 +116,6 @@ pub fn is_tool_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == FUTURE_BOOSTER_ENERGY_CAPSULE_EFFECT.as_str()
             || e == SMALL_BALLOON_EFFECT.as_str()
             || e == ELEGANT_CAPE_EFFECT.as_str()
+            || e == DECEPTIVE_NEEDLE_EFFECT.as_str()
     )
 }

--- a/tests/stadiums.rs
+++ b/tests/stadiums.rs
@@ -6,5 +6,7 @@ mod arena_of_antiquity_test;
 mod fragrant_forest_test;
 #[path = "stadiums/kids_room_test.rs"]
 mod kids_room_test;
+#[path = "stadiums/soothing_shore_test.rs"]
+mod soothing_shore_test;
 #[path = "stadiums/stadium_test.rs"]
 mod stadium_test;

--- a/tests/stadiums.rs
+++ b/tests/stadiums.rs
@@ -6,6 +6,8 @@ mod arena_of_antiquity_test;
 mod fragrant_forest_test;
 #[path = "stadiums/kids_room_test.rs"]
 mod kids_room_test;
+#[path = "stadiums/rainbow_cave_test.rs"]
+mod rainbow_cave_test;
 #[path = "stadiums/soothing_shore_test.rs"]
 mod soothing_shore_test;
 #[path = "stadiums/stadium_test.rs"]

--- a/tests/stadiums/rainbow_cave_test.rs
+++ b/tests/stadiums/rainbow_cave_test.rs
@@ -1,0 +1,111 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn game_with_rainbow_cave(
+    current: Option<EnergyType>,
+    next: Option<EnergyType>,
+) -> deckgym::Game<'static> {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.active_stadium = Some(get_card_by_enum(CardId::B4155RainbowCave));
+    state.energy_zone[0].current = current;
+    state.energy_zone[0].next = next;
+    game.set_state(state);
+    game
+}
+
+fn use_stadium(game: &mut deckgym::Game<'static>, actor: usize) {
+    game.apply_action(&Action {
+        actor,
+        action: SimpleAction::UseStadium,
+        is_stack: false,
+    });
+}
+
+fn has_use_stadium(game: &deckgym::Game<'static>) -> bool {
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium))
+}
+
+#[test]
+fn test_rainbow_cave_discards_current_energy_and_produces_the_next_one() {
+    let mut game = game_with_rainbow_cave(Some(EnergyType::Fire), Some(EnergyType::Water));
+
+    assert!(
+        has_use_stadium(&game),
+        "UseStadium should be available while an Energy is generated in the Energy Zone"
+    );
+
+    use_stadium(&mut game, 0);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.energy_zone[0].current,
+        Some(EnergyType::Water),
+        "The previewed next Energy should be produced as the new current Energy"
+    );
+    assert!(
+        state.energy_zone[0].next.is_some(),
+        "A fresh next Energy should be queued up behind it"
+    );
+    assert_eq!(
+        state.discard_energies[0],
+        vec![EnergyType::Fire],
+        "The generated Energy should end up in the discard pile"
+    );
+    assert!(
+        state.has_used_stadium[0],
+        "Rainbow Cave is a once-per-turn stadium effect"
+    );
+    assert!(
+        !has_use_stadium(&game),
+        "Player 0 should not be able to use Rainbow Cave twice in one turn"
+    );
+}
+
+#[test]
+fn test_rainbow_cave_unavailable_when_energy_zone_is_empty() {
+    // `current` is None once the player has already attached their Energy for the turn,
+    // so there is nothing left to discard.
+    let game = game_with_rainbow_cave(None, Some(EnergyType::Water));
+
+    assert!(
+        !has_use_stadium(&game),
+        "UseStadium should not be offered when no Energy is generated in the Energy Zone"
+    );
+}
+
+#[test]
+fn test_rainbow_cave_new_energy_is_still_attachable_this_turn() {
+    let mut game = game_with_rainbow_cave(Some(EnergyType::Fire), Some(EnergyType::Water));
+    use_stadium(&mut game, 0);
+
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    let attaches_water = actions.iter().any(|action| match &action.action {
+        SimpleAction::Attach {
+            attachments,
+            is_turn_energy: true,
+        } => attachments
+            .iter()
+            .any(|(_, energy, _)| *energy == EnergyType::Water),
+        _ => false,
+    });
+    assert!(
+        attaches_water,
+        "The newly produced Energy should be attachable during the same turn"
+    );
+}

--- a/tests/stadiums/soothing_shore_test.rs
+++ b/tests/stadiums/soothing_shore_test.rs
@@ -1,0 +1,115 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard, TrainerCard},
+    test_support::get_initialized_game,
+};
+
+fn trainer_from_id(card_id: CardId) -> TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+fn end_turn(game: &mut deckgym::Game<'static>, actor: usize) {
+    game.apply_action(&Action {
+        actor,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+}
+
+#[test]
+fn test_soothing_shore_heals_only_water_energy_pokemon_of_player_ending_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            // Active has [W] Energy attached -> should heal 20.
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_energy(vec![EnergyType::Water])
+                .with_remaining_hp(30),
+            // Benched, but no [W] Energy -> should not heal.
+            PlayedCard::from_id(CardId::A1033Charmander)
+                .with_energy(vec![EnergyType::Fire])
+                .with_remaining_hp(30),
+        ],
+        vec![
+            // Opponent has [W] Energy too, but it is not their turn ending -> no heal.
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_energy(vec![EnergyType::Water])
+                .with_remaining_hp(30),
+        ],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0] = vec![get_card_by_enum(CardId::B4154SoothingShore)];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: trainer_from_id(CardId::B4154SoothingShore),
+        },
+        is_stack: false,
+    });
+    assert!(
+        game.get_state_clone().active_stadium.is_some(),
+        "Soothing Shore should be playable and become the active stadium"
+    );
+
+    end_turn(&mut game, 0);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_remaining_hp(0, 0),
+        50,
+        "Active with [W] Energy should heal 20 at the end of its owner's turn"
+    );
+    assert_eq!(
+        state.get_remaining_hp(0, 1),
+        30,
+        "Benched Pokemon without [W] Energy should not heal"
+    );
+    assert_eq!(
+        state.get_remaining_hp(1, 0),
+        30,
+        "Opponent's Pokemon should not heal at the end of the other player's turn"
+    );
+}
+
+#[test]
+fn test_soothing_shore_heals_the_opponent_when_their_turn_ends() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Water])
+            .with_remaining_hp(30)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Water])
+            .with_remaining_hp(30)],
+    );
+    state.current_player = 1;
+    state.turn_count = 4;
+    state.active_stadium = Some(get_card_by_enum(CardId::B4154SoothingShore));
+    game.set_state(state);
+
+    end_turn(&mut game, 1);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_remaining_hp(1, 0),
+        50,
+        "Stadium effects apply to both players: player 1 heals when player 1's turn ends"
+    );
+    assert_eq!(
+        state.get_remaining_hp(0, 0),
+        30,
+        "Player 0 should not heal at the end of player 1's turn"
+    );
+}

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -1,5 +1,7 @@
 #[path = "tools/booster_capsule_test.rs"]
 mod booster_capsule_test;
+#[path = "tools/deceptive_needle_test.rs"]
+mod deceptive_needle_test;
 #[path = "tools/lucky_egg_test.rs"]
 mod lucky_egg_test;
 #[path = "tools/lucky_ice_pop_test.rs"]

--- a/tests/tools/deceptive_needle_test.rs
+++ b/tests/tools/deceptive_needle_test.rs
@@ -1,0 +1,108 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn end_turn(game: &mut deckgym::Game<'static>, actor: usize) {
+    game.apply_action(&Action {
+        actor,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+}
+
+#[test]
+fn test_deceptive_needle_damages_opponent_active_at_end_of_holders_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        // Murkrow is a [D] Pokemon, so the needle's condition is met.
+        vec![PlayedCard::from_id(CardId::A2096Murkrow)
+            .with_tool(get_card_by_enum(CardId::B4148DeceptiveNeedle))],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    game.set_state(state);
+
+    let opponent_hp_before = game.get_state_clone().get_remaining_hp(1, 0);
+
+    end_turn(&mut game, 0);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_remaining_hp(1, 0),
+        opponent_hp_before - 10,
+        "Deceptive Needle should do 10 damage to the opponent's Active at the end of your turn"
+    );
+}
+
+#[test]
+fn test_deceptive_needle_does_nothing_on_a_non_darkness_holder() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        // Bulbasaur is [G], not [D], so the needle stays dormant.
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_tool(get_card_by_enum(CardId::B4148DeceptiveNeedle))],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    game.set_state(state);
+
+    let opponent_hp_before = game.get_state_clone().get_remaining_hp(1, 0);
+
+    end_turn(&mut game, 0);
+
+    assert_eq!(
+        game.get_state_clone().get_remaining_hp(1, 0),
+        opponent_hp_before,
+        "A non-[D] holder should not trigger Deceptive Needle"
+    );
+}
+
+#[test]
+fn test_deceptive_needle_does_nothing_from_the_bench_or_on_the_opponents_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass]),
+            // [D] holder, but benched rather than in the Active Spot.
+            PlayedCard::from_id(CardId::A2096Murkrow)
+                .with_tool(get_card_by_enum(CardId::B4148DeceptiveNeedle)),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    game.set_state(state);
+
+    let opponent_hp_before = game.get_state_clone().get_remaining_hp(1, 0);
+
+    // End player 0's turn: the needle is on the bench, so nothing happens.
+    end_turn(&mut game, 0);
+    assert_eq!(
+        game.get_state_clone().get_remaining_hp(1, 0),
+        opponent_hp_before,
+        "A benched holder should not trigger Deceptive Needle"
+    );
+
+    // End player 1's turn: the needle only fires at the end of *its owner's* turn, and
+    // player 0 (the owner) must not take damage from their own tool either.
+    let player_0_hp_before = game.get_state_clone().get_remaining_hp(0, 0);
+    end_turn(&mut game, 1);
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_remaining_hp(0, 0),
+        player_0_hp_before,
+        "Deceptive Needle should not fire at the end of the opponent's turn"
+    );
+}

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -14,6 +14,8 @@ mod juliana_test;
 mod korrina_cabbie_parasol_lady_test;
 #[path = "trainers/marlon_test.rs"]
 mod marlon_test;
+#[path = "trainers/order_pad_test.rs"]
+mod order_pad_test;
 #[path = "trainers/professor_sada_test.rs"]
 mod professor_sada_test;
 #[path = "trainers/professor_turo_test.rs"]

--- a/tests/trainers/order_pad_test.rs
+++ b/tests/trainers/order_pad_test.rs
@@ -1,0 +1,95 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard, TrainerCard},
+    test_support::get_initialized_game,
+};
+
+fn trainer_from_id(card_id: CardId) -> TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+/// Sets up a board where player 0 holds Order Pad and their deck only contains
+/// `deck_cards`, then plays Order Pad.
+fn play_order_pad(seed: u64, deck_cards: Vec<Card>) -> deckgym::State {
+    let order_pad = trainer_from_id(CardId::B4145OrderPad);
+
+    let mut game = get_initialized_game(seed);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0] = vec![Card::Trainer(order_pad.clone())];
+    state.decks[0].cards = deck_cards;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: order_pad,
+        },
+        is_stack: false,
+    });
+
+    game.get_state_clone()
+}
+
+#[test]
+fn test_order_pad_is_playable_and_puts_item_in_hand_on_heads() {
+    let potion = get_card_by_enum(CardId::PA001Potion);
+
+    let mut heads_seen = 0;
+    let mut tails_seen = 0;
+    for seed in 0..30 {
+        let state = play_order_pad(seed, vec![potion.clone()]);
+
+        if state.hands[0].contains(&potion) {
+            heads_seen += 1;
+            assert!(
+                state.decks[0].cards.is_empty(),
+                "Seed {seed}: the Item should have left the deck on heads"
+            );
+        } else {
+            tails_seen += 1;
+            assert_eq!(
+                state.decks[0].cards,
+                vec![potion.clone()],
+                "Seed {seed}: the Item should stay in the deck on tails"
+            );
+        }
+    }
+
+    assert!(heads_seen > 0, "Order Pad should hit heads for some seed");
+    assert!(tails_seen > 0, "Order Pad should hit tails for some seed");
+}
+
+#[test]
+fn test_order_pad_never_pulls_a_non_item_card() {
+    // Deck holds a Supporter, a Tool and a Pokemon: none of them are Item cards, so
+    // Order Pad can never move any of them to hand, on heads or tails.
+    let cynthia = get_card_by_enum(CardId::A2152Cynthia);
+    let giant_cape = get_card_by_enum(CardId::A2147GiantCape);
+    let charmander = get_card_by_enum(CardId::A1033Charmander);
+    let deck_cards = vec![cynthia, giant_cape, charmander];
+
+    for seed in 0..15 {
+        let state = play_order_pad(seed, deck_cards.clone());
+
+        assert_eq!(
+            state.decks[0].cards.len(),
+            deck_cards.len(),
+            "Seed {seed}: Order Pad should not pull non-Item cards out of the deck"
+        );
+        assert!(
+            state.hands[0].is_empty(),
+            "Seed {seed}: hand should stay empty when the deck has no Item cards"
+        );
+    }
+}


### PR DESCRIPTION
Implements the unimplemented Item and Stadium cards in the B4 (Ruler of the Skies) set. **Each card is its own commit** so they can be reviewed and dropped independently.

## Cards

| Commit | Card | Type | Effect |
|---|---|---|---|
| `ffe1613` | B4 145 Order Pad | Item | Flip a coin. If heads, put a random Item card from your deck into your hand. |
| `0a5e856` | B4 154 Soothing Shore | Stadium | At the end of each player's turn, that player heals 20 damage from each of their Pokémon that has any [W] Energy attached. |
| `842a199` | B4 155 Rainbow Cave | Stadium | Once during each player's turn, that player may discard the Energy generated in their Energy Zone. If they do, the next Energy is produced. |
| `d22e501` | B4 148 Deceptive Needle | Tool | At the end of your turn, if the [D] Pokémon this card is attached to is in the Active Spot, do 10 damage to your opponent's Active Pokémon. |

## Scope note

`TrainerType::Item` and `TrainerType::Tool` are distinct in this codebase, so "every Item card" is ambiguous: strictly by that enum the only Item card is Order Pad. Because TCG Pocket prints Pokémon Tools as Item cards, the B4 Tools were included as well. Supporters (Psychic, Drayden, Skyla, Wally) are deliberately left out.

**B4 149 Clear Veil was dropped at the author's request** and is no longer part of this branch. It remains unimplemented, along with the four B4 Supporters.

## Notable implementation decisions

- **Rainbow Cave** is modeled as an activated stadium (`UseStadium`), gated on there actually being a generated Energy to discard. Using it discards `energy_zone.current` into the player's Energy discard pile and then rotates the zone, so the previewed `next` Energy becomes attachable in the same turn. The discarded Energy lands in `discard_energies` for consistency with every other "discard Energy" path in the engine, which means cards like Professor Sada can reach it — worth a second opinion if that's not the intended reading.
- **Soothing Shore** and **Deceptive Needle** both hook into `on_end_turn`, keyed on the player whose turn is ending. Deceptive Needle is gated on the holder being that player's Active Pokémon *and* a [D] Pokémon.
- **Order Pad** reuses the existing `item_search_outcomes` search branch, wrapped in a coin flip like Arven's item/tool split.

## Testing

TDD throughout — tests were written and observed failing before each implementation.

- New Game-level integration tests: `tests/trainers/order_pad_test.rs`, `tests/stadiums/soothing_shore_test.rs`, `tests/stadiums/rainbow_cave_test.rs`, `tests/tools/deceptive_needle_test.rs` (9 tests total, all driving the public `Game` API). The Order Pad tests include a negative control so they can't pass vacuously.
- `cargo test --features "tui test-utils"` — full suite green, 632 passed / 0 failed.
- `cargo run --bin card_test -- "<id>"` — 10,000 random games per card against all decks in `example_decks/`, no errors for any of the four.
- `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.

Card count badge updated: 3298 → 3302 (87.8%).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MBkNJNkNX6HuFcLDUdFaEG