### PR TITLE
Implement Dragonair (B4 117, B4 175, B4 233) Dragon's Blessing ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # deckgym-core: Pokémon TCG Pocket Simulator
 
-![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3315_%2F_3761_%2888.1%25%29-green)
+![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3318_%2F_3761_%2888.2%25%29-green)
 
 **deckgym-core** is a high-performance Rust library designed for simulating Pokémon TCG Pocket games. It features a command-line interface (CLI) capable of running 10,000 simulations in approximately 3 seconds. This is the library that powers https://www.deckgym.com.
 

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -64,6 +64,10 @@ pub enum AbilityMechanic {
         energy_type: EnergyType,
         self_damage: u32,
     },
+    /// Dragonair's Dragon's Blessing: "Once during your turn, if this Pokémon is on your Bench,
+    /// you may attach an Energy from your discard pile to your Active Pokémon." The player
+    /// chooses which discarded Energy type to attach when the discard pile holds more than one.
+    AttachEnergyFromDiscardToActiveFromBench,
     ReduceDamageFromAttacks {
         amount: u32,
     },

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -117,6 +117,9 @@ fn forecast_ability_by_mechanic(
                 )
             }
         }),
+        AbilityMechanic::AttachEnergyFromDiscardToActiveFromBench => {
+            Outcomes::single_fn(dragonair_dragons_blessing)
+        }
         AbilityMechanic::ReduceDamageFromAttacks { .. } => {
             panic!("ReduceDamageFromAttacks is a passive ability")
         }
@@ -826,6 +829,30 @@ fn vaporeon_wash_out(_: &mut StdRng, state: &mut State, action: &Action) {
     state
         .move_generation_stack
         .push((acting_player, possible_moves));
+}
+
+/// Dragonair's Dragon's Blessing: attach an Energy from the discard pile to the Active Pokémon.
+/// The player chooses which discarded Energy type to attach when more than one is available.
+fn dragonair_dragons_blessing(_: &mut StdRng, state: &mut State, action: &Action) {
+    let player = action.actor;
+    let mut energy_types: Vec<EnergyType> = state.discard_energies[player].clone();
+    energy_types.sort();
+    energy_types.dedup();
+
+    let possible_attachments: Vec<SimpleAction> = energy_types
+        .into_iter()
+        .map(|energy_type| SimpleAction::AttachTypedFromDiscard {
+            in_play_idx: 0,
+            energy_type,
+            count: 1,
+        })
+        .collect();
+
+    if !possible_attachments.is_empty() {
+        state
+            .move_generation_stack
+            .push((player, possible_attachments));
+    }
 }
 
 /// Lunala ex's Psychic Connect: move all `energy_type` Energy from 1 chosen Benched `energy_type`

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -244,6 +244,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
                 self_damage: 20,
             },
         );
