### PR TITLE
Implement 6 cards: Cheren, Primarina, Mallow, Jasmine, Porygon-Z, Meganium

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # deckgym-core: Pokémon TCG Pocket Simulator
 
-![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3318_%2F_3761_%2888.2%25%29-green)
+![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3328_%2F_3761_%2888.5%25%29-green)
 
 **deckgym-core** is a high-performance Rust library designed for simulating Pokémon TCG Pocket games. It features a command-line interface (CLI) capable of running 10,000 simulations in approximately 3 seconds. This is the library that powers https://www.deckgym.com.
 

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -3,8 +3,12 @@ use crate::models::{EnergyType, StatusCondition};
 #[derive(Debug, Clone, PartialEq)]
 pub enum AbilityMechanic {
     VictreebelFragranceTrap,
+    /// Heal `amount` damage from each of your Pokémon. `energy_type` restricts which Pokémon are
+    /// healed: `None` heals all of them, `Some(t)` heals only your Pokémon of that type (e.g.
+    /// Primarina's Melodious Healing, which heals only your [W] Pokémon).
     HealAllYourPokemon {
         amount: u32,
+        energy_type: Option<EnergyType>,
     },
     HealOneYourPokemon {
         amount: u32,

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -41,7 +41,10 @@ fn forecast_ability_by_mechanic(
 ) -> Outcomes {
     match mechanic {
         AbilityMechanic::VictreebelFragranceTrap => Outcomes::single_fn(victreebel_ability),
-        AbilityMechanic::HealAllYourPokemon { amount } => heal_all_your_pokemon(*amount),
+        AbilityMechanic::HealAllYourPokemon {
+            amount,
+            energy_type,
+        } => heal_all_your_pokemon(*amount, *energy_type),
         AbilityMechanic::HealOneYourPokemon { amount } => heal_one_your_pokemon(*amount),
         AbilityMechanic::HealOneYourPokemonExAndDiscardRandomEnergy { amount } => {
             heal_one_your_pokemon_ex_and_discard_random_energy(*amount)
@@ -318,10 +321,12 @@ fn discard_energy_to_increase_type_damage(
     })
 }
 
-fn heal_all_your_pokemon(amount: u32) -> Outcomes {
+fn heal_all_your_pokemon(amount: u32, energy_type: Option<EnergyType>) -> Outcomes {
     Outcomes::single_fn(move |_rng, state, action| {
         for pokemon in state.in_play_pokemon[action.actor].iter_mut().flatten() {
-            pokemon.heal(amount);
+            if energy_type.is_none_or(|t| pokemon.get_energy_type() == Some(t)) {
+                pokemon.heal(amount);
+            }
         }
     })
 }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -599,6 +599,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::DiscardRandomGlobalEnergy { count } => {
             discard_random_global_energy_attack(attack.fixed_damage, *count, state)
         }
+        Mechanic::RandomizeOpponentNextEnergy => {
+            randomize_opponent_next_energy_attack(attack.fixed_damage)
+        }
         Mechanic::RandomDamageToOpponentPokemonPerSelfEnergy {
             energy_type,
             damage_per_hit,
@@ -2303,6 +2306,17 @@ fn damage_and_discard_all_energy(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let active = state.get_active_mut(action.actor);
         active.attached_energy.clear(); // Discard all energy
+    })
+}
+
+/// Porygon-Z's Buggy Beam: the Energy previewed in the opponent's Energy Zone becomes a
+/// uniformly random one of the 8 basic Energy types (i.e. every type the Energy Zone can
+/// generate), even if their deck declares no such Energy.
+fn randomize_opponent_next_energy_attack(damage: u32) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |rng, state, action| {
+        let choices = EnergyType::SELECTABLE;
+        let opponent = (action.actor + 1) % 2;
+        state.energy_zone[opponent].next = Some(choices[rng.gen_range(0..choices.len())]);
     })
 }
 

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -134,6 +134,7 @@ pub fn forecast_trainer_action(
             Outcomes::single_fn(lyra_effect)
         }
         CardId::A4156Will | CardId::A4196Will => Outcomes::single_fn(will_effect),
+        CardId::A4160Jasmine | CardId::A4200Jasmine => Outcomes::single_fn(jasmine_effect),
         CardId::A4158Silver | CardId::A4198Silver | CardId::A4b336Silver | CardId::A4b337Silver => {
             Outcomes::single_fn(silver_effect)
         }
@@ -717,6 +718,19 @@ fn adaman_effect(_: &mut StdRng, state: &mut State, action: &Action) {
         TurnEffect::ReducedDamageForType {
             amount: 20,
             energy_type: EnergyType::Metal,
+            player: action.actor,
+        },
+        1,
+    );
+}
+
+fn jasmine_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // During your opponent's next turn, all of your Steelix and Skarmory ex take -50 damage from
+    // attacks from your opponent's Pokémon.
+    state.add_turn_effect(
+        TurnEffect::ReducedDamageForSpecificPokemon {
+            amount: 50,
+            pokemon_names: vec!["Steelix".to_string(), "Skarmory ex".to_string()],
             player: action.actor,
         },
         1,

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -14,8 +14,8 @@ use crate::{
     },
     card_ids::CardId,
     card_logic::{
-        can_rare_candy_evolve, diantha_targets, ilima_targets, psychic_energy_sources,
-        quick_grow_extract_candidates, wallace_candidates,
+        can_rare_candy_evolve, diantha_targets, ilima_targets, mallow_targets,
+        psychic_energy_sources, quick_grow_extract_candidates, wallace_candidates,
     },
     combinatorics::generate_combinations,
     effects::TurnEffect,
@@ -128,6 +128,7 @@ pub fn forecast_trainer_action(
         | CardId::A4b351Lusamine
         | CardId::A4b375Lusamine => Outcomes::single_fn(lusamine_effect),
         CardId::A3149Ilima | CardId::A3191Ilima => Outcomes::single_fn(ilima_effect),
+        CardId::A3154Mallow | CardId::A3196Mallow => Outcomes::single_fn(mallow_effect),
         CardId::A3150Kiawe | CardId::A3192Kiawe => Outcomes::single_fn(kiawe_effect),
         CardId::A4157Lyra | CardId::A4197Lyra | CardId::A4b332Lyra | CardId::A4b333Lyra => {
             Outcomes::single_fn(lyra_effect)
@@ -751,6 +752,30 @@ fn diantha_effect(_: &mut StdRng, state: &mut State, action: &Action) {
             in_play_idx,
             heal_amount: 90,
             discard_energies: vec![EnergyType::Psychic; 2],
+        })
+        .collect::<Vec<_>>();
+
+    if !possible_moves.is_empty() {
+        state
+            .move_generation_stack
+            .push((action.actor, possible_moves));
+    }
+}
+
+fn mallow_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Heal all damage from 1 of your Shiinotic or Tsareena. If you do, discard all Energy from
+    // that Pokémon.
+    let possible_moves = mallow_targets(state, action.actor)
+        .into_iter()
+        .map(|in_play_idx| {
+            let pokemon = state.in_play_pokemon[action.actor][in_play_idx]
+                .as_ref()
+                .expect("Mallow target should be in play");
+            SimpleAction::HealAndDiscardEnergy {
+                in_play_idx,
+                heal_amount: pokemon.get_effective_total_hp() - pokemon.get_remaining_hp(),
+                discard_energies: pokemon.attached_energy.clone(),
+            }
         })
         .collect::<Vec<_>>();
 

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -190,6 +190,7 @@ pub fn forecast_trainer_action(
         }
         CardId::B3147FieldBlower => Outcomes::single_fn(field_blower_effect),
         CardId::B3149Korrina | CardId::B3190Korrina => Outcomes::single_fn(korrina_effect),
+        CardId::B3151Cheren | CardId::B3192Cheren => Outcomes::single_fn(cheren_effect),
         CardId::B3150Cabbie | CardId::B3191Cabbie => card_search_outcomes_with_filter_multiple(
             acting_player,
             state,
@@ -732,6 +733,21 @@ fn jasmine_effect(_: &mut StdRng, state: &mut State, action: &Action) {
             amount: 50,
             pokemon_names: vec!["Steelix".to_string(), "Skarmory ex".to_string()],
             player: action.actor,
+            attacker_must_be_ex: false,
+        },
+        1,
+    );
+}
+
+fn cheren_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // During your opponent's next turn, all of your Watchog and Stoutland take -100 damage from
+    // attacks from your opponent's Pokémon ex.
+    state.add_turn_effect(
+        TurnEffect::ReducedDamageForSpecificPokemon {
+            amount: 100,
+            pokemon_names: vec!["Watchog".to_string(), "Stoutland".to_string()],
+            player: action.actor,
+            attacker_must_be_ex: true,
         },
         1,
     );

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -76,6 +76,9 @@ pub enum Mechanic {
     DiscardRandomGlobalEnergy {
         count: usize,
     },
+    /// Porygon-Z's Buggy Beam: replace the Energy queued up in the opponent's Energy Zone with a
+    /// uniformly random one of the 8 basic Energy types, regardless of their deck's Energy.
+    RandomizeOpponentNextEnergy,
     RandomDamageToOpponentPokemonPerSelfEnergy {
         energy_type: EnergyType,
         damage_per_hit: u32,

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -262,17 +262,29 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
         // map.insert("Once during your turn, you may flip a coin. If heads, your opponent's Active Pokémon is now Poisoned.", todo_implementation);
         map.insert(
             "Once during your turn, you may heal 10 damage from each of your Pokémon.",
-            AbilityMechanic::HealAllYourPokemon { amount: 10 },
+            AbilityMechanic::HealAllYourPokemon {
+                amount: 10,
+                energy_type: None,
+            },
         );
         map.insert(
             "Once during your turn, you may heal 20 damage from each of your Pokémon.",
-            AbilityMechanic::HealAllYourPokemon { amount: 20 },
+            AbilityMechanic::HealAllYourPokemon {
+                amount: 20,
+                energy_type: None,
+            },
         );
         map.insert(
             "Once during your turn, you may heal 20 damage from your Active Pokémon.",
             AbilityMechanic::HealActiveYourPokemon { amount: 20 },
         );
-        // map.insert("Once during your turn, you may heal 30 damage from each of your [W] Pokémon.", todo_implementation);
+        map.insert(
+            "Once during your turn, you may heal 30 damage from each of your [W] Pokémon.",
+            AbilityMechanic::HealAllYourPokemon {
+                amount: 30,
+                energy_type: Some(EnergyType::Water),
+            },
+        );
         // map.insert("Once during your turn, you may look at the top card of your deck.", todo_implementation);
         map.insert(
             "Once during your turn, you may make your opponent's Active Pokémon Burned.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -805,7 +805,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Heal 10 damage from this Pokémon.",
         Mechanic::SelfHeal { amount: 10 },
     );
-    // map.insert("Heal 20 damage from each of your Pokémon.", todo_implementation);
+    map.insert(
+        "Heal 20 damage from each of your Pokémon.",
+        Mechanic::HealAllYourPokemon { amount: 20 },
+    );
     map.insert(
         "Heal 20 damage from this Pokémon.",
         Mechanic::SelfHeal { amount: 20 },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -66,7 +66,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     // map.insert("Change the type of a random Energy attached to your opponent's Active Pokémon to 1 of the following at random: [G], [R], [W], [L], [P], [F], [D], or [M].", todo_implementation);
-    // map.insert("Change the type of the next Energy that will be generated for your opponent to 1 of the following at random: [G], [R], [W], [L], [P], [F], [D], or [M].", todo_implementation);
+    map.insert(
+        "Change the type of the next Energy that will be generated for your opponent to 1 of the following at random: [G], [R], [W], [L], [P], [F], [D], or [M].",
+        Mechanic::RandomizeOpponentNextEnergy,
+    );
     map.insert(
         "Choose 1 of your opponent's Active Pokémon's attacks and use it as this attack.",
         Mechanic::CopyAttack {

--- a/src/card_logic/mallow.rs
+++ b/src/card_logic/mallow.rs
@@ -1,0 +1,18 @@
+use crate::State;
+
+/// Names of Pokémon that Mallow can heal.
+const MALLOW_TARGETS: [&str; 2] = ["Shiinotic", "Tsareena"];
+
+/// Mallow: "Heal all damage from 1 of your Shiinotic or Tsareena. If you do, discard all Energy
+/// from that Pokémon."
+///
+/// Only damaged Pokémon qualify: healing an undamaged one would heal nothing, and the discard is
+/// gated on the heal actually happening ("If you do").
+pub fn mallow_targets(state: &State, player: usize) -> Vec<usize> {
+    state
+        .enumerate_in_play_pokemon(player)
+        .filter(|(_, pokemon)| pokemon.is_damaged())
+        .filter(|(_, pokemon)| MALLOW_TARGETS.contains(&pokemon.get_name().as_str()))
+        .map(|(in_play_idx, _)| in_play_idx)
+        .collect()
+}

--- a/src/card_logic/mod.rs
+++ b/src/card_logic/mod.rs
@@ -1,5 +1,6 @@
 mod diantha;
 mod ilima;
+mod mallow;
 mod psychic;
 mod quick_grow_extract;
 mod rare_candy;
@@ -7,6 +8,7 @@ mod wallace;
 
 pub use diantha::diantha_targets;
 pub use ilima::ilima_targets;
+pub use mallow::mallow_targets;
 pub use psychic::{active_has_psychic_attack, psychic_energy_sources};
 pub use quick_grow_extract::quick_grow_extract_candidates;
 pub use rare_candy::{can_rare_candy_evolve, get_highest_evolutions};

--- a/src/deck.rs
+++ b/src/deck.rs
@@ -216,16 +216,7 @@ mod tests {
 
     #[test]
     fn test_energy_type_is_selectable() {
-        for energy in [
-            EnergyType::Grass,
-            EnergyType::Fire,
-            EnergyType::Water,
-            EnergyType::Lightning,
-            EnergyType::Psychic,
-            EnergyType::Fighting,
-            EnergyType::Darkness,
-            EnergyType::Metal,
-        ] {
+        for energy in EnergyType::SELECTABLE {
             assert!(energy.is_selectable(), "{energy:?} should be selectable");
         }
         assert!(!EnergyType::Dragon.is_selectable());

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -90,6 +90,14 @@ pub enum TurnEffect {
         energy_type: EnergyType,
         player: usize,
     },
+    /// `player`'s Pokémon named in `pokemon_names` take `amount` less damage from the opponent's
+    /// attacks (e.g. Jasmine, protecting Steelix and Skarmory ex). Like `ReducedDamageForType`,
+    /// this covers Benched Pokémon too, since the wording is "all of your ...".
+    ReducedDamageForSpecificPokemon {
+        amount: u32,
+        pokemon_names: Vec<String>,
+        player: usize,
+    },
     IncreasedDamage {
         amount: u32,
     },

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -93,10 +93,14 @@ pub enum TurnEffect {
     /// `player`'s Pokémon named in `pokemon_names` take `amount` less damage from the opponent's
     /// attacks (e.g. Jasmine, protecting Steelix and Skarmory ex). Like `ReducedDamageForType`,
     /// this covers Benched Pokémon too, since the wording is "all of your ...".
+    ///
+    /// `attacker_must_be_ex` narrows the reduction to attacks from the opponent's Pokémon ex
+    /// (e.g. Cheren, protecting Watchog and Stoutland).
     ReducedDamageForSpecificPokemon {
         amount: u32,
         pokemon_names: Vec<String>,
         player: usize,
+        attacker_must_be_ex: bool,
     },
     IncreasedDamage {
         amount: u32,

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -839,6 +839,7 @@ fn get_turn_effect_damage_reduction(
         return 0;
     }
     let target_energy_type = target_pokemon.get_energy_type();
+    let target_name = target_pokemon.get_name();
     state
         .get_current_turn_effects()
         .iter()
@@ -850,6 +851,11 @@ fn get_turn_effect_damage_reduction(
             } if *player == target_player && target_energy_type == Some(*energy_type) => {
                 Some(*amount)
             }
+            TurnEffect::ReducedDamageForSpecificPokemon {
+                amount,
+                pokemon_names,
+                player,
+            } if *player == target_player && pokemon_names.contains(&target_name) => Some(*amount),
             _ => None,
         })
         .sum::<u32>()

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -832,12 +832,14 @@ fn get_turn_effect_damage_reduction(
     state: &State,
     target_player: usize,
     target_pokemon: &crate::models::PlayedCard,
-    attacking_player: usize,
+    attacking_ref: (usize, &crate::models::PlayedCard),
     is_from_active_attack: bool,
 ) -> u32 {
+    let (attacking_player, attacking_pokemon) = attacking_ref;
     if !is_from_active_attack || attacking_player == target_player {
         return 0;
     }
+    let attacker_is_ex = attacking_pokemon.card.is_ex();
     let target_energy_type = target_pokemon.get_energy_type();
     let target_name = target_pokemon.get_name();
     state
@@ -855,7 +857,13 @@ fn get_turn_effect_damage_reduction(
                 amount,
                 pokemon_names,
                 player,
-            } if *player == target_player && pokemon_names.contains(&target_name) => Some(*amount),
+                attacker_must_be_ex,
+            } if *player == target_player
+                && pokemon_names.contains(&target_name)
+                && (!attacker_must_be_ex || attacker_is_ex) =>
+            {
+                Some(*amount)
+            }
             _ => None,
         })
         .sum::<u32>()
@@ -1130,7 +1138,7 @@ pub(crate) fn modify_damage(
             state,
             target_player,
             receiving_pokemon,
-            attacking_player,
+            (attacking_player, attacking_pokemon),
             is_from_active_attack,
         )
     };

--- a/src/models/card.rs
+++ b/src/models/card.rs
@@ -23,6 +23,19 @@ pub enum EnergyType {
     Colorless,
 }
 impl EnergyType {
+    /// The 8 Energy types the Energy Zone can generate, i.e. the ones a deck can be built
+    /// around. See `is_selectable`.
+    pub const SELECTABLE: [EnergyType; 8] = [
+        EnergyType::Grass,
+        EnergyType::Fire,
+        EnergyType::Water,
+        EnergyType::Lightning,
+        EnergyType::Psychic,
+        EnergyType::Fighting,
+        EnergyType::Darkness,
+        EnergyType::Metal,
+    ];
+
     pub(crate) fn from_str(energy_type: &str) -> Option<Self> {
         match energy_type {
             "Grass" => Some(EnergyType::Grass),

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -146,6 +146,8 @@ pub fn trainer_move_generation_implementation(
         | CardId::A4198Silver
         | CardId::A4156Will
         | CardId::A4196Will
+        | CardId::A4160Jasmine
+        | CardId::A4200Jasmine
         | CardId::A4b336Silver
         | CardId::A4b337Silver
         | CardId::PA002XSpeed

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -233,6 +233,7 @@ pub fn trainer_move_generation_implementation(
         }
         CardId::B3147FieldBlower => can_play_field_blower(state, trainer_card),
         CardId::B3149Korrina | CardId::B3190Korrina => can_play_trainer(state, trainer_card),
+        CardId::B3151Cheren | CardId::B3192Cheren => can_play_trainer(state, trainer_card),
         CardId::B3150Cabbie | CardId::B3191Cabbie => can_play_cabbie(state, trainer_card),
         CardId::B3152ParasolLady | CardId::B3193ParasolLady => {
             can_play_parasol_lady(state, trainer_card)

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -3,7 +3,7 @@ use crate::{
     card_ids::CardId,
     card_logic::{
         active_has_psychic_attack, can_rare_candy_evolve, diantha_targets, ilima_targets,
-        psychic_energy_sources, quick_grow_extract_candidates, wallace_candidates,
+        mallow_targets, psychic_energy_sources, quick_grow_extract_candidates, wallace_candidates,
     },
     effects::TurnEffect,
     hooks::{
@@ -136,6 +136,7 @@ pub fn trainer_move_generation_implementation(
         | CardId::A4b375Lusamine => can_play_lusamine(state, trainer_card),
         CardId::A2153Volkner | CardId::A2193Volkner => can_play_volkner(state, trainer_card),
         CardId::A3149Ilima | CardId::A3191Ilima => can_play_ilima(state, trainer_card),
+        CardId::A3154Mallow | CardId::A3196Mallow => can_play_mallow(state, trainer_card),
         CardId::A3150Kiawe | CardId::A3192Kiawe => can_play_kiawe(state, trainer_card),
         CardId::A4157Lyra | CardId::A4197Lyra | CardId::A4b332Lyra | CardId::A4b333Lyra => {
             can_play_lyra(state, trainer_card)
@@ -796,6 +797,15 @@ fn can_play_piers(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simpl
 }
 
 /// Check if Diantha can be played (requires damaged Psychic Pokemon with >= 2 Psychic Energy)
+/// Check if Mallow can be played (requires a damaged Shiinotic or Tsareena in play)
+fn can_play_mallow(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    if mallow_targets(state, state.current_player).is_empty() {
+        cannot_play_trainer()
+    } else {
+        can_play_trainer(state, trainer_card)
+    }
+}
+
 fn can_play_diantha(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
     let has_target = !diantha_targets(state, state.current_player).is_empty();
     if has_target {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -166,6 +166,8 @@ mod ninetales_ember_dance_test;
 mod passimian_ex_offload_pass_test;
 #[path = "pokemon/porygonz_cyberjack_test.rs"]
 mod porygonz_cyberjack_test;
+#[path = "pokemon/primarina_melodious_healing_test.rs"]
+mod primarina_melodious_healing_test;
 #[path = "pokemon/psyduck_test.rs"]
 mod psyduck_test;
 #[path = "pokemon/raichu_evoshock_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -164,6 +164,8 @@ mod morpeko_test;
 mod ninetales_ember_dance_test;
 #[path = "pokemon/passimian_ex_offload_pass_test.rs"]
 mod passimian_ex_offload_pass_test;
+#[path = "pokemon/porygonz_buggy_beam_test.rs"]
+mod porygonz_buggy_beam_test;
 #[path = "pokemon/porygonz_cyberjack_test.rs"]
 mod porygonz_cyberjack_test;
 #[path = "pokemon/primarina_melodious_healing_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -148,6 +148,8 @@ mod mega_rayquaza_ex_mega_burst_test;
 mod mega_sceptile_terminating_tail_test;
 #[path = "pokemon/mega_steelix_adamantine_rolling_test.rs"]
 mod mega_steelix_adamantine_rolling_test;
+#[path = "pokemon/meganium_bloomshine_test.rs"]
+mod meganium_bloomshine_test;
 #[path = "pokemon/meowstic_test.rs"]
 mod meowstic_test;
 #[path = "pokemon/meowth_carefree_steps_test.rs"]

--- a/tests/pokemon/meganium_bloomshine_test.rs
+++ b/tests/pokemon/meganium_bloomshine_test.rs
@@ -1,0 +1,41 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Meganium's "Bloomshine": 80 damage, then "Heal 20 damage from each of your Pokémon."
+#[test]
+fn test_bloomshine_damages_opponent_and_heals_all_your_pokemon() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A4010Meganium)
+                .with_energy(vec![
+                    EnergyType::Grass,
+                    EnergyType::Grass,
+                    EnergyType::Colorless,
+                ])
+                .with_damage(50),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(30),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A4010Meganium, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+
+    // Venusaur ex (190 HP) takes the 80 damage.
+    assert_eq!(state.get_remaining_hp(1, 0), 110);
+
+    // Every one of the attacker's Pokemon heals 20, and healing never exceeds full HP.
+    assert_eq!(state.get_remaining_hp(0, 0), 150 - 50 + 20);
+    assert_eq!(state.get_remaining_hp(0, 1), 70 - 30 + 20);
+    assert_eq!(state.get_remaining_hp(0, 2), 60);
+}

--- a/tests/pokemon/porygonz_buggy_beam_test.rs
+++ b/tests/pokemon/porygonz_buggy_beam_test.rs
@@ -1,0 +1,63 @@
+use std::collections::HashSet;
+
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Porygon-Z's "Buggy Beam": 80 damage, then "Change the type of the next Energy that will be
+/// generated for your opponent to 1 of the following at random: [G], [R], [W], [L], [P], [F],
+/// [D], or [M]."
+///
+/// The opponent's deck (weezing-arbok) only ever generates [D], so any other type in their
+/// energy zone preview must have come from Buggy Beam.
+#[test]
+fn test_buggy_beam_randomizes_opponents_next_energy() {
+    let mut observed = HashSet::new();
+
+    for seed in 0..40u64 {
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![PlayedCard::from_id(CardId::A2129PorygonZ).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Grass,
+                EnergyType::Grass,
+            ])],
+            vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A2129PorygonZ, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        assert_eq!(state.get_remaining_hp(1, 0), 190 - 80, "seed {seed}");
+
+        let next = state.energy_zone[1]
+            .next
+            .expect("opponent should have a next energy queued");
+        assert!(
+            next.is_selectable(),
+            "seed {seed}: Buggy Beam should only pick one of the 8 basic Energy types"
+        );
+        observed.insert(next);
+
+        // The attacker's own energy zone is untouched.
+        assert_eq!(state.energy_zone[0].next, Some(EnergyType::Grass));
+    }
+
+    assert!(
+        observed.len() > 1,
+        "expected Buggy Beam to produce more than one Energy type across seeds, got {observed:?}"
+    );
+    assert!(
+        observed.iter().any(|e| *e != EnergyType::Darkness),
+        "expected at least one Energy type the opponent's deck could not have generated"
+    );
+}

--- a/tests/pokemon/primarina_melodious_healing_test.rs
+++ b/tests/pokemon/primarina_melodious_healing_test.rs
@@ -1,0 +1,42 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::PlayedCard,
+    test_support::get_test_game_with_board,
+};
+
+/// Primarina's "Melodious Healing": "Once during your turn, you may heal 30 damage from each of
+/// your [W] Pokémon." Only the [W] Pokemon heal, and only once per turn.
+#[test]
+fn test_melodious_healing_heals_only_your_water_pokemon() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A3048Primarina).with_damage(50),
+            // Squirtle is [W]; Charmander is not.
+            PlayedCard::from_id(CardId::A1053Squirtle).with_damage(40),
+            PlayedCard::from_id(CardId::A1033Charmander).with_damage(40),
+        ],
+        vec![PlayedCard::from_id(CardId::A1055Blastoise).with_damage(60)],
+    );
+
+    let use_ability = Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 0 },
+        is_stack: false,
+    };
+    game.apply_action(&use_ability);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_remaining_hp(0, 0), 140 - 50 + 30);
+    assert_eq!(state.get_remaining_hp(0, 1), 60 - 40 + 30);
+    // Charmander is [R], so it is untouched.
+    assert_eq!(state.get_remaining_hp(0, 2), 60 - 40);
+    // The opponent's [W] Pokemon is not healed either.
+    assert_eq!(state.get_remaining_hp(1, 0), 150 - 60);
+
+    // The ability is once per turn, so it is no longer offered.
+    let (_, actions) = state.generate_possible_actions();
+    assert!(!actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseAbility { in_play_idx: 0 })));
+}

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -14,6 +14,8 @@ mod iris_trainer_test;
 mod juliana_test;
 #[path = "trainers/korrina_cabbie_parasol_lady_test.rs"]
 mod korrina_cabbie_parasol_lady_test;
+#[path = "trainers/mallow_test.rs"]
+mod mallow_test;
 #[path = "trainers/marlon_test.rs"]
 mod marlon_test;
 #[path = "trainers/order_pad_test.rs"]

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -10,6 +10,8 @@ mod elesa_test;
 mod field_blower_test;
 #[path = "trainers/iris_trainer_test.rs"]
 mod iris_trainer_test;
+#[path = "trainers/jasmine_test.rs"]
+mod jasmine_test;
 #[path = "trainers/juliana_test.rs"]
 mod juliana_test;
 #[path = "trainers/korrina_cabbie_parasol_lady_test.rs"]

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -1,5 +1,7 @@
 #[path = "trainers/barry_test.rs"]
 mod barry_test;
+#[path = "trainers/cheren_test.rs"]
+mod cheren_test;
 #[path = "trainers/cynthia_test.rs"]
 mod cynthia_test;
 #[path = "trainers/drayden_test.rs"]

--- a/tests/trainers/cheren_test.rs
+++ b/tests/trainers/cheren_test.rs
@@ -1,0 +1,94 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Cheren: "During your opponent's next turn, all of your Watchog and Stoutland take -100 damage
+/// from attacks from your opponent's Pokémon ex."
+///
+/// Player 0 puts `defender` in the Active Spot, optionally plays Cheren, ends the turn, and then
+/// player 1's `attacker` uses its first attack. Returns the defender's remaining HP.
+fn attack_defender(defender: PlayedCard, attacker: CardId, play_cheren: bool) -> u32 {
+    let mut game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![defender],
+        vec![PlayedCard::from_id(attacker).with_energy(vec![
+            EnergyType::Grass,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+        ])],
+    );
+
+    if play_cheren {
+        let cheren = match get_card_by_enum(CardId::B3151Cheren) {
+            Card::Trainer(trainer_card) => trainer_card,
+            _ => panic!("Cheren should be a Trainer card"),
+        };
+        let mut state = game.get_state_clone();
+        state.hands[0].push(Card::Trainer(cheren.clone()));
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::Play {
+                trainer_card: cheren,
+            },
+            is_stack: false,
+        });
+    }
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(attacker, 0),
+        is_stack: false,
+    });
+
+    game.get_state_clone().get_remaining_hp(0, 0)
+}
+
+#[test]
+fn test_cheren_reduces_damage_from_pokemon_ex() {
+    // Venusaur ex's Razor Leaf does 60, fully absorbed by Cheren's -100.
+    let watchog = PlayedCard::from_id(CardId::B1200Watchog);
+    assert_eq!(
+        attack_defender(watchog.clone(), CardId::A1004VenusaurEx, false),
+        100 - 60
+    );
+    assert_eq!(attack_defender(watchog, CardId::A1004VenusaurEx, true), 100);
+}
+
+#[test]
+fn test_cheren_does_not_reduce_damage_from_non_ex() {
+    // Bulbasaur's Vine Whip does 40, and Bulbasaur is not a Pokémon ex.
+    let stoutland = PlayedCard::from_id(CardId::B1203Stoutland);
+    assert_eq!(
+        attack_defender(stoutland.clone(), CardId::A1001Bulbasaur, false),
+        150 - 40
+    );
+    assert_eq!(
+        attack_defender(stoutland, CardId::A1001Bulbasaur, true),
+        150 - 40
+    );
+}
+
+#[test]
+fn test_cheren_does_not_protect_other_pokemon() {
+    // Snorlax is neither Watchog nor Stoutland, so it takes the full 60 from a Pokémon ex.
+    let snorlax = PlayedCard::from_id(CardId::A1211Snorlax);
+    assert_eq!(
+        attack_defender(snorlax, CardId::A1004VenusaurEx, true),
+        150 - 60
+    );
+}

