### PR TITLE
Implement all B4 Supporter cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # deckgym-core: Pokémon TCG Pocket Simulator
 
-![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3298_%2F_3761_%2887.7%25%29-green)
+![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3306_%2F_3761_%2887.9%25%29-green)
 
 **deckgym-core** is a high-performance Rust library designed for simulating Pokémon TCG Pocket games. It features a command-line interface (CLI) capable of running 10,000 simulations in approximately 3 seconds. This is the library that powers https://www.deckgym.com.
 

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -71,6 +71,7 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::DiscardToolFromPokemon { .. }
         | SimpleAction::DiscardActiveStadium
         | SimpleAction::DiscardRandomOpponentActiveEnergy
+        | SimpleAction::MoveRandomOpponentEnergyToActive { .. }
         | SimpleAction::ApplyStatusToOpponentActive { .. }
         | SimpleAction::Noop => forecast_deterministic_action(),
         SimpleAction::UseAbility { in_play_idx } => forecast_ability(state, action, *in_play_idx),
@@ -346,6 +347,12 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
                 state.discard_from_active(opponent, &[energy]);
             }
         }
+        SimpleAction::MoveRandomOpponentEnergyToActive { from_in_play_idx } => {
+            let opponent = (action.actor + 1) % 2;
+            // NOTE: Using the last energy instead of a random one to avoid expanding the game
+            // tree, mirroring DiscardRandomOpponentActiveEnergy and Piers.
+            apply_move_last_energy(state, opponent, *from_in_play_idx, 0);
+        }
         SimpleAction::ApplyStatusToOpponentActive { condition } => {
             let opponent = (action.actor + 1) % 2;
             state.apply_status_condition(opponent, 0, *condition);
@@ -384,6 +391,17 @@ fn apply_attach_tool(state: &mut State, actor: usize, in_play_idx: usize, tool_c
         && pokemon.get_energy_type() == Some(crate::models::EnergyType::Metal)
     {
         pokemon.cure_status_conditions();
+    }
+}
+
+/// Moves 1 Energy from `from_idx` to `to_idx` within `player`'s own board, without the caller
+/// having to know which Energy types are attached.
+fn apply_move_last_energy(state: &mut State, player: usize, from_idx: usize, to_idx: usize) {
+    let energy = state.in_play_pokemon[player][from_idx]
+        .as_ref()
+        .and_then(|pokemon| pokemon.attached_energy.last().copied());
+    if let Some(energy) = energy {
+        apply_move_energy(state, player, from_idx, to_idx, energy, 1);
     }
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -20,7 +20,7 @@ use crate::{
     effects::{CardEffect, TurnEffect},
     hooks::{
         attack_effect_ignores_opponent_active_effects, can_evolve_into, contains_energy,
-        get_attack_cost, get_retreat_cost, get_stage,
+        get_attack_cost, get_extra_random_spread_hits, get_retreat_cost, get_stage,
     },
     models::{Attack, Card, EnergyType, StatusCondition, TrainerType},
     State,
@@ -597,7 +597,12 @@ fn forecast_effect_attack_by_mechanic(
             times,
             damage_per_hit,
             include_own_bench,
-        } => random_spread_damage(state, *times, *damage_per_hit, *include_own_bench),
+        } => random_spread_damage(
+            state,
+            *times + get_extra_random_spread_hits(state, &attack.title),
+            *damage_per_hit,
+            *include_own_bench,
+        ),
         Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage } => {
             extra_damage_if_knocked_out_last_turn_attack(state, attack.fixed_damage, *extra_damage)
         }

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -14,8 +14,8 @@ use crate::{
     },
     card_ids::CardId,
     card_logic::{
-        can_rare_candy_evolve, diantha_targets, ilima_targets, quick_grow_extract_candidates,
-        wallace_candidates,
+        can_rare_candy_evolve, diantha_targets, ilima_targets, psychic_energy_sources,
+        quick_grow_extract_candidates, wallace_candidates,
     },
     combinatorics::generate_combinations,
     effects::TurnEffect,
@@ -216,6 +216,7 @@ pub fn forecast_trainer_action(
         CardId::B3b068Wallace | CardId::B3b085Wallace => wallace_effect(acting_player, state),
         CardId::B4152Skyla | CardId::B4192Skyla => Outcomes::single_fn(skyla_effect),
         CardId::B4153Wally | CardId::B4193Wally => Outcomes::single_fn(wally_effect),
+        CardId::B4150Psychic | CardId::B4190Psychic => Outcomes::single_fn(psychic_effect),
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1186,6 +1187,19 @@ fn skyla_effect(_: &mut StdRng, state: &mut State, action: &Action) {
         state
             .move_generation_stack
             .push((action.actor, possible_activations));
+    }
+}
+
+fn psychic_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Choose 1 of your opponent's Benched Pokémon and move a random Energy from it to your
+    // opponent's Active Pokémon.
+    let opponent = (action.actor + 1) % 2;
+    let choices = psychic_energy_sources(state, opponent)
+        .into_iter()
+        .map(|from_in_play_idx| SimpleAction::MoveRandomOpponentEnergyToActive { from_in_play_idx })
+        .collect::<Vec<_>>();
+    if !choices.is_empty() {
+        state.move_generation_stack.push((action.actor, choices));
     }
 }
 

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -217,6 +217,7 @@ pub fn forecast_trainer_action(
         CardId::B4152Skyla | CardId::B4192Skyla => Outcomes::single_fn(skyla_effect),
         CardId::B4153Wally | CardId::B4193Wally => Outcomes::single_fn(wally_effect),
         CardId::B4150Psychic | CardId::B4190Psychic => Outcomes::single_fn(psychic_effect),
+        CardId::B4151Drayden | CardId::B4191Drayden => Outcomes::single_fn(drayden_effect),
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1188,6 +1189,18 @@ fn skyla_effect(_: &mut StdRng, state: &mut State, action: &Action) {
             .move_generation_stack
             .push((action.actor, possible_activations));
     }
+}
+
+fn drayden_effect(_: &mut StdRng, state: &mut State, _: &Action) {
+    // During this turn, 1 of your opponent's Pokémon is chosen 1 more time for the Draco Meteor
+    // attack used by your Pokémon.
+    state.add_turn_effect(
+        TurnEffect::ExtraRandomSpreadHits {
+            amount: 1,
+            attack_name: "Draco Meteor".to_string(),
+        },
+        0,
+    );
 }
 
 fn psychic_effect(_: &mut StdRng, state: &mut State, action: &Action) {

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -214,6 +214,7 @@ pub fn forecast_trainer_action(
             puppy_loving_girl_effect(acting_player, state)
         }
         CardId::B3b068Wallace | CardId::B3b085Wallace => wallace_effect(acting_player, state),
+        CardId::B4152Skyla | CardId::B4192Skyla => Outcomes::single_fn(skyla_effect),
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1169,6 +1170,22 @@ fn lyra_effect(_: &mut StdRng, state: &mut State, action: &Action) {
     state
         .move_generation_stack
         .push((action.actor, possible_activations))
+}
+
+fn skyla_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Switch your Active Stage 1 Pokémon with 1 of your Benched Pokémon.
+    let possible_activations = state
+        .enumerate_bench_pokemon(action.actor)
+        .map(|(in_play_idx, _)| SimpleAction::Activate {
+            player: action.actor,
+            in_play_idx,
+        })
+        .collect::<Vec<_>>();
+    if !possible_activations.is_empty() {
+        state
+            .move_generation_stack
+            .push((action.actor, possible_activations));
+    }
 }
 
 fn eevee_bag_effect(_: &mut StdRng, state: &mut State, action: &Action) {

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -215,6 +215,7 @@ pub fn forecast_trainer_action(
         }
         CardId::B3b068Wallace | CardId::B3b085Wallace => wallace_effect(acting_player, state),
         CardId::B4152Skyla | CardId::B4192Skyla => Outcomes::single_fn(skyla_effect),
+        CardId::B4153Wally | CardId::B4193Wally => Outcomes::single_fn(wally_effect),
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1185,6 +1186,23 @@ fn skyla_effect(_: &mut StdRng, state: &mut State, action: &Action) {
         state
             .move_generation_stack
             .push((action.actor, possible_activations));
+    }
+}
+
+fn wally_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Take a [C] Energy from your Energy Zone and attach it to 1 of your Stage 2 Pokémon.
+    let possible_targets = state
+        .enumerate_in_play_pokemon(action.actor)
+        .filter(|(_, pokemon)| get_stage(pokemon) == 2)
+        .map(|(in_play_idx, _)| SimpleAction::Attach {
+            attachments: vec![(1, EnergyType::Colorless, in_play_idx)],
+            is_turn_energy: false,
+        })
+        .collect::<Vec<_>>();
+    if !possible_targets.is_empty() {
+        state
+            .move_generation_stack
+            .push((action.actor, possible_targets));
     }
 }
 

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -164,6 +164,11 @@ pub enum SimpleAction {
     DiscardActiveStadium,
     /// Crawdaunt's Unruly Claw: discard a random Energy from the opponent's Active Pokémon
     DiscardRandomOpponentActiveEnergy,
+    /// Psychic (Supporter): move a random Energy from one of the opponent's Benched Pokémon to
+    /// the opponent's Active Pokémon.
+    MoveRandomOpponentEnergyToActive {
+        from_in_play_idx: usize,
+    },
     /// Apply a chosen Special Condition to the opponent's Active Pokémon (e.g. Dustox's Select Powder).
     ApplyStatusToOpponentActive {
         condition: StatusCondition,
@@ -336,6 +341,9 @@ impl fmt::Display for SimpleAction {
             SimpleAction::DiscardActiveStadium => write!(f, "DiscardActiveStadium"),
             SimpleAction::DiscardRandomOpponentActiveEnergy => {
                 write!(f, "DiscardRandomOpponentActiveEnergy")
+            }
+            SimpleAction::MoveRandomOpponentEnergyToActive { from_in_play_idx } => {
+                write!(f, "MoveRandomOpponentEnergyToActive({from_in_play_idx})")
             }
             SimpleAction::UseStadium => write!(f, "UseStadium"),
             SimpleAction::ApplyStatusToOpponentActive { condition } => {

--- a/src/card_logic/mod.rs
+++ b/src/card_logic/mod.rs
@@ -1,11 +1,13 @@
 mod diantha;
 mod ilima;
+mod psychic;
 mod quick_grow_extract;
 mod rare_candy;
 mod wallace;
 
 pub use diantha::diantha_targets;
 pub use ilima::ilima_targets;
+pub use psychic::{active_has_psychic_attack, psychic_energy_sources};
 pub use quick_grow_extract::quick_grow_extract_candidates;
 pub use rare_candy::{can_rare_candy_evolve, get_highest_evolutions};
 pub use wallace::wallace_candidates;

--- a/src/card_logic/psychic.rs
+++ b/src/card_logic/psychic.rs
@@ -1,0 +1,27 @@
+use crate::State;
+
+/// Name of the attack the Psychic Supporter requires in the Active Spot.
+const PSYCHIC_ATTACK: &str = "Psychic";
+
+/// Psychic (Supporter) can only be used if the player's Active Pokémon has the Psychic attack.
+pub fn active_has_psychic_attack(state: &State, player: usize) -> bool {
+    state.maybe_get_active(player).is_some_and(|active| {
+        active
+            .card
+            .get_attacks()
+            .iter()
+            .any(|attack| attack.title == PSYCHIC_ATTACK)
+    })
+}
+
+/// The opponent's Benched Pokémon that have Energy to move to their Active Pokémon.
+pub fn psychic_energy_sources(state: &State, opponent: usize) -> Vec<usize> {
+    if state.maybe_get_active(opponent).is_none() {
+        return vec![];
+    }
+    state
+        .enumerate_bench_pokemon(opponent)
+        .filter(|(_, pokemon)| !pokemon.attached_energy.is_empty())
+        .map(|(in_play_idx, _)| in_play_idx)
+        .collect()
+}

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -122,6 +122,12 @@ pub enum TurnEffect {
         amount: u32,
     },
     ForceFirstHeads,
+    /// A random-spread attack with this name chooses a Pokémon `amount` more times
+    /// (e.g. Drayden boosting Draco Meteor).
+    ExtraRandomSpreadHits {
+        amount: usize,
+        attack_name: String,
+    },
     BonusPointForHaxorusActiveKO,
     ReducedAttackCostForSpecificPokemon {
         amount: u8,

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -881,6 +881,22 @@ fn get_future_booster_damage_bonus(attacking_pokemon: &PlayedCard) -> u32 {
     0
 }
 
+/// Extra times a random-spread attack (e.g. Draco Meteor) chooses a Pokémon this turn, granted
+/// by cards like Drayden.
+pub(crate) fn get_extra_random_spread_hits(state: &State, attack_name: &str) -> usize {
+    state
+        .get_current_turn_effects()
+        .iter()
+        .filter_map(|effect| match effect {
+            TurnEffect::ExtraRandomSpreadHits {
+                amount,
+                attack_name: effect_attack_name,
+            } if effect_attack_name == attack_name => Some(*amount),
+            _ => None,
+        })
+        .sum()
+}
+
 // TODO: Confirm is_from_attack and goes to enemy active
 pub(crate) fn modify_damage(
     state: &State,

--- a/src/hooks/mod.rs
+++ b/src/hooks/mod.rs
@@ -12,6 +12,7 @@ pub(crate) use core::can_play_support;
 pub(crate) use core::contains_energy;
 pub(crate) use core::energy_missing;
 pub(crate) use core::get_attack_cost;
+pub(crate) use core::get_extra_random_spread_hits;
 pub(crate) use core::get_stage;
 pub(crate) use core::is_ancient_pokemon;
 pub(crate) use core::is_future_pokemon;

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -247,6 +247,7 @@ pub fn trainer_move_generation_implementation(
         }
         CardId::B3b068Wallace | CardId::B3b085Wallace => can_play_wallace(state, trainer_card),
         CardId::B4152Skyla | CardId::B4192Skyla => can_play_skyla(state, trainer_card),
+        CardId::B4153Wally | CardId::B4193Wally => can_play_wally(state, trainer_card),
         _ => None,
     }
 }
@@ -699,6 +700,18 @@ fn can_play_skyla(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simpl
         .is_some_and(|active| get_stage(active) == 1);
     let has_bench = state.enumerate_bench_pokemon(player).count() > 0;
     if active_is_stage_1 && has_bench {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
+}
+
+/// Check if Wally can be played (requires at least 1 Stage 2 Pokémon in play)
+fn can_play_wally(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let has_stage_2 = state
+        .enumerate_in_play_pokemon(state.current_player)
+        .any(|(_, pokemon)| get_stage(pokemon) == 2);
+    if has_stage_2 {
         can_play_trainer(state, trainer_card)
     } else {
         cannot_play_trainer()

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -2,8 +2,8 @@ use crate::{
     actions::{abilities::AbilityMechanic, get_ability_mechanic, SimpleAction},
     card_ids::CardId,
     card_logic::{
-        can_rare_candy_evolve, diantha_targets, ilima_targets, quick_grow_extract_candidates,
-        wallace_candidates,
+        active_has_psychic_attack, can_rare_candy_evolve, diantha_targets, ilima_targets,
+        psychic_energy_sources, quick_grow_extract_candidates, wallace_candidates,
     },
     effects::TurnEffect,
     hooks::{
@@ -248,6 +248,7 @@ pub fn trainer_move_generation_implementation(
         CardId::B3b068Wallace | CardId::B3b085Wallace => can_play_wallace(state, trainer_card),
         CardId::B4152Skyla | CardId::B4192Skyla => can_play_skyla(state, trainer_card),
         CardId::B4153Wally | CardId::B4193Wally => can_play_wally(state, trainer_card),
+        CardId::B4150Psychic | CardId::B4190Psychic => can_play_psychic(state, trainer_card),
         _ => None,
     }
 }
@@ -712,6 +713,20 @@ fn can_play_wally(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simpl
         .enumerate_in_play_pokemon(state.current_player)
         .any(|(_, pokemon)| get_stage(pokemon) == 2);
     if has_stage_2 {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
+}
+
+/// Check if Psychic (Supporter) can be played (requires the Active Pokémon to have the Psychic
+/// attack, and an opponent's Benched Pokémon with Energy to move)
+fn can_play_psychic(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let player = state.current_player;
+    let opponent = (player + 1) % 2;
+    if active_has_psychic_attack(state, player)
+        && !psychic_energy_sources(state, opponent).is_empty()
+    {
         can_play_trainer(state, trainer_card)
     } else {
         cannot_play_trainer()

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -246,6 +246,7 @@ pub fn trainer_move_generation_implementation(
             can_play_trainer(state, trainer_card)
         }
         CardId::B3b068Wallace | CardId::B3b085Wallace => can_play_wallace(state, trainer_card),
+        CardId::B4152Skyla | CardId::B4192Skyla => can_play_skyla(state, trainer_card),
         _ => None,
     }
 }
@@ -688,6 +689,20 @@ fn can_play_lyra(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simple
         }
     }
     cannot_play_trainer()
+}
+
+/// Check if Skyla can be played (requires a Stage 1 Active Pokémon and at least 1 benched Pokémon)
+fn can_play_skyla(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let player = state.current_player;
+    let active_is_stage_1 = state
+        .maybe_get_active(player)
+        .is_some_and(|active| get_stage(active) == 1);
+    let has_bench = state.enumerate_bench_pokemon(player).count() > 0;
+    if active_is_stage_1 && has_bench {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
 }
 
 /// Check if Eevee Bag can be played (requires at least 1 Pokemon that evolved from Eevee in play)

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -249,6 +249,7 @@ pub fn trainer_move_generation_implementation(
         CardId::B4152Skyla | CardId::B4192Skyla => can_play_skyla(state, trainer_card),
         CardId::B4153Wally | CardId::B4193Wally => can_play_wally(state, trainer_card),
         CardId::B4150Psychic | CardId::B4190Psychic => can_play_psychic(state, trainer_card),
+        CardId::B4151Drayden | CardId::B4191Drayden => can_play_trainer(state, trainer_card),
         _ => None,
     }
 }

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -76,6 +76,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::DiscardToolFromPokemon { .. } => 5,
         SimpleAction::DiscardActiveStadium => 5,
         SimpleAction::DiscardRandomOpponentActiveEnergy => 10,
+        SimpleAction::MoveRandomOpponentEnergyToActive { .. } => 10,
         SimpleAction::ApplyStatusToOpponentActive { .. } => 10,
         SimpleAction::UseStadium => 5, // Stadium abilities like Mesagoza
         SimpleAction::Noop => 0,       // No operation has no weight

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -18,6 +18,8 @@ mod marlon_test;
 mod professor_sada_test;
 #[path = "trainers/professor_turo_test.rs"]
 mod professor_turo_test;
+#[path = "trainers/psychic_test.rs"]
+mod psychic_test;
 #[path = "trainers/puppy_loving_girl_test.rs"]
 mod puppy_loving_girl_test;
 #[path = "trainers/skyla_test.rs"]

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -20,6 +20,8 @@ mod professor_sada_test;
 mod professor_turo_test;
 #[path = "trainers/puppy_loving_girl_test.rs"]
 mod puppy_loving_girl_test;
+#[path = "trainers/skyla_test.rs"]
+mod skyla_test;
 #[path = "trainers/volkner_test.rs"]
 mod volkner_test;
 #[path = "trainers/wallace_test.rs"]

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -26,3 +26,5 @@ mod skyla_test;
 mod volkner_test;
 #[path = "trainers/wallace_test.rs"]
 mod wallace_test;
+#[path = "trainers/wally_test.rs"]
+mod wally_test;

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -2,6 +2,8 @@
 mod barry_test;
 #[path = "trainers/cynthia_test.rs"]
 mod cynthia_test;
+#[path = "trainers/drayden_test.rs"]
+mod drayden_test;
 #[path = "trainers/elesa_test.rs"]
 mod elesa_test;
 #[path = "trainers/field_blower_test.rs"]

--- a/tests/trainers/drayden_test.rs
+++ b/tests/trainers/drayden_test.rs
@@ -1,0 +1,113 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+    Game,
+};
+
+fn make_trainer_card(card_id: CardId) -> deckgym::models::TrainerCard {
+    get_card_by_enum(card_id).as_trainer()
+}
+
+/// Rayquaza ex's Draco Meteor against a lone Wailord ex: every hit lands on the same target,
+/// so the total damage is fully determined by the number of times a Pokémon is chosen.
+fn game_with_rayquaza_against_wailord() -> Game<'static> {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::PA064RayquazaEx)
+            .with_energy(vec![EnergyType::Colorless; 4])],
+        vec![PlayedCard::from_id(CardId::B4037WailordEx)],
+    );
+    state.hands[0] = vec![Card::Trainer(make_trainer_card(CardId::B4151Drayden))];
+    game.set_state(state);
+    game
+}
+
+#[test]
+fn test_draco_meteor_without_drayden_hits_four_times() {
+    let mut game = game_with_rayquaza_against_wailord();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::PA064RayquazaEx, 0),
+        is_stack: false,
+    });
+
+    // 4 chosen times x 40 damage = 160.
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 250 - 160);
+}
+
+/// Drayden: "During this turn, 1 of your opponent's Pokémon is chosen 1 more time for the
+/// Draco Meteor attack used by your Pokémon."
+#[test]
+fn test_drayden_adds_one_draco_meteor_hit() {
+    let mut game = game_with_rayquaza_against_wailord();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: make_trainer_card(CardId::B4151Drayden),
+        },
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::PA064RayquazaEx, 0),
+        is_stack: false,
+    });
+
+    // 5 chosen times x 40 damage = 200.
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 250 - 200);
+}
+
+#[test]
+fn test_drayden_does_not_boost_other_random_spread_attacks() {
+    // Magcargo's Spurt Fire also chooses its targets at random, but Drayden only names the
+    // Draco Meteor attack, so its total damage must stay at 3 x 50.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A4031Magcargo).with_energy(vec![EnergyType::Fire; 2]),
+            PlayedCard::from_id(CardId::B4037WailordEx),
+        ],
+        vec![PlayedCard::from_id(CardId::B4037WailordEx)],
+    );
+    state.hands[0] = vec![Card::Trainer(make_trainer_card(CardId::B4151Drayden))];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: make_trainer_card(CardId::B4151Drayden),
+        },
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A4031Magcargo, 0),
+        is_stack: false,
+    });
+
+    // Spurt Fire spreads 3 x 50 between the opponent's Wailord ex and Magcargo's own benched
+    // Wailord ex; neither can be Knocked Out by 150 damage, so the totals are readable.
+    let state = game.get_state_clone();
+    let opponent_damage = 250 - state.get_active(1).get_remaining_hp();
+    let own_bench_damage = 250
+        - state.in_play_pokemon[0][1]
+            .as_ref()
+            .expect("Benched Wailord ex should survive")
+            .get_remaining_hp();
+    assert_eq!(opponent_damage + own_bench_damage, 150);
+}

