### PR TITLE
Implement B4 cards: Raichu, Dustox, Cradily

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # deckgym-core: Pokémon TCG Pocket Simulator
 
-![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3310_%2F_3761_%2888.0%25%29-green)
+![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3315_%2F_3761_%2888.1%25%29-green)
 
 **deckgym-core** is a high-performance Rust library designed for simulating Pokémon TCG Pocket games. It features a command-line interface (CLI) capable of running 10,000 simulations in approximately 3 seconds. This is the library that powers https://www.deckgym.com.
 

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -183,6 +183,10 @@ pub enum AbilityMechanic {
     DamageOpponentActiveOnEvolve {
         amount: u32,
     },
+    /// Raichu's Evoshock: "Once during your turn, when you play this Pokémon from your hand to
+    /// evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is
+    /// now Paralyzed." Offered as an optional `UseAbility` when the evolution resolves.
+    CoinFlipParalyzeOpponentActiveOnEvolve,
     DiscardRandomEnergyFromOpponentActiveOnEvolve,
     CanEvolveIntoEeveeEvolution,
     CanEvolveOnFirstTurnIfActive,

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -1,4 +1,4 @@
-use crate::models::EnergyType;
+use crate::models::{EnergyType, StatusCondition};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum AbilityMechanic {
@@ -124,6 +124,12 @@ pub enum AbilityMechanic {
     PoisonOpponentActive,
     ConfuseOpponentActive,
     BurnOpponentActive,
+    /// Dustox's Variety Powder: 1 Special Condition is chosen at random from `options` and
+    /// inflicted on the opponent's Active Pokémon. Conditions already affecting that Pokémon are
+    /// excluded from the draw, so the ability is unusable once all `options` are applied.
+    RandomStatusConditionToOpponentActive {
+        options: Vec<StatusCondition>,
+    },
     RemoveRandomSpecialConditionFromActive,
     HealActiveYourPokemon {
         amount: u32,

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -240,6 +240,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::DamageOpponentActiveOnEvolve { .. } => {
             panic!("DamageOpponentActiveOnEvolve is triggered on evolve")
         }
+        AbilityMechanic::CoinFlipParalyzeOpponentActiveOnEvolve => {
+            coin_flip_paralyze_opponent_active()
+        }
         AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve => {
             panic!("DiscardRandomEnergyFromOpponentActiveOnEvolve is triggered on evolve")
         }
@@ -563,6 +566,16 @@ fn coin_flip_sleep_opponent_active() -> Outcomes {
         Box::new(|_, state, action| {
             let opponent = (action.actor + 1) % 2;
             state.apply_status_condition(opponent, 0, StatusCondition::Asleep);
+        }),
+        Box::new(|_, _, _| {}),
+    )
+}
+
+fn coin_flip_paralyze_opponent_active() -> Outcomes {
+    Outcomes::binary_coin(
+        Box::new(|_, state, action| {
+            let opponent = (action.actor + 1) % 2;
+            state.apply_status_condition(opponent, 0, StatusCondition::Paralyzed);
         }),
         Box::new(|_, _, _| {}),
     )

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -185,6 +185,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::PoisonOpponentActive => poison_opponent_active(),
         AbilityMechanic::ConfuseOpponentActive => confuse_opponent_active(),
         AbilityMechanic::BurnOpponentActive => burn_opponent_active(),
+        AbilityMechanic::RandomStatusConditionToOpponentActive { options } => {
+            random_status_condition_to_opponent_active(state, action.actor, options)
+        }
         AbilityMechanic::RemoveRandomSpecialConditionFromActive => {
             remove_random_special_condition_from_active()
         }
@@ -534,6 +537,51 @@ fn burn_opponent_active() -> Outcomes {
         let opponent = (action.actor + 1) % 2;
         state.apply_status_condition(opponent, 0, StatusCondition::Burned);
     })
+}
+
+/// Dustox's Variety Powder: one Special Condition is drawn uniformly at random from the options
+/// that aren't already affecting the opponent's Active Pokémon. Each candidate gets its own branch
+/// so the random draw is visible in the forecast.
+fn random_status_condition_to_opponent_active(
+    state: &State,
+    actor: usize,
+    options: &[StatusCondition],
+) -> Outcomes {
+    let opponent = (actor + 1) % 2;
+    let candidates = selectable_status_conditions(state, opponent, options);
+    if candidates.is_empty() {
+        return Outcomes::single_fn(|_, _, _| {});
+    }
+
+    let probability = 1.0 / candidates.len() as f64;
+    let probabilities = vec![probability; candidates.len()];
+    let mutations = candidates
+        .into_iter()
+        .map(|condition| -> Mutation {
+            Box::new(move |_, state, action| {
+                let opponent = (action.actor + 1) % 2;
+                state.apply_status_condition(opponent, 0, condition);
+            })
+        })
+        .collect();
+    Outcomes::from_parts(probabilities, mutations)
+}
+
+/// The subset of `options` that the given player's Active Pokémon isn't already affected by.
+pub(crate) fn selectable_status_conditions(
+    state: &State,
+    player: usize,
+    options: &[StatusCondition],
+) -> Vec<StatusCondition> {
+    let Some(active) = state.maybe_get_active(player) else {
+        return vec![];
+    };
+    let applied = active_special_conditions(active);
+    options
+        .iter()
+        .copied()
+        .filter(|condition| !applied.contains(condition))
+        .collect()
 }
 
 fn remove_random_special_condition_from_active() -> Outcomes {

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -707,7 +707,7 @@ pub(crate) fn apply_evolve(
     }
 
     // Run special logic hooks on evolution
-    on_evolve(acting_player, state, to_card, !from_deck)
+    on_evolve(acting_player, state, to_card, position, !from_deck)
 }
 
 fn forecast_pokemon_communication(

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -222,6 +222,18 @@ fn forecast_effect_attack_by_mechanic(
             *damage_per_heads,
         ),
         Mechanic::SelfHeal { amount } => self_heal_attack(*amount, attack),
+        Mechanic::SelfHealAndCardEffect {
+            heal_amount,
+            opponent,
+            effect,
+            duration,
+        } => self_heal_and_card_effect_attack(
+            attack.fixed_damage,
+            *heal_amount,
+            *opponent,
+            effect.clone(),
+            *duration,
+        ),
         Mechanic::HealOneYourPokemon { amount } => heal_one_your_pokemon_attack(*amount),
         Mechanic::HealOneYourBenchedPokemon { amount } => {
             heal_one_your_benched_pokemon_attack(*amount)
@@ -2132,6 +2144,28 @@ fn self_heal_attack(heal: u32, attack: &Attack) -> AttackOutcomes {
     active_damage_effect_doutcome(attack.fixed_damage, move |_, state, action| {
         let active = state.get_active_mut(action.actor);
         active.heal(heal);
+    })
+}
+
+/// Cradily's Stick and Absorb: damage, then heal the attacker and leave a `CardEffect` on the
+/// chosen Active Pokémon (`opponent: true` → the Defending Pokémon).
+fn self_heal_and_card_effect_attack(
+    damage: u32,
+    heal: u32,
+    opponent: bool,
+    effect: CardEffect,
+    effect_duration: u8,
+) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        state.get_active_mut(action.actor).heal(heal);
+        let target = if opponent {
+            (action.actor + 1) % 2
+        } else {
+            action.actor
+        };
+        if let Some(pokemon) = state.in_play_pokemon[target][0].as_mut() {
+            pokemon.add_effect(effect.clone(), effect_duration);
+        }
     })
 }
 

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -34,6 +34,15 @@ pub enum Mechanic {
     CoinFlipSelfHeal {
         amount: u32,
     },
+    /// Cradily's Stick and Absorb: deal damage, heal `heal_amount` from the attacking Pokémon, then
+    /// apply a `CardEffect` to an Active Pokémon (`opponent: true` → the Defending Pokémon).
+    /// `SelfHeal` plus `DamageAndCardEffect` in one attack.
+    SelfHealAndCardEffect {
+        heal_amount: u32,
+        opponent: bool,
+        effect: CardEffect,
+        duration: u8,
+    },
     SearchToHandByEnergy {
         energy_type: EnergyType,
     },

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -213,6 +213,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may draw 2 cards.",
             AbilityMechanic::DrawCardsOnEvolve { amount: 2 },
         );
+        map.insert(
+            "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
+            AbilityMechanic::CoinFlipParalyzeOpponentActiveOnEvolve,
+        );
         // map.insert("Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may have your opponent shuffle their hand into their deck. For each remaining point that your opponent needs to win, they draw a card.", todo_implementation);
         map.insert(
             "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may heal 60 damage from 1 of your [W] Pokémon.",

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -6,7 +6,7 @@ use std::sync::LazyLock;
 
 use crate::actions::abilities::AbilityMechanic;
 use crate::effects::CardEffect;
-use crate::models::{Card, EnergyType};
+use crate::models::{Card, EnergyType, StatusCondition};
 
 /// Map from ability effect text to its AbilityMechanic.
 pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMechanic>> =
@@ -336,6 +336,16 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "Once during your turn, you may take a [P] Energy from your Energy Zone and attach it to this Pokémon. If you use this Ability, your turn ends.",
             AbilityMechanic::AttachEnergyFromZoneToSelfAndEndTurn {
                 energy_type: EnergyType::Psychic,
+            },
+        );
+        map.insert(
+            "Once during your turn, you may use this Ability. 1 Special Condition from among Burned, Confused, and Poisoned is chosen at random, and your opponent's Active Pokémon is now affected by that Special Condition. Any Special Conditions already affecting that Pokémon will not be chosen.",
+            AbilityMechanic::RandomStatusConditionToOpponentActive {
+                options: vec![
+                    StatusCondition::Burned,
+                    StatusCondition::Confused,
+                    StatusCondition::Poisoned,
+                ],
             },
         );
         // map.insert("Pokémon (both yours and your opponent's) can't be healed.", todo_implementation);

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -816,6 +816,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::SelfHeal { amount: 30 },
     );
     map.insert(
+        "Heal 30 damage from this Pokémon. During your opponent's next turn, the Defending Pokémon can't retreat.",
+        Mechanic::SelfHealAndCardEffect {
+            heal_amount: 30,
+            opponent: true,
+            effect: CardEffect::NoRetreat,
+            duration: 1,
+        },
+    );
+    map.insert(
         "Heal 40 damage from this Pokémon.",
         Mechanic::SelfHeal { amount: 40 },
     );

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -16,6 +16,7 @@ pub mod professor_sada;
 mod shared_mutations;
 mod types;
 