--- a/tests/trainers/jasmine_test.rs
+++ b/tests/trainers/jasmine_test.rs
@@ -1,0 +1,80 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+    Game,
+};
+
+/// Jasmine: "During your opponent's next turn, all of your Steelix and Skarmory ex take -50
+/// damage from attacks from your opponent's Pokémon."
+///
+/// Player 0 sets up `defender`, optionally plays Jasmine, ends the turn, and then player 1's
+/// Venusaur ex uses Razor Leaf (60) into it. Returns the defender's remaining HP.
+fn razor_leaf_into(defender: PlayedCard, play_jasmine: bool) -> u32 {
+    let mut game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![defender],
+        vec![
+            PlayedCard::from_id(CardId::A1004VenusaurEx).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+    );
+
+    if play_jasmine {
+        let jasmine = match get_card_by_enum(CardId::A4160Jasmine) {
+            Card::Trainer(trainer_card) => trainer_card,
+            _ => panic!("Jasmine should be a Trainer card"),
+        };
+        let mut state = game.get_state_clone();
+        state.hands[0].push(Card::Trainer(jasmine.clone()));
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::Play {
+                trainer_card: jasmine,
+            },
+            is_stack: false,
+        });
+    }
+
+    end_turn_and_attack(&mut game);
+    game.get_state_clone().get_remaining_hp(0, 0)
+}
+
+fn end_turn_and_attack(game: &mut Game<'static>) {
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(CardId::A1004VenusaurEx, 0),
+        is_stack: false,
+    });
+}
+
+#[test]
+fn test_jasmine_reduces_damage_to_steelix() {
+    let steelix = PlayedCard::from_id(CardId::A4122Steelix);
+    assert_eq!(razor_leaf_into(steelix.clone(), false), 150 - 60);
+    assert_eq!(razor_leaf_into(steelix, true), 150 - 10);
+}
+
+#[test]
+fn test_jasmine_does_not_protect_other_pokemon() {
+    // Registeel is a [M] Pokemon that Jasmine does not name, so it takes the full 60.
+    let registeel = PlayedCard::from_id(CardId::A2112Registeel);
+    assert_eq!(razor_leaf_into(registeel.clone(), false), 110 - 60);
+    assert_eq!(razor_leaf_into(registeel, true), 110 - 60);
+}