--- a/tests/trainers/psychic_test.rs
+++ b/tests/trainers/psychic_test.rs
@@ -1,0 +1,128 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn make_trainer_card(card_id: CardId) -> deckgym::models::TrainerCard {
+    get_card_by_enum(card_id).as_trainer()
+}
+
+/// Psychic (Supporter): "You can use this card only if your Pokémon in the Active Spot has the
+/// Psychic attack. Choose 1 of your opponent's Benched Pokémon and move a random Energy from it
+/// to your opponent's Active Pokémon."
+#[test]
+fn test_psychic_moves_energy_from_opponent_bench_to_opponent_active() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    // Alakazam has the Psychic attack, so the Supporter is usable.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1117Alakazam)],
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1033Charmander)
+                .with_energy(vec![EnergyType::Fire, EnergyType::Fire]),
+        ],
+    );
+
+    let psychic = make_trainer_card(CardId::B4150Psychic);
+    state.hands[0] = vec![Card::Trainer(psychic.clone())];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: psychic,
+        },
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0, "The player who played Psychic makes the choice");
+    assert_eq!(
+        choices.len(),
+        1,
+        "Only the benched Charmander has Energy to move"
+    );
+    assert!(matches!(
+        choices[0].action,
+        SimpleAction::MoveRandomOpponentEnergyToActive {
+            from_in_play_idx: 1
+        }
+    ));
+    game.apply_action(&choices[0].clone());
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).attached_energy, vec![EnergyType::Fire]);
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("Charmander should still be benched")
+            .attached_energy,
+        vec![EnergyType::Fire]
+    );
+}
+
+#[test]
+fn test_psychic_cannot_be_played_without_psychic_attack_active() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    // Bulbasaur's only attack is Vine Whip, so Psychic can't be used.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1033Charmander).with_energy(vec![EnergyType::Fire]),
+        ],
+    );
+
+    let psychic = make_trainer_card(CardId::B4150Psychic);
+    state.hands[0] = vec![Card::Trainer(psychic)];
+    game.set_state(state);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        !choices.iter().any(
+            |choice| matches!(&choice.action, SimpleAction::Play { trainer_card } if trainer_card.id == "B4 150")
+        ),
+        "Psychic shouldn't be playable unless the Active Pokemon has the Psychic attack"
+    );
+}
+
+#[test]
+fn test_psychic_cannot_be_played_when_opponent_bench_has_no_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1117Alakazam)],
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass]),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+
+    let psychic = make_trainer_card(CardId::B4150Psychic);
+    state.hands[0] = vec![Card::Trainer(psychic)];
+    game.set_state(state);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        !choices.iter().any(
+            |choice| matches!(&choice.action, SimpleAction::Play { trainer_card } if trainer_card.id == "B4 150")
+        ),
+        "Psychic shouldn't be playable when no Benched opponent Pokemon has Energy"
+    );
+}

