### PR TITLE
Reject Dragon and Colorless energy zones, and make get_color's panic informative

### DIFF
--- a/src/deck.rs
+++ b/src/deck.rs
@@ -98,6 +98,14 @@ impl Deck {
             return false;
         }
 
+        // The Energy Zone has to be able to generate what the deck declares, so every
+        // energy must be selectable (i.e. not Dragon or Colorless). A Dragon deck is
+        // legal, but it is built around the energy its attacks actually cost.
+        if self.energy_types.is_empty() || !self.energy_types.iter().all(EnergyType::is_selectable)
+        {
+            return false;
+        }
+
         // Check that no card name appears more than twice
         let mut card_counts = std::collections::HashMap::new();
         for card in &self.cards {
@@ -177,6 +185,52 @@ mod tests {
     use rand::thread_rng;
 
     use super::*;
+
+    /// The Energy Zone cannot generate Dragon or Colorless energy, so a deck
+    /// declaring either is not buildable in-game. This is easy to get wrong when
+    /// energy is inferred from a deck's Pokemon types rather than its attack costs:
+    /// an all-Dragon deck yields `Energy: Dragon`, which is not playable.
+    #[test]
+    fn test_is_valid_rejects_non_selectable_energy() {
+        let cards = "\n1 A1 225\n1 A2 150\n1 A2b 70\n2 A3 66\n1 A4 66\n1 B1 223\n2 B1 225\n2 B2b 51\n2 B4 117\n1 B4 120\n2 B4 155\n2 P-A 5\n2 P-A 7";
+
+        for energy in ["Dragon", "Colorless"] {
+            let deck = Deck::from_string(&format!("Energy: {energy}{cards}"))
+                .expect("deck should still parse");
+            assert_eq!(deck.cards.len(), 20);
+            assert!(
+                deck.cards.iter().filter(|c| c.is_basic()).count() >= 1,
+                "deck should otherwise be legal, so only the energy is at fault"
+            );
+            assert!(!deck.is_valid(), "{energy} energy zone should be rejected");
+        }
+
+        // Same 20 cards, but declaring energy the Energy Zone can actually make.
+        let deck = Deck::from_string(&format!("Energy: Fire, Lightning{cards}")).unwrap();
+        assert!(deck.is_valid());
+
+        // A mix is only as valid as its worst member.
+        let deck = Deck::from_string(&format!("Energy: Fire, Dragon{cards}")).unwrap();
+        assert!(!deck.is_valid());
+    }
+
+    #[test]
+    fn test_energy_type_is_selectable() {
+        for energy in [
+            EnergyType::Grass,
+            EnergyType::Fire,
+            EnergyType::Water,
+            EnergyType::Lightning,
+            EnergyType::Psychic,
+            EnergyType::Fighting,
+            EnergyType::Darkness,
+            EnergyType::Metal,
+        ] {
+            assert!(energy.is_selectable(), "{energy:?} should be selectable");
+        }
+        assert!(!EnergyType::Dragon.is_selectable());
+        assert!(!EnergyType::Colorless.is_selectable());
+    }
 
     #[test]
     fn test_deck_from_file() {

--- a/src/game.rs
+++ b/src/game.rs
@@ -162,7 +162,6 @@ impl<'a> Game<'a> {
     fn get_color(&self, actor: usize) -> String {
         let energy = self.state.decks[actor].energy_types[0];
         let color = match energy {
-            EnergyType::Colorless => todo!(),
             EnergyType::Fighting => "red",
             EnergyType::Fire => "red",
             EnergyType::Grass => "green",
@@ -171,7 +170,14 @@ impl<'a> Game<'a> {
             EnergyType::Water => "blue",
             EnergyType::Darkness => "bright_black",
             EnergyType::Metal => "bright_black",
-            EnergyType::Dragon => todo!(),
+            // The Energy Zone cannot generate these, so a deck built around one is
+            // not playable. `Deck::is_valid` rejects them, so getting here means an
+            // unvalidated deck reached `Game`.
+            EnergyType::Colorless | EnergyType::Dragon => panic!(
+                "Player {actor}'s deck declares a {} energy zone, which the Energy Zone \
+                 cannot generate. Check Deck::is_valid before starting a Game.",
+                energy.as_str()
+            ),
         };
         color.to_string()
     }

--- a/src/models/card.rs
+++ b/src/models/card.rs
@@ -39,6 +39,16 @@ impl EnergyType {
         }
     }
 
+    /// Whether a deck can be built around this energy, i.e. whether the Energy Zone
+    /// can generate it.
+    ///
+    /// Dragon and Colorless cannot. Colorless only ever appears as an attack cost
+    /// (payable by any energy), and there is no Dragon energy in the game — Dragon
+    /// Pokemon are powered by other types.
+    pub fn is_selectable(&self) -> bool {
+        !matches!(self, EnergyType::Dragon | EnergyType::Colorless)
+    }
+
     pub fn as_str(&self) -> &'static str {
         match self {
             EnergyType::Grass => "Grass",


### PR DESCRIPTION
The Energy Zone can only generate the eight basic energy types. Colorless only ever appears as an attack cost, payable by any energy, and there is no Dragon energy in the game — Dragon Pokémon are powered by other types. A deck declaring either as its energy zone is not buildable, but the library accepted it and then aborted mid-game with an opaque message.

## Changes

**1. `Deck::is_valid` rejects non-playable energy zones**

Adds `EnergyType::is_selectable()` and requires every declared energy to pass it, plus the list to be non-empty. This is easy to get wrong when a deck's energy is inferred from its Pokémon types rather than its attack costs — an all-Dragon deck yields `Energy: Dragon`, which is not playable, and its attacks never become payable in simulation, so any win rate computed against it is meaningless.

**2. `get_color` panics with a useful message instead of `todo!()`**

```rust
EnergyType::Colorless => todo!(),
...
EnergyType::Dragon => todo!(),
```

`Game::play_tick` calls `get_color` on every tick, so a deck declaring one of these aborted on the very first tick with a bare `not yet implemented` — no indication of which deck, which player, or what was actually wrong. Since such decks really are invalid, this keeps throwing, but names the offending energy and points at `Deck::is_valid`:

```
Player 1's deck declares a Dragon energy zone, which the Energy Zone cannot
generate. Check Deck::is_valid before starting a Game.
```

## Tests

- `test_is_valid_rejects_non_selectable_energy` — Dragon and Colorless rejected; the same 20 cards declaring `Energy: Fire, Lightning` accepted; a `Fire, Dragon` mix rejected. Confirmed to fail before the change.
- `test_energy_type_is_selectable` — the eight basic types are selectable, Dragon and Colorless are not.

Full suite green: 27 test binaries, 0 failures. `cargo fmt --check` and `cargo clippy --all-targets` clean.

## Review feedback

- Reverted all `src/optimize.rs` changes — that file is untouched now.
- Kept `get_color` throwing rather than mapping the two energies to colors, with a more informative message.
- Removed the `game.rs` test.