+        map.insert(
+            "Once during your turn, if this Pokémon is on your Bench, you may attach an Energy from your discard pile to your Active [N] Pokémon.",
+            AbilityMechanic::AttachEnergyFromDiscardToActiveFromBench,
+        );
         // map.insert("Once during your turn, you may choose either player. Look at the top card of that player's deck.", todo_implementation);
         map.insert(
             "Once during your turn, you may discard the top card of your opponent's deck.",

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -94,6 +94,9 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::AttachEnergyFromDiscardToSelfAndDamage { energy_type, .. } => {
             !card.ability_used && state.discard_energies[state.current_player].contains(energy_type)
         }
+        AbilityMechanic::AttachEnergyFromDiscardToActiveFromBench => {
+            can_use_dragonair_dragons_blessing(state, _in_play_index, card)
+        }
         AbilityMechanic::ReduceDamageFromAttacks { .. } => false,
         AbilityMechanic::ReduceOpponentActiveDamage { .. } => false,
         AbilityMechanic::IncreaseDamageWhenRemainingHpAtMost { .. } => false,
@@ -294,6 +297,18 @@ fn can_use_dismantling_keys(state: &State, in_play_idx: usize, card: &PlayedCard
     state
         .maybe_get_active(opponent)
         .is_some_and(|active| active.has_tool_attached())
+}
+
+fn can_use_dragonair_dragons_blessing(
+    state: &State,
+    in_play_idx: usize,
+    card: &PlayedCard,
+) -> bool {
+    if in_play_idx == 0 || card.ability_used {
+        return false;
+    }
+    state.maybe_get_active(state.current_player).is_some()
+        && !state.discard_energies[state.current_player].is_empty()
 }
 
 fn can_use_crobat_cunning_link(state: &State, card: &PlayedCard) -> bool {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -50,6 +50,8 @@ mod cradily_stick_and_absorb_test;
 mod crawdaunt_unruly_claw_test;
 #[path = "pokemon/darkrai_ex_test.rs"]
 mod darkrai_ex_test;
+#[path = "pokemon/dragonair_dragons_blessing_test.rs"]
+mod dragonair_dragons_blessing_test;
 #[path = "pokemon/durant_test.rs"]
 mod durant_test;
 #[path = "pokemon/dusknoir_shadow_void_test.rs"]

--- a/tests/pokemon/dragonair_dragons_blessing_test.rs
+++ b/tests/pokemon/dragonair_dragons_blessing_test.rs
@@ -1,0 +1,91 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_test_game_with_board,
+};
+
+/// Dragon's Blessing: "Once during your turn, if this Pokémon is on your Bench, you may attach
+/// an Energy from your discard pile to your Active Pokémon."
+#[test]
+fn test_dragonair_dragons_blessing_attaches_chosen_energy_to_active() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::B4175Dragonair),
+        ],
+        vec![PlayedCard::from_id(CardId::A1002Ivysaur)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.discard_energies[0] = vec![EnergyType::Fire, EnergyType::Water];
+    game.set_state(state);
+
+    let ability_action = Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 1 },
+        is_stack: false,
+    };
+    game.apply_action(&ability_action);
+
+    // Player should be offered a choice of which discarded Energy type to attach.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(
+        choices.len(),
+        2,
+        "Expected a choice for each distinct discarded Energy type; got: {choices:?}"
+    );
+    assert!(choices.iter().all(|choice| matches!(
+        choice.action,
+        SimpleAction::AttachTypedFromDiscard {
+            in_play_idx: 0,
+            count: 1,
+            ..
+        }
+    )));
+
+    let water_choice = choices
+        .iter()
+        .find(|choice| {
+            matches!(
+                choice.action,
+                SimpleAction::AttachTypedFromDiscard {
+                    energy_type: EnergyType::Water,
+                    ..
+                }
+            )
+        })
+        .expect("Should have a choice to attach Water energy")
+        .clone();
+    game.apply_action(&water_choice);
+
+    let state = game.get_state_clone();
+    let active = state.get_active(0);
+    assert_eq!(active.attached_energy, vec![EnergyType::Water]);
+    assert_eq!(state.discard_energies[0], vec![EnergyType::Fire]);
+
+    // Ability is "once during your turn", so it should no longer be offered.
+    let (_actor, actions) = state.generate_possible_actions();
+    assert!(!actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseAbility { in_play_idx: 1 })));
+}
+
+/// Dragon's Blessing can only be used while Dragonair is on the Bench, not while Active.
+#[test]
+fn test_dragonair_dragons_blessing_not_available_while_active() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4175Dragonair)],
+        vec![PlayedCard::from_id(CardId::A1002Ivysaur)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.discard_energies[0] = vec![EnergyType::Fire];
+    game.set_state(state);
+
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(!actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseAbility { in_play_idx: 0 })));
+}


### PR DESCRIPTION
Adds the AttachEnergyFromDiscardToActiveFromBench ability mechanic: while on the Bench, lets the player attach a chosen Energy type from the discard pile to the Active Pokemon. Draconic Whip needed no custom logic since it's a plain fixed-damage attack.