--- a/tests/trainers/skyla_test.rs
+++ b/tests/trainers/skyla_test.rs
@@ -2,7 +2,7 @@ use deckgym::{
     actions::{Action, SimpleAction},
     card_ids::CardId,
     database::get_card_by_enum,
-    models::{Card, PlayedCard},
+    models::{Card, EnergyType, PlayedCard},
     test_support::get_initialized_game,
 };
 
@@ -59,6 +59,66 @@ fn test_skyla_switches_active_stage_1_with_bench() {
             .get_name(),
         "Wartortle"
     );
+}
+
+#[test]
+fn test_skyla_does_not_consume_the_turn_retreat() {
+    // Skyla's switch is free: the player can still pay to retreat afterwards, putting the
+    // Pokemon Skyla promoted right back on the Bench.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1054Wartortle),
+            // Charmander needs 1 Energy to pay its own retreat cost once promoted.
+            PlayedCard::from_id(CardId::A1033Charmander).with_energy(vec![EnergyType::Fire]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let skyla = make_trainer_card(CardId::B4152Skyla);
+    state.hands[0] = vec![Card::Trainer(skyla.clone())];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: skyla,
+        },
+        is_stack: false,
+    });
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    game.apply_action(&choices[0].clone());
+    assert_eq!(
+        game.get_state_clone().get_active(0).get_name(),
+        "Charmander"
+    );
+
+    // The regular retreat for the turn is still available.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let retreat_action = choices
+        .iter()
+        .find(|choice| matches!(choice.action, SimpleAction::Retreat(1)))
+        .expect("Retreating should still be possible after Skyla")
+        .clone();
+    game.apply_action(&retreat_action);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(0).get_name(), "Wartortle");
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .expect("Charmander should be back on the Bench")
+            .get_name(),
+        "Charmander"
+    );
+    // The retreat was paid for, unlike Skyla's free switch.
+    assert!(state.get_active(0).attached_energy.is_empty());
+    assert_eq!(state.discard_energies[0], vec![EnergyType::Fire]);
 }
 
 #[test]