+pub(crate) use apply_abilities_action::selectable_status_conditions;
 pub(crate) use apply_action::apply_action;
 pub(crate) use apply_action::apply_evolve;
 pub(crate) use apply_action::apply_place_card;

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -115,7 +115,13 @@ pub(crate) fn can_evolve_into(evolution_card: &Card, base_pokemon: &PlayedCard) 
 }
 
 /// Called when a Pokémon evolves
-pub(crate) fn on_evolve(actor: usize, state: &mut State, to_card: &Card, from_hand: bool) {
+pub(crate) fn on_evolve(
+    actor: usize,
+    state: &mut State,
+    to_card: &Card,
+    in_play_idx: usize,
+    from_hand: bool,
+) {
     if !from_hand {
         return;
     }
@@ -178,6 +184,9 @@ pub(crate) fn on_evolve(actor: usize, state: &mut State, to_card: &Card, from_ha
                 ],
             ));
         }
+        Some(AbilityMechanic::CoinFlipParalyzeOpponentActiveOnEvolve) => {
+            offer_on_evolve_ability(actor, state, in_play_idx);
+        }
         Some(AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve) => {
             let opponent = (actor + 1) % 2;
             let has_energy = state
@@ -195,6 +204,15 @@ pub(crate) fn on_evolve(actor: usize, state: &mut State, to_card: &Card, from_ha
         }
         _ => {}
     }