--- a/tests/trainers/mallow_test.rs
+++ b/tests/trainers/mallow_test.rs
@@ -1,0 +1,92 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn mallow_card() -> deckgym::models::TrainerCard {
+    match get_card_by_enum(CardId::A3154Mallow) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Mallow should be a Trainer card"),
+    }
+}
+
+/// Mallow: "Heal all damage from 1 of your Shiinotic or Tsareena. If you do, discard all Energy
+/// from that Pokémon."
+#[test]
+fn test_mallow_fully_heals_tsareena_and_discards_all_its_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A3020Tsareena)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Grass])
+                .with_damage(90),
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_energy(vec![EnergyType::Grass])
+                .with_damage(20),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.hands[0].push(Card::Trainer(mallow_card()));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: mallow_card(),
+        },
+        is_stack: false,
+    });
+
+    // Only Tsareena is a valid target; Bulbasaur is damaged but is neither Shiinotic nor Tsareena.
+    let (actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(actions.len(), 1);
+    let heal_action = actions[0].clone();
+    assert!(matches!(
+        heal_action.action,
+        SimpleAction::HealAndDiscardEnergy { in_play_idx: 0, .. }
+    ));
+    game.apply_action(&heal_action);
+
+    let state = game.get_state_clone();
+    let tsareena = state.get_active(0);
+    assert_eq!(tsareena.get_remaining_hp(), 130);
+    assert!(tsareena.attached_energy.is_empty());
+    assert_eq!(
+        state.discard_energies[0],
+        vec![EnergyType::Grass, EnergyType::Grass]
+    );
+
+    // Bulbasaur is untouched.
+    assert_eq!(state.get_remaining_hp(0, 1), 70 - 20);
+}
+
+/// Without a damaged Shiinotic or Tsareena, Mallow can't be played at all.
+#[test]
+fn test_mallow_is_not_playable_without_a_damaged_target() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        // An undamaged Tsareena would heal nothing, so playing Mallow would be a no-op.
+        vec![
+            PlayedCard::from_id(CardId::A3020Tsareena)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Grass]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(20),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.hands[0].push(Card::Trainer(mallow_card()));
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(!actions.iter().any(|action| matches!(
+        &action.action,
+        SimpleAction::Play { trainer_card } if trainer_card.name == "Mallow"
+    )));
+}


### PR DESCRIPTION
Implements 6 cards, one commit each. Each commit adds its Game-level tests first, then the implementation.

| Commit | Card | Effect |
| --- | --- | --- |
| `e3bd7a2` | Meganium (A4 010) | Bloomshine — "Heal 20 damage from each of your Pokémon." |
| `8cabbe5` | Primarina (A3 048) | Melodious Healing — "…heal 30 damage from each of your [W] Pokémon." |
| `6dca6a9` | Porygon-Z (A2 129) | Buggy Beam — randomize the opponent's next generated Energy |
| `a4eb524` | Mallow (A3 154, A3 196) | Heal all damage from 1 of your Shiinotic or Tsareena, then discard all its Energy |
| `d2dd0f5` | Jasmine (A4 160, A4 200) | Steelix / Skarmory ex take -50 from attacks next turn |
| `1d66f7e` | Cheren (B3 151, B3 192) | Watchog / Stoutland take -100 from Pokémon ex attacks next turn |

Card count goes from 3318 to **3328 / 3761 (88.5%)** — 10 cards, since the star/full-art variants of the Supporters share the same effect text.

Dusknoir (B1 105) was originally part of this PR and has been dropped — see the note at the bottom.

## Notable implementation choices

**Reuse over new mechanics.** Meganium is a pure map entry on the existing `HealAllYourPokemon` attack mechanic. Primarina generalizes the `HealAllYourPokemon` *ability* mechanic with an `energy_type: Option<EnergyType>` filter (`None` preserves the existing 10/20 variants). Cheren reuses the `ReducedDamageForSpecificPokemon` turn effect that Jasmine introduces, extended with an `attacker_must_be_ex` flag.

**Jasmine / Cheren** add `ReducedDamageForSpecificPokemon`, the by-name counterpart to the existing by-type `ReducedDamageForType` (Adaman). Like that one it also covers Benched Pokémon, matching the "all of your …" wording, and names are matched exactly so Mega Steelix ex is not protected by Jasmine.

**Mallow** follows Marlon and Diantha: a `card_logic/mallow.rs` target helper shared by move generation and the effect, offering one `HealAndDiscardEnergy` choice per damaged Shiinotic/Tsareena. Undamaged targets are excluded — healing nothing would leave the "If you do" discard ungated — so Mallow is unplayable without a damaged target.

**Porygon-Z.** The 8 Energy types the card lists are exactly the ones the Energy Zone can generate, so they're lifted into a reusable `EnergyType::SELECTABLE` constant beside `is_selectable`.

## Testing

- New Game-level tests for each card under `tests/pokemon/` and `tests/trainers/`, written before the implementation.
- `cargo test --features "tui test-utils"` — 669 tests across 28 binaries pass.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt` clean.
- `cargo run --bin card_test` (10,000 games vs. every deck in `example_decks/`) runs clean for A4 010, A3 048, A3 154, A4 160, and B3 151.

One caveat: `card_test` can't run for **A2 129** (Porygon-Z) because `temp_deck_generator` picks A1 209 Porygon, whose Data Scan ability isn't implemented yet, and the generated deck panics on move generation. This is pre-existing and unrelated to this PR. Verified instead with 2000 simulated games using an equivalent deck built on A2 127 Porygon (no ability).

## Dropped: Dusknoir (B1 105)

Fade into Darkness ("When this Pokémon is Knocked Out, flip a coin. If heads, your opponent can't get any points for it.") was implemented and then dropped from this PR at the author's request.

Recording why, in case it's picked up later: unlike Ursaluna's Guts, it triggers on *any* Knock Out — attack damage, poison, self-damage, a Tool being discarded — so it can't be enumerated as an attack outcome branch the way `split_with_guts_survival` is. The flip has to happen where points are awarded, in `handle_knockouts`, which has no access to the game's rng. Implementing it faithfully meant threading `&mut StdRng` through `handle_knockouts`, `handle_damage`, `on_end_turn`, the Pokémon Checkup helpers, and `State::attach_energy_from_{zone,discard}` — a wide engine change for one card, so it does not belong bundled with five straightforward card implementations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PeigfYurkypkqNa1jApPWw