--- a/tests/trainers/skyla_test.rs
+++ b/tests/trainers/skyla_test.rs
@@ -1,0 +1,118 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn make_trainer_card(card_id: CardId) -> deckgym::models::TrainerCard {
+    get_card_by_enum(card_id).as_trainer()
+}
+
+/// Skyla: "Switch your Active Stage 1 Pokémon with 1 of your Benched Pokémon."
+#[test]
+fn test_skyla_switches_active_stage_1_with_bench() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    // Wartortle is a Stage 1, so Skyla can switch it out for the benched Charmander.
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1054Wartortle),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let skyla = make_trainer_card(CardId::B4152Skyla);
+    state.hands[0] = vec![Card::Trainer(skyla.clone())];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: skyla,
+        },
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(choices.iter().all(|choice| matches!(
+        choice.action,
+        SimpleAction::Activate {
+            player: 0,
+            in_play_idx: 1
+        }
+    )));
+    game.apply_action(&choices[0].clone());
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(0).get_name(), "Charmander");
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .expect("Wartortle should be benched")
+            .get_name(),
+        "Wartortle"
+    );
+}
+
+#[test]
+fn test_skyla_cannot_be_played_with_basic_active() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    // Squirtle is Basic, so Skyla has no legal target even though the bench is occupied.
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1053Squirtle),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let skyla = make_trainer_card(CardId::B4152Skyla);
+    state.hands[0] = vec![Card::Trainer(skyla)];
+    game.set_state(state);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        !choices.iter().any(
+            |choice| matches!(&choice.action, SimpleAction::Play { trainer_card } if trainer_card.id == "B4 152")
+        ),
+        "Skyla shouldn't be playable when the Active Pokemon isn't a Stage 1"
+    );
+}
+
+#[test]
+fn test_skyla_cannot_be_played_with_empty_bench() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1054Wartortle)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let skyla = make_trainer_card(CardId::B4152Skyla);
+    state.hands[0] = vec![Card::Trainer(skyla)];
+    game.set_state(state);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        !choices.iter().any(
+            |choice| matches!(&choice.action, SimpleAction::Play { trainer_card } if trainer_card.id == "B4 152")
+        ),
+        "Skyla shouldn't be playable without a Benched Pokemon to switch to"
+    );
+}