+}
+
+/// Offers an optional on-evolve ability as a `UseAbility` / `Noop` choice. The ability's own
+/// logic (including any coin flip) then runs through the regular `forecast_ability` pathway.
+fn offer_on_evolve_ability(actor: usize, state: &mut State, in_play_idx: usize) {
+    state.move_generation_stack.push((
+        actor,
+        vec![SimpleAction::UseAbility { in_play_idx }, SimpleAction::Noop],
+    ));
 }
 
 /// Called when a basic Pokémon is placed from hand onto the bench (index > 0).

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -161,6 +161,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::HealTypedPokemonOnEvolve { .. } => false,
         AbilityMechanic::AttachEnergyFromZoneToActiveTypedOnEvolve { .. } => false,
         AbilityMechanic::DamageOpponentActiveOnEvolve { .. } => false,
+        AbilityMechanic::CoinFlipParalyzeOpponentActiveOnEvolve => false,
         AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve => false,
         AbilityMechanic::CanEvolveIntoEeveeEvolution => false,
         AbilityMechanic::CanEvolveOnFirstTurnIfActive => false,

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -1,5 +1,6 @@
 use crate::{
     actions::abilities::AbilityMechanic,
+    actions::selectable_status_conditions,
     actions::{ability_mechanic_from_effect, SimpleAction},
     hooks::is_ultra_beast,
     models::{EnergyType, PlayedCard},
@@ -132,6 +133,15 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::PoisonOpponentActive => _in_play_index == 0 && !card.ability_used,
         AbilityMechanic::ConfuseOpponentActive => _in_play_index == 0 && !card.ability_used,
         AbilityMechanic::BurnOpponentActive => !card.ability_used,
+        AbilityMechanic::RandomStatusConditionToOpponentActive { options } => {
+            !card.ability_used
+                && !selectable_status_conditions(
+                    state,
+                    (state.current_player + 1) % 2,
+                    options.as_slice(),
+                )
+                .is_empty()
+        }
         AbilityMechanic::RemoveRandomSpecialConditionFromActive => {
             can_use_remove_random_special_condition_from_active(state, card)
         }

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -160,6 +160,8 @@ mod passimian_ex_offload_pass_test;
 mod porygonz_cyberjack_test;
 #[path = "pokemon/psyduck_test.rs"]
 mod psyduck_test;
+#[path = "pokemon/raichu_evoshock_test.rs"]
+mod raichu_evoshock_test;
 #[path = "pokemon/rampardos_head_smash_test.rs"]
 mod rampardos_head_smash_test;
 #[path = "pokemon/roaring_moon_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -44,6 +44,8 @@ mod charmeleon_ignition_test;
 mod comfey_flower_shield_test;
 #[path = "pokemon/corviknight_line_test.rs"]
 mod corviknight_line_test;
+#[path = "pokemon/cradily_stick_and_absorb_test.rs"]
+mod cradily_stick_and_absorb_test;
 #[path = "pokemon/crawdaunt_unruly_claw_test.rs"]
 mod crawdaunt_unruly_claw_test;
 #[path = "pokemon/darkrai_ex_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -54,6 +54,8 @@ mod durant_test;
 mod dusknoir_shadow_void_test;
 #[path = "pokemon/dustox_select_powder_test.rs"]
 mod dustox_select_powder_test;
+#[path = "pokemon/dustox_variety_powder_test.rs"]
+mod dustox_variety_powder_test;
 #[path = "pokemon/emboar_flare_storm_test.rs"]
 mod emboar_flare_storm_test;
 #[path = "pokemon/emolga_dedenne_ex_tool_damage_test.rs"]

--- a/tests/pokemon/cradily_stick_and_absorb_test.rs
+++ b/tests/pokemon/cradily_stick_and_absorb_test.rs
@@ -1,0 +1,114 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+    Game,
+};
+
+/// Cradily (B4 007) – Stick and Absorb: 70 damage, "Heal 30 damage from this Pokémon. During your
+/// opponent's next turn, the Defending Pokémon can't retreat."
+fn use_stick_and_absorb() -> Game<'static> {
+    let mut game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B4007Cradily)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Grass])
+            .with_damage(50)],
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4007Cradily, 0),
+        is_stack: false,
+    });
+
+    game
+}
+
+#[test]
+fn test_stick_and_absorb_damages_and_heals_self() {
+    let game = use_stick_and_absorb();
+    let state = game.get_state_clone();
+
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        80,
+        "Stick and Absorb should deal 70 damage (Snorlax 150 -> 80)"
+    );
+    assert_eq!(
+        state.get_active(0).get_remaining_hp(),
+        130,
+        "Stick and Absorb should heal 30 from Cradily (150 - 50 + 30 = 130)"
+    );
+}
+
+#[test]
+fn test_stick_and_absorb_blocks_defender_retreat_next_turn() {
+    let mut game = use_stick_and_absorb();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 1, "It should be the opponent's turn");
+    assert!(
+        !choices
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(_))),
+        "The Defending Pokémon should not be able to retreat during the opponent's next turn"
+    );
+}
+
+/// Control: without Stick and Absorb the same board can retreat, proving the assertion above is
+/// driven by the attack's effect and not by a missing retreat precondition.
+#[test]
+fn test_defender_can_retreat_without_stick_and_absorb() {
+    let mut game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B4007Cradily)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Grass])
+            .with_damage(50)],
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 1, "It should be the opponent's turn");
+    assert!(
+        choices
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(_))),
+        "Snorlax should be able to retreat when it wasn't hit by Stick and Absorb"
+    );
+}

