### PR TITLE
Implement Silcoon (B4 002) and Cascoon (B4 004) Cocoon Collector

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -35,7 +35,8 @@ use super::{
     outcomes::{CoinSeq, Outcomes},
     shared_mutations::{
         pokemon_search_outcomes, pokemon_search_outcomes_by_type, search_and_bench_basic,
-        search_and_bench_by_name, search_to_hand_by_evolves_from, supporter_search_outcomes,
+        search_and_bench_by_name, search_and_bench_multiple_by_names,
+        search_to_hand_by_evolves_from, supporter_search_outcomes,
     },
     SimpleAction,
 };
@@ -292,6 +293,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::SearchToBenchByName { name } => {
             AttackOutcomes::from_effect_outcomes(search_and_bench_by_name(state, name.clone()))
         }
+        Mechanic::SearchToBenchByNames { names, count } => AttackOutcomes::from_effect_outcomes(
+            search_and_bench_multiple_by_names(state, names.clone(), *count),
+        ),
         Mechanic::SearchToBenchBasic => {
             AttackOutcomes::from_effect_outcomes(search_and_bench_basic(state))
         }

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -49,6 +49,13 @@ pub enum Mechanic {
     SearchToBenchByName {
         name: String,
     },
+    /// Silcoon's & Cascoon's Cocoon Collector: "Put 3 random cards from among Silcoon and Cascoon
+    /// from your deck onto your Bench." Puts up to `count` random cards named after any of `names`
+    /// onto the Bench, limited by how many are in the deck and by the available Bench space.
+    SearchToBenchByNames {
+        names: Vec<String>,
+        count: usize,
+    },
     SearchToBenchBasic,
     SearchRandomPokemonToHand,
     SearchToHandByEvolvesFrom {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2355,6 +2355,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per_card: 10,
         },
     );
+    // Silcoon & Cascoon - Cocoon Collector
+    map.insert(
+        "Put 3 random cards from among Silcoon and Cascoon from your deck onto your Bench.",
+        Mechanic::SearchToBenchByNames {
+            names: vec!["Silcoon".to_string(), "Cascoon".to_string()],
+            count: 3,
+        },
+    );
     // Mega Metagross ex - Gatling Slug
     map.insert(
         "This attack does 10 more damage for each [M] Energy attached to this Pokémon.",

--- a/src/actions/shared_mutations.rs
+++ b/src/actions/shared_mutations.rs
@@ -3,7 +3,9 @@ use std::cmp::min;
 
 use crate::{
     actions::{
-        apply_action_helpers::Mutations, apply_evolve, apply_place_card, outcomes::Outcomes,
+        apply_action_helpers::{Mutation, Mutations},
+        apply_evolve, apply_place_card,
+        outcomes::Outcomes,
     },
     combinatorics::generate_combinations,
     hooks::can_evolve_into,
@@ -185,6 +187,61 @@ pub(crate) fn search_and_bench_by_name(state: &State, card_name: String) -> Outc
         move |card: &Card| card.get_name() == card_name,
         "Card should be in deck",
     )
+}
+
+/// Silcoon's & Cascoon's Cocoon Collector: put up to `count` random cards named after any of
+/// `names` from the deck onto the Bench (capped by the deck's contents and the Bench space).
+pub(crate) fn search_and_bench_multiple_by_names(
+    state: &State,
+    names: Vec<String>,
+    count: usize,
+) -> Outcomes {
+    let acting_player = state.current_player;
+    let eligible_cards: Vec<Card> = state.decks[acting_player]
+        .cards
+        .iter()
+        .filter(|card| names.contains(&card.get_name()))
+        .cloned()
+        .collect();
+    let free_slots = state.in_play_pokemon[acting_player]
+        .iter()
+        .filter(|slot| slot.is_none())
+        .count();
+    let num_to_place = min(count, min(eligible_cards.len(), free_slots));
+
+    if num_to_place == 0 {
+        // Nothing to fetch (or nowhere to put it), so just shuffle the deck.
+        return Outcomes::single_fn(|rng, state, action| {
+            state.decks[action.actor].shuffle(false, rng);
+        });
+    }
+
+    let combinations = generate_combinations(&eligible_cards, num_to_place);
+    let probabilities = vec![1.0 / (combinations.len() as f64); combinations.len()];
+    let mutations: Mutations = combinations
+        .into_iter()
+        .map(|combo| -> Mutation {
+            Box::new(move |rng, state, action| {
+                for card in &combo {
+                    let Some(bench_idx) = state.in_play_pokemon[action.actor]
+                        .iter()
+                        .position(|slot| slot.is_none())
+                    else {
+                        debug!("No bench space available, skipping remaining cards");
+                        break;
+                    };
+                    debug!(
+                        "Fetched {card:?} from deck for player {} to place on bench",
+                        action.actor
+                    );
+                    apply_place_card(state, action.actor, card, bench_idx, true);
+                }
+                state.decks[action.actor].shuffle(false, rng);
+            })
+        })
+        .collect();
+
+    Outcomes::from_parts(probabilities, mutations)
 }
 
 pub(crate) fn search_and_bench_basic(state: &State) -> Outcomes {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -186,6 +186,8 @@ mod salamence_test;
 mod sawk_test;
 #[path = "pokemon/shinx_hide_test.rs"]
 mod shinx_hide_test;
+#[path = "pokemon/silcoon_cascoon_cocoon_collector_test.rs"]
+mod silcoon_cascoon_cocoon_collector_test;
 #[path = "pokemon/slither_wing_test.rs"]
 mod slither_wing_test;
 #[path = "pokemon/smoochum_test.rs"]

--- a/tests/pokemon/silcoon_cascoon_cocoon_collector_test.rs
+++ b/tests/pokemon/silcoon_cascoon_cocoon_collector_test.rs
@@ -1,0 +1,87 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Silcoon's & Cascoon's Cocoon Collector: "Put 3 random cards from among Silcoon and
+/// Cascoon from your deck onto your Bench."
+#[test]
+fn test_cocoon_collector_puts_silcoon_and_cascoon_from_deck_onto_bench() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4002Silcoon).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+
+    let mut state = game.get_state_clone();
+    // 3 eligible cards (Silcoon/Cascoon) plus a non-eligible one, so the outcome is deterministic.
+    state.decks[0].cards = vec![
+        get_card_by_enum(CardId::B4004Cascoon),
+        get_card_by_enum(CardId::A1033Charmander),
+        get_card_by_enum(CardId::B1004Silcoon),
+        get_card_by_enum(CardId::B1006Cascoon),
+    ];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4002Silcoon, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    for bench_idx in 1..4 {
+        let benched = state.in_play_pokemon[0][bench_idx]
+            .as_ref()
+            .expect("Cocoon Collector should fill all 3 Bench slots");
+        assert!(
+            matches!(benched.get_name().as_str(), "Silcoon" | "Cascoon"),
+            "Only Silcoon and Cascoon should be put onto the Bench, got {}",
+            benched.get_name()
+        );
+    }
+    assert_eq!(
+        state.decks[0].cards.len(),
+        1,
+        "Only the non-eligible Charmander should remain in the deck"
+    );
+}
+
+#[test]
+fn test_cocoon_collector_is_limited_by_available_bench_space() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4004Cascoon).with_energy(vec![EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::A1033Charmander),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.decks[0].cards = vec![
+        get_card_by_enum(CardId::B4002Silcoon),
+        get_card_by_enum(CardId::B1006Cascoon),
+        get_card_by_enum(CardId::A1033Charmander),
+    ];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4004Cascoon, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let benched = state.in_play_pokemon[0][3]
+        .as_ref()
+        .expect("The single open Bench slot should be filled");
+    assert!(matches!(benched.get_name().as_str(), "Silcoon" | "Cascoon"));
+    assert_eq!(
+        state.decks[0].cards.len(),
+        2,
+        "Only 1 card should leave the deck when there is a single open Bench slot"
+    );
+}


### PR DESCRIPTION
Adds the SearchToBenchByNames mechanic: "Put 3 random cards from among
Silcoon and Cascoon from your deck onto your Bench." The new
search_and_bench_multiple_by_names helper enumerates the possible
unordered draws of matching cards from the deck, capped by both the
deck's contents and the available Bench space, and shuffles the deck
afterwards.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014VYhfb9ATCuRKCic3i3wUx