--- a/tests/trainers/wally_test.rs
+++ b/tests/trainers/wally_test.rs
@@ -1,0 +1,146 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn make_trainer_card(card_id: CardId) -> deckgym::models::TrainerCard {
+    get_card_by_enum(card_id).as_trainer()
+}
+
+/// Wally: "Take a [C] Energy from your Energy Zone and attach it to 1 of your Stage 2 Pokémon."
+#[test]
+fn test_wally_attaches_colorless_energy_to_stage_2() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    // Blastoise is a Stage 2; the benched Charmander is not a legal Wally target.
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1055Blastoise),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let wally = make_trainer_card(CardId::B4153Wally);
+    state.hands[0] = vec![Card::Trainer(wally.clone())];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: wally,
+        },
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(
+        choices.len(),
+        1,
+        "Only the Stage 2 Blastoise should be a Wally target"
+    );
+    assert!(matches!(
+        &choices[0].action,
+        SimpleAction::Attach { attachments, is_turn_energy: false }
+            if attachments == &vec![(1, EnergyType::Colorless, 0)]
+    ));
+    game.apply_action(&choices[0].clone());
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(0).attached_energy,
+        vec![EnergyType::Colorless]
+    );
+}
+
+#[test]
+fn test_wally_can_target_a_benched_stage_2() {
+    // Wally is not restricted to the Active Spot: every Stage 2 in play is a valid target.
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1055Blastoise),
+            PlayedCard::from_id(CardId::A1003Venusaur),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let wally = make_trainer_card(CardId::B4153Wally);
+    state.hands[0] = vec![Card::Trainer(wally.clone())];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: wally,
+        },
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(
+        choices.len(),
+        2,
+        "Both Stage 2 Pokemon should be targetable"
+    );
+    let bench_choice = choices
+        .iter()
+        .find(|choice| {
+            matches!(
+                &choice.action,
+                SimpleAction::Attach { attachments, .. }
+                    if attachments == &vec![(1, EnergyType::Colorless, 1)]
+            )
+        })
+        .expect("Benched Venusaur should be a Wally target")
+        .clone();
+    game.apply_action(&bench_choice);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .expect("Venusaur should still be benched")
+            .attached_energy,
+        vec![EnergyType::Colorless]
+    );
+    assert!(state.get_active(0).attached_energy.is_empty());
+}
+
+#[test]
+fn test_wally_cannot_be_played_without_stage_2() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 3;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1054Wartortle)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let wally = make_trainer_card(CardId::B4153Wally);
+    state.hands[0] = vec![Card::Trainer(wally)];
+    game.set_state(state);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        !choices.iter().any(
+            |choice| matches!(&choice.action, SimpleAction::Play { trainer_card } if trainer_card.id == "B4 153")
+        ),
+        "Wally shouldn't be playable without a Stage 2 Pokemon in play"
+    );
+}


### PR DESCRIPTION
Implements every Supporter card in the Ruler of the Skies (B4) set. Each card is its own commit so they can be reviewed independently, plus a final badge update.

| Commit | Card | Effect |
| --- | --- | --- |
| `Implement Skyla (B4 152)` | Skyla (B4 152 / B4 192) | Switch your Active Stage 1 Pokémon with 1 of your Benched Pokémon. |
| `Implement Wally (B4 153)` | Wally (B4 153 / B4 193) | Take a [C] Energy from your Energy Zone and attach it to 1 of your Stage 2 Pokémon. |
| `Implement Psychic (B4 150)` | Psychic (B4 150 / B4 190) | Usable only if your Active has the Psychic attack. Choose 1 of your opponent's Benched Pokémon and move a random Energy from it to your opponent's Active Pokémon. |
| `Implement Drayden (B4 151)` | Drayden (B4 151 / B4 191) | During this turn, 1 of your opponent's Pokémon is chosen 1 more time for the Draco Meteor attack used by your Pokémon. |

### Notable engine changes

- **`SimpleAction::MoveRandomOpponentEnergyToActive`** — Psychic moves Energy on the *opponent's* board while the *acting* player picks the source, which the existing `MoveEnergy` action (always applied to `action.actor`'s board) can't express. Like `DiscardRandomOpponentActiveEnergy` and Piers, it takes the last attached Energy rather than a true random one, to avoid expanding the game tree.
- **`TurnEffect::ExtraRandomSpreadHits { amount, attack_name }`** — Drayden adds extra "chosen times" to a named random-spread attack. The `RandomSpreadDamage` mechanic now adds `get_extra_random_spread_hits(state, &attack.title)` to its base `times`, so it works for every Draco Meteor variant (Dragonite, Rayquaza ex, Noivern) without per-card wiring.
- **`card_logic::psychic`** — shared move-generation/apply predicates (`active_has_psychic_attack`, `psychic_energy_sources`), following the existing `diantha`/`ilima`/`wallace` pattern.

### Testing

Tests were written before each implementation, at the `Game` public API level:

- `tests/trainers/skyla_test.rs` — switches an Active Stage 1 with the bench; not playable with a Basic Active or an empty bench.
- `tests/trainers/wally_test.rs` — attaches [C] to a Stage 2 only; benched Stage 2 targets work; not playable without a Stage 2.
- `tests/trainers/psychic_test.rs` — moves Energy from a chosen opponent bench slot to their Active; not playable without the Psychic attack or without an Energy source.
- `tests/trainers/drayden_test.rs` — Draco Meteor deals 4×40 baseline and 5×40 with Drayden; Magcargo's Spurt Fire is unaffected.

Also ran `cargo test --features "tui test-utils" --all-targets`, `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo run --bin card_test` for B4 150–153 (10,000 games each against all example decks, no errors).

`card_status` goes from 3298 to 3306 complete cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A3iHJYcd2ASFd8EaaJW862

---
_Generated by [Claude Code](https://claude.ai/code/session_01A3iHJYcd2ASFd8EaaJW862)_