--- a/tests/pokemon/dustox_variety_powder_test.rs
+++ b/tests/pokemon/dustox_variety_powder_test.rs
@@ -1,0 +1,122 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{PlayedCard, StatusCondition},
+    test_support::get_initialized_game_with_board,
+    Game,
+};
+
+/// Dustox (B4 005) – Variety Powder: "Once during your turn, you may use this Ability. 1 Special
+/// Condition from among Burned, Confused, and Poisoned is chosen at random, and your opponent's
+/// Active Pokémon is now affected by that Special Condition. Any Special Conditions already
+/// affecting that Pokémon will not be chosen."
+fn game_with_dustox(seed: u64, opponent_conditions: &[StatusCondition]) -> Game<'static> {
+    let mut game = get_initialized_game_with_board(
+        seed,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B4005Dustox)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let mut state = game.get_state_clone();
+    for condition in opponent_conditions {
+        state.apply_status_condition(1, 0, *condition);
+    }
+    game.set_state(state);
+
+    game
+}
+
+fn use_variety_powder(seed: u64, opponent_conditions: &[StatusCondition]) -> [bool; 3] {
+    let mut game = game_with_dustox(seed, opponent_conditions);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 0 },
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let opponent_active = state.get_active(1);
+    [
+        opponent_active.is_burned(),
+        opponent_active.is_confused(),
+        opponent_active.is_poisoned(),
+    ]
+}
+
+#[test]
+fn test_variety_powder_inflicts_each_of_the_three_conditions_at_random() {
+    let mut seen = [false, false, false];
+
+    for seed in 0..40u64 {
+        let inflicted = use_variety_powder(seed, &[]);
+        assert_eq!(
+            inflicted.iter().filter(|x| **x).count(),
+            1,
+            "seed {seed}: Variety Powder should inflict exactly 1 Special Condition"
+        );
+        for (seen, inflicted) in seen.iter_mut().zip(inflicted) {
+            *seen |= inflicted;
+        }
+    }
+
+    assert_eq!(
+        seen,
+        [true, true, true],
+        "expected Burned, Confused and Poisoned to each be chosen on at least one seed"
+    );
+}
+
+#[test]
+fn test_variety_powder_does_not_choose_already_applied_conditions() {
+    for seed in 0..20u64 {
+        let inflicted =
+            use_variety_powder(seed, &[StatusCondition::Burned, StatusCondition::Poisoned]);
+
+        assert!(
+            inflicted[1],
+            "seed {seed}: Confused is the only remaining option, so it must be chosen"
+        );
+    }
+}
+
+#[test]
+fn test_variety_powder_unavailable_when_all_conditions_already_applied() {
+    let game = game_with_dustox(
+        0,
+        &[
+            StatusCondition::Burned,
+            StatusCondition::Confused,
+            StatusCondition::Poisoned,
+        ],
+    );
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::UseAbility { .. })),
+        "Variety Powder should not be usable when no Special Condition can be chosen"
+    );
+}
+
+#[test]
+fn test_variety_powder_is_once_per_turn() {
+    let mut game = game_with_dustox(0, &[]);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 0 },
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::UseAbility { .. })),
+        "Variety Powder should only be usable once per turn"
+    );
+}

