### PR TITLE
Fix panic when a deck's energy type is Colorless or Dragon

### DIFF
--- a/src/game.rs
+++ b/src/game.rs
@@ -160,9 +160,15 @@ impl<'a> Game<'a> {
 
     /// see https://github.com/colored-rs/colored?tab=readme-ov-file#colors
     fn get_color(&self, actor: usize) -> String {
-        let energy = self.state.decks[actor].energy_types[0];
+        // Decks always have at least 1 energy type, but this is only about how to color the
+        // log line, so fall back to Colorless instead of panicking if that ever changes.
+        let energy = self.state.decks[actor]
+            .energy_types
+            .first()
+            .copied()
+            .unwrap_or(EnergyType::Colorless);
         let color = match energy {
-            EnergyType::Colorless => todo!(),
+            EnergyType::Colorless => "white",
             EnergyType::Fighting => "red",
             EnergyType::Fire => "red",
             EnergyType::Grass => "green",
@@ -171,7 +177,7 @@ impl<'a> Game<'a> {
             EnergyType::Water => "blue",
             EnergyType::Darkness => "bright_black",
             EnergyType::Metal => "bright_black",
-            EnergyType::Dragon => todo!(),
+            EnergyType::Dragon => "cyan",
         };
         color.to_string()
     }

--- a/tests/engine/game_api_test.rs
+++ b/tests/engine/game_api_test.rs
@@ -52,3 +52,59 @@ fn test_first_ko() {
     assert_eq!(game.get_state_clone().turn_count, 7);
     assert_eq!(winner, Some(GameOutcome::Win(0)));
 }
+
+/// A deck whose energy types resolve to [C] (a Colorless deck, or any deck file without an
+/// explicit `Energy:` line whose Pokémon are Colorless) must be playable: `play_tick` colors
+/// its log lines by the deck's first energy type, and every energy type needs a color.
+#[test]
+fn test_game_plays_deck_with_colorless_energy() {
+    let colorless_deck = deckgym::Deck::from_string(
+        "2 Furfrou B4 142\n\
+         2 Professor's Research P-A 007\n\
+         2 Poké Ball P-A 005\n\
+         2 Potion P-A 001\n\
+         2 X Speed P-A 002\n\
+         2 Red Card P-A 006\n\
+         2 Rare Candy A3 144\n\
+         2 Copycat B1 225\n\
+         2 Sabrina A1 225\n\
+         2 Cyrus A2 150",
+    )
+    .expect("Valid Deck Format");
+    let (_, deck_b) = load_test_decks();
+    let players: Vec<Box<dyn Player>> = vec![
+        Box::new(RandomPlayer {
+            deck: colorless_deck,
+        }),
+        Box::new(RandomPlayer { deck: deck_b }),
+    ];
+    let mut game = deckgym::Game::new(players, 0);
+    game.play();
+}
+
+/// Same for a [N] (Dragon) deck: Dragon Pokémon have no Energy of their own, so a deck file
+/// without an explicit `Energy:` line resolves to [N] and must still be playable.
+#[test]
+fn test_game_plays_deck_with_dragon_energy() {
+    let dragon_deck = deckgym::Deck::from_string(
+        "Energy: Dragon\n\
+         2 Furfrou B4 142\n\
+         2 Professor's Research P-A 007\n\
+         2 Poké Ball P-A 005\n\
+         2 Potion P-A 001\n\
+         2 X Speed P-A 002\n\
+         2 Red Card P-A 006\n\
+         2 Rare Candy A3 144\n\
+         2 Copycat B1 225\n\
+         2 Sabrina A1 225\n\
+         2 Cyrus A2 150",
+    )
+    .expect("Valid Deck Format");
+    let (_, deck_b) = load_test_decks();
+    let players: Vec<Box<dyn Player>> = vec![
+        Box::new(RandomPlayer { deck: dragon_deck }),
+        Box::new(RandomPlayer { deck: deck_b }),
+    ];
+    let mut game = deckgym::Game::new(players, 0);
+    game.play();
+}


### PR DESCRIPTION
`Game::play_tick` colors its log line by the deck's first energy type, and
`get_color` still had `todo!()` for [C] and [N]. Any deck that resolves to
one of those — an explicit `Energy: Colorless` / `Energy: Dragon` line, or a
deck file with no `Energy:` line whose Pokémon are Colorless (deck parsing
infers the energy types from the cards) — panicked with "not yet implemented"
on the first tick of every game.

Give both a color and fall back to Colorless if a deck ever has no energy
type, so how a log line is colored can never end a game.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012waLqUQve42YLQsLkdXUAD