--- a/tests/pokemon/raichu_evoshock_test.rs
+++ b/tests/pokemon/raichu_evoshock_test.rs
@@ -1,0 +1,108 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::PlayedCard,
+    test_support::get_initialized_game_with_board,
+    Game,
+};
+
+/// Raichu (B4 050) – Evoshock: "Once during your turn, when you play this Pokémon from your hand
+/// to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is
+/// now Paralyzed."
+fn evolve_pikachu_into_raichu(seed: u64) -> Game<'static> {
+    let mut game = get_initialized_game_with_board(
+        seed,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B4049Pikachu)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::B4050Raichu));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Evolve {
+            evolution: get_card_by_enum(CardId::B4050Raichu),
+            in_play_idx: 0,
+            from_deck: false,
+        },
+        is_stack: false,
+    });
+
+    game
+}
+
+#[test]
+fn test_raichu_evoshock_is_optional_on_evolve() {
+    let game = evolve_pikachu_into_raichu(0);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(choices.len(), 2, "Evoshock should be optional (2 choices)");
+    assert!(
+        choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::UseAbility { in_play_idx: 0 })),
+        "Evoshock should be offered on the Pokémon that just evolved"
+    );
+    assert!(
+        choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::Noop)),
+        "Declining Evoshock should be an option"
+    );
+}
+
+#[test]
+fn test_raichu_evoshock_paralyzes_opponent_active_on_heads() {
+    let mut saw_paralyzed = false;
+    let mut saw_not_paralyzed = false;
+
+    for seed in 0..20u64 {
+        let mut game = evolve_pikachu_into_raichu(seed);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::UseAbility { in_play_idx: 0 },
+            is_stack: true,
+        });
+
+        let state = game.get_state_clone();
+        assert_eq!(state.get_active(0).get_name(), "Raichu");
+        if state.get_active(1).is_paralyzed() {
+            saw_paralyzed = true;
+        } else {
+            saw_not_paralyzed = true;
+        }
+    }
+
+    assert!(
+        saw_paralyzed,
+        "expected at least one seed where Evoshock flipped heads and paralyzed the opponent"
+    );
+    assert!(
+        saw_not_paralyzed,
+        "expected at least one seed where Evoshock flipped tails and did nothing"
+    );
+}
+
+#[test]
+fn test_raichu_evoshock_declined_leaves_opponent_unaffected() {
+    let mut game = evolve_pikachu_into_raichu(0);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Noop,
+        is_stack: true,
+    });
+
+    assert!(
+        !game.get_state_clone().get_active(1).is_paralyzed(),
+        "Declining Evoshock should leave the opponent's Active Pokémon unaffected"
+    );
+}


### PR DESCRIPTION
Implements three cards from Ruler of the Skies (B4). Each card is its own commit so they can be reviewed independently.

> **Note:** Samurott (B4 044) was originally part of this PR and has been dropped at the author's request. The branch has been rebased onto latest `main`.

### `Implement Raichu (B4 050) Evoshock ability`
> Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.

New `AbilityMechanic::CoinFlipParalyzeOpponentActiveOnEvolve`. The `on_evolve` hook offers it as an optional `UseAbility` / `Noop` choice, so the coin flip resolves through the regular `forecast_ability` pathway (`Outcomes::binary_coin`) rather than a bespoke branch. `on_evolve` now also receives the in-play index of the Pokémon that evolved, so the offered ability targets the right slot instead of assuming the Active Spot.

Covers B4 050, B4 164, B4 232.

### `Implement Dustox (B4 005) Variety Powder ability`
> Once during your turn, you may use this Ability. 1 Special Condition from among Burned, Confused, and Poisoned is chosen at random ... Any Special Conditions already affecting that Pokémon will not be chosen.

New `AbilityMechanic::RandomStatusConditionToOpponentActive { options }`. Forecasts one equally-likely branch per still-selectable condition (so the randomness is visible in the forecast rather than hidden inside a single mutation). Move generation hides the ability once every option already affects the opponent's Active Pokémon.

### `Implement Cradily (B4 007) Stick and Absorb attack`
> Heal 30 damage from this Pokémon. During your opponent's next turn, the Defending Pokémon can't retreat. (70 damage)

New `Mechanic::SelfHealAndCardEffect`, combining the existing `SelfHeal` and `DamageAndCardEffect` behaviors: damage resolves first, then the attacker heals and the chosen Active Pokémon gets the `CardEffect` (here `NoRetreat`, duration 1).

### `Update implemented-cards badge`
3310 → 3315 / 3761 (88.1%), per `cargo run --bin card_status`.

## Testing

Each card was developed test-first, with `Game`-level integration tests under `tests/pokemon/`:

- `raichu_evoshock_test.rs` — optionality on evolve, paralysis across 20 seeds (both coin faces observed), declining is a no-op.
- `dustox_variety_powder_test.rs` — exactly one condition inflicted and all three observed across 40 seeds, already-applied conditions excluded, ability unavailable when all three are applied, once-per-turn.
- `cradily_stick_and_absorb_test.rs` — 70 damage + 30 self-heal, defender can't retreat next turn, plus a control case proving the retreat block comes from the attack.

All re-run against latest `main` after the rebase:

- `cargo test --features "tui test-utils"` — full suite passing
- `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run --bin card_test -- "B4 050" / "B4 005" / "B4 007"` — 10,000 games each against all `example_decks/`, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGhvXMPsdBdkdq4vmJ7u2P