### PR TITLE
Implement 8 optimizer-requested cards (Coalossal ×2, Politoed, Pidgeot, Mega Pidgeot ex, Magnezone, Jellicent, Leftovers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # deckgym-core: Pokémon TCG Pocket Simulator
 
-![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3328_%2F_3761_%2888.5%25%29-green)
+![Card Implemented](https://img.shields.io/badge/Cards_Implemented-3340_%2F_3761_%2888.8%25%29-green)
 
 **deckgym-core** is a high-performance Rust library designed for simulating Pokémon TCG Pocket games. It features a command-line interface (CLI) capable of running 10,000 simulations in approximately 3 seconds. This is the library that powers https://www.deckgym.com.
 

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -75,6 +75,12 @@ pub enum AbilityMechanic {
     ReduceDamageFromAttacks {
         amount: u32,
     },
+    /// Magnezone's Resilience Link: like `ReduceDamageFromAttacks`, but only while its owner has
+    /// Arceus or Arceus ex in play. Because it depends on the board it cannot be modeled as a
+    /// plain `CardEffect` derived from the card alone; it is resolved in `hooks::modify_damage`.
+    ReduceDamageFromAttacksIfArceusInPlay {
+        amount: u32,
+    },
     ReduceOpponentActiveDamage {
         amount: u32,
     },

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -214,6 +214,13 @@ pub enum AbilityMechanic {
         amount: u32,
     },
     PoisonAttackerOnDamaged,
+    /// Jellicent's Bouncy Body: if this Pokémon is in the Active Spot and is damaged by an attack
+    /// from the opponent's Pokémon, its owner takes an Energy of `energy_type` from their Energy
+    /// Zone and attaches it to 1 of their Benched Pokémon (their choice). Passive; triggered from
+    /// the damage path.
+    AttachEnergyFromZoneToBenchedOnDamaged {
+        energy_type: EnergyType,
+    },
     IncreaseAttackCostForOpponentActive {
         amount: u32,
     },

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -126,6 +126,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::ReduceDamageFromAttacks { .. } => {
             panic!("ReduceDamageFromAttacks is a passive ability")
         }
+        AbilityMechanic::ReduceDamageFromAttacksIfArceusInPlay { .. } => {
+            panic!("ReduceDamageFromAttacksIfArceusInPlay is a passive ability")
+        }
         AbilityMechanic::ReduceOpponentActiveDamage { .. } => {
             panic!("ReduceOpponentActiveDamage is a passive ability")
         }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -270,6 +270,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::PoisonAttackerOnDamaged => {
             panic!("PoisonAttackerOnDamaged is a passive ability")
         }
+        AbilityMechanic::AttachEnergyFromZoneToBenchedOnDamaged { .. } => {
+            panic!("AttachEnergyFromZoneToBenchedOnDamaged is a passive ability")
+        }
         AbilityMechanic::IncreaseAttackCostForOpponentActive { .. } => {
             panic!("IncreaseAttackCostForOpponentActive is a passive ability")
         }

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -544,7 +544,41 @@ pub(crate) fn handle_damage_only(
             state.apply_status_condition(attacking_player, 0, StatusCondition::Poisoned);
             debug!("Poison Barb: Poisoned the attacking Pokemon");
         }
+
+        if attacking_player != target_player {
+            apply_bouncy_body(state, target_player);
+        }
     }
+}
+
+/// Jellicent's Bouncy Body: the Active Pokémon was just damaged by an attack from the opponent's
+/// Pokémon, so its owner takes an Energy from their Energy Zone and attaches it to 1 of their
+/// Benched Pokémon (their choice).
+///
+/// Queued before knockouts resolve, so the choice is offered while the Bench is still intact
+/// (promotions are inserted at the bottom of the stack and therefore resolve afterwards).
+fn apply_bouncy_body(state: &mut State, target_player: usize) {
+    let Some(AbilityMechanic::AttachEnergyFromZoneToBenchedOnDamaged { energy_type }) = state
+        .in_play_pokemon[target_player][0]
+        .as_ref()
+        .and_then(|active| get_ability_mechanic(&active.card))
+    else {
+        return;
+    };
+
+    let choices = state
+        .enumerate_bench_pokemon(target_player)
+        .map(|(in_play_idx, _)| SimpleAction::Attach {
+            attachments: vec![(1, *energy_type, in_play_idx)],
+            is_turn_energy: false,
+        })
+        .collect::<Vec<_>>();
+    if choices.is_empty() {
+        return; // Nowhere to put the Energy.
+    }
+
+    debug!("Bouncy Body: Attaching a {energy_type:?} Energy to a Benched Pokemon");
+    state.move_generation_stack.push((target_player, choices));
 }
 
 fn is_iris_bonus_active(

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -667,6 +667,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::DamageAndDiscardOpponentDeck { discard_count } => {
             damage_and_discard_opponent_deck(attack.fixed_damage, *discard_count)
         }
+        Mechanic::FlipUntilTailsDiscardOpponentDeck => {
+            flip_until_tails_discard_opponent_deck(attack.fixed_damage)
+        }
         Mechanic::MegaAmpharosExLightningLancer => mega_ampharos_lightning_lancer(state),
         Mechanic::OminousClaw => ominous_claw_attack(state.current_player, attack.fixed_damage),
         Mechanic::DarknessClaw => darkness_claw_attack(state.current_player, attack.fixed_damage),
@@ -1927,16 +1930,29 @@ fn tiered_coin_flip_damage(
 /// For attacks that deal damage and discard cards from the top of opponent's deck
 fn damage_and_discard_opponent_deck(damage: u32, discard_count: usize) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
-        let opponent = (action.actor + 1) % 2;
-
-        for _ in 0..discard_count {
-            if let Some(card) = state.decks[opponent].draw() {
-                state.discard_piles[opponent].push(card);
-            } else {
-                break; // No more cards to discard
-            }
-        }
+        discard_top_opponent_deck(state, action.actor, discard_count);
     })
+}
+
+/// Flip a coin until tails, discarding the top card of the opponent's deck for each heads
+/// (e.g. Coalossal's Mountain Crush). Truncated at 8 heads like the other flip-until-tails
+/// attacks, to keep the probability space manageable.
+fn flip_until_tails_discard_opponent_deck(damage: u32) -> AttackOutcomes {
+    AttackOutcomes::geometric_until_tails(8, move |heads| {
+        active_damage_effect_outcome(damage, move |_, state, action| {
+            discard_top_opponent_deck(state, action.actor, heads);
+        })
+    })
+}
+
+fn discard_top_opponent_deck(state: &mut State, actor: usize, discard_count: usize) {
+    let opponent = (actor + 1) % 2;
+    for _ in 0..discard_count {
+        let Some(card) = state.decks[opponent].draw() else {
+            break; // No more cards to discard
+        };
+        state.discard_piles[opponent].push(card);
+    }
 }
 
 fn vaporeon_hyper_whirlpool(_state: &State, damage: u32) -> AttackOutcomes {

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -640,6 +640,15 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfEvolvedThisTurn { extra_damage } => {
             extra_damage_if_evolved_this_turn_attack(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::ExtraDamageIfEvolvedFromThisTurn {
+            pokemon_name,
+            extra_damage,
+        } => extra_damage_if_evolved_from_this_turn_attack(
+            state,
+            attack.fixed_damage,
+            pokemon_name,
+            *extra_damage,
+        ),
         Mechanic::RecoilIfKo { self_damage } => {
             recoil_if_ko_attack(attack.fixed_damage, *self_damage)
         }
@@ -2919,6 +2928,31 @@ fn extra_damage_if_evolved_this_turn_attack(
         .map(|p| p.played_this_turn)
         .unwrap_or(false);
     let damage = if evolved {
+        base_damage + extra_damage
+    } else {
+        base_damage
+    };
+    active_damage_doutcome(damage)
+}
+
+/// Like `extra_damage_if_evolved_this_turn_attack`, but the evolution must have come from a
+/// specific Pokémon: the card directly underneath the active must be `pokemon_name`.
+fn extra_damage_if_evolved_from_this_turn_attack(
+    state: &State,
+    base_damage: u32,
+    pokemon_name: &str,
+    extra_damage: u32,
+) -> AttackOutcomes {
+    let evolved_from_named = state.in_play_pokemon[state.current_player][0]
+        .as_ref()
+        .is_some_and(|active| {
+            active.played_this_turn
+                && active
+                    .cards_behind
+                    .last()
+                    .is_some_and(|under| under.get_name() == pokemon_name)
+        });
+    let damage = if evolved_from_named {
         base_damage + extra_damage
     } else {
         base_damage

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -321,6 +321,9 @@ fn forecast_effect_attack_by_mechanic(
             damage_and_discard_energy(attack.fixed_damage, 1)
         }
         Mechanic::CoinFlipDiscardEnergyFromOpponentActive => mawile_crunch(),
+        Mechanic::CoinFlipsDiscardEnergyFromOpponentActiveOrNothing { num_coins } => {
+            coin_flips_discard_energy_or_nothing(attack.fixed_damage, *num_coins)
+        }
         Mechanic::DiscardOpponentActiveToolsBeforeDamage => {
             discard_opponent_active_tools_before_damage(attack.fixed_damage)
         }
@@ -1871,24 +1874,47 @@ fn self_discard_energy_and_card_effect(
 /// For attacks that deal damage and discard random energy from opponent's active Pokémon
 fn damage_and_discard_energy(damage: u32, discard_count: usize) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |rng, state, action| {
-        let opponent = (action.actor + 1) % 2;
-        let mut to_discard = Vec::new();
-        let mut remaining = state.get_active(opponent).attached_energy.clone();
-
-        for _ in 0..discard_count {
-            if remaining.is_empty() {
-                break; // No more energy to discard
-            }
-
-            let energy_count = remaining.len();
-            let rand_idx = rng.gen_range(0..energy_count);
-            to_discard.push(remaining.swap_remove(rand_idx));
-        }
-
-        if !to_discard.is_empty() {
-            state.discard_from_active(opponent, &to_discard);
-        }
+        discard_random_energy_from_opponent_active(rng, state, action.actor, discard_count);
     })
+}
+
+/// Flip `num_coins` coins and discard a random Energy from the opponent's Active Pokémon for
+/// each heads (e.g. Pidgeot's Twister). On all tails the attack does nothing — including no
+/// damage — so that branch is a no-op outcome.
+fn coin_flips_discard_energy_or_nothing(damage: u32, num_coins: usize) -> AttackOutcomes {
+    AttackOutcomes::binomial_by_heads(num_coins, move |heads| {
+        if heads == 0 {
+            return AttackOutcome::noop();
+        }
+        active_damage_effect_outcome(damage, move |rng, state, action| {
+            discard_random_energy_from_opponent_active(rng, state, action.actor, heads);
+        })
+    })
+}
+
+fn discard_random_energy_from_opponent_active(
+    rng: &mut StdRng,
+    state: &mut State,
+    actor: usize,
+    discard_count: usize,
+) {
+    let opponent = (actor + 1) % 2;
+    let mut to_discard = Vec::new();
+    let mut remaining = state.get_active(opponent).attached_energy.clone();
+
+    for _ in 0..discard_count {
+        if remaining.is_empty() {
+            break; // No more energy to discard
+        }
+
+        let energy_count = remaining.len();
+        let rand_idx = rng.gen_range(0..energy_count);
+        to_discard.push(remaining.swap_remove(rand_idx));
+    }
+
+    if !to_discard.is_empty() {
+        state.discard_from_active(opponent, &to_discard);
+    }
 }
 
 fn discard_opponent_active_tools_before_damage(damage: u32) -> AttackOutcomes {

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -85,6 +85,12 @@ pub enum Mechanic {
     },
     DiscardEnergyFromOpponentActive,
     CoinFlipDiscardEnergyFromOpponentActive,
+    /// Pidgeot's Twister / Mega Pidgeot ex's Giant Twister: flip `num_coins` coins and discard a
+    /// random Energy from the opponent's Active Pokémon for each heads. If every coin is tails
+    /// the attack does nothing at all — not even its `fixed_damage`.
+    CoinFlipsDiscardEnergyFromOpponentActiveOrNothing {
+        num_coins: usize,
+    },
     DiscardOpponentActiveToolsBeforeDamage,
     ExtraDamageIfEx {
         extra_damage: u32,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -433,6 +433,9 @@ pub enum Mechanic {
     DamageAndDiscardOpponentDeck {
         discard_count: usize,
     },
+    /// Coalossal's Mountain Crush: deal the attack's `fixed_damage`, then flip a coin until
+    /// tails, discarding the top card of the opponent's deck for each heads.
+    FlipUntilTailsDiscardOpponentDeck,
     MegaAmpharosExLightningLancer,
     OminousClaw,
     DarknessClaw,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -354,6 +354,13 @@ pub enum Mechanic {
     ExtraDamageIfEvolvedThisTurn {
         extra_damage: u32,
     },
+    /// Politoed's Raid: extra damage if this Pokémon evolved *from a specific Pokémon* during
+    /// this turn. Unlike `ExtraDamageIfEvolvedThisTurn` this also checks the card directly
+    /// underneath, so evolving via Rare Candy (which skips the named Stage 1) does not qualify.
+    ExtraDamageIfEvolvedFromThisTurn {
+        pokemon_name: String,
+        extra_damage: u32,
+    },
     BenchCountDamage {
         include_fixed_damage: bool,
         damage_per: u32,

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -170,7 +170,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             AbilityMechanic::IncreaseDamageIfArceusInPlay { amount: 30 },
         );
         // map.insert("If you have Arceus or Arceus ex in play, this Pokémon has no Retreat Cost.", todo_implementation);
-        // map.insert("If you have Arceus or Arceus ex in play, this Pokémon takes -30 damage from attacks.", todo_implementation);
+        map.insert(
+            "If you have Arceus or Arceus ex in play, this Pokémon takes -30 damage from attacks.",
+            AbilityMechanic::ReduceDamageFromAttacksIfArceusInPlay { amount: 30 },
+        );
         // map.insert("If you have Latias in play, this Pokémon has no Retreat Cost.", todo_implementation);
         // map.insert("If you have another Falinks in play, this Pokémon's attacks do +20 damage to your opponent's Active Pokémon, and this Pokémon takes -20 damage from attacks from your opponent's Pokémon.", todo_implementation);
         map.insert(

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -151,7 +151,12 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon, do 20 damage to the Attacking Pokémon.",
             AbilityMechanic::CounterattackDamage { amount: 20 },
         );
-        // map.insert("If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon, take a [W] Energy from your Energy Zone and attach it to 1 of your Benched Pokémon.", todo_implementation);
+        map.insert(
+            "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon, take a [W] Energy from your Energy Zone and attach it to 1 of your Benched Pokémon.",
+            AbilityMechanic::AttachEnergyFromZoneToBenchedOnDamaged {
+                energy_type: EnergyType::Water,
+            },
+        );
         map.insert(
             "If this Pokémon is in the Active Spot and is damaged by an attack from your opponent's Pokémon, the Attacking Pokémon is now Poisoned.",
             AbilityMechanic::PoisonAttackerOnDamaged,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -473,7 +473,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             coin_flip: false,
         },
     );
-    // map.insert("Flip 2 coins. For each heads, discard a random Energy from your opponent's Active Pokémon. If both of them are tails, this attack does nothing.", todo_implementation);
+    map.insert(
+        "Flip 2 coins. For each heads, discard a random Energy from your opponent's Active Pokémon. If both of them are tails, this attack does nothing.",
+        Mechanic::CoinFlipsDiscardEnergyFromOpponentActiveOrNothing { num_coins: 2 },
+    );
     map.insert(
         "Flip 2 coins. If both of them are heads, this attack does 70 more damage.",
         Mechanic::ExtraDamageIfBothHeads { extra_damage: 70 },

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1106,7 +1106,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     // map.insert("If your opponent's Active Pokémon is a [G] Pokémon, this attack does 40 more damage.", todo_implementation);
-    // map.insert("If your opponent's Active Pokémon is a [G] Pokémon, this attack does 50 more damage.", todo_implementation);
+    map.insert(
+        "If your opponent's Active Pokémon is a [G] Pokémon, this attack does 50 more damage.",
+        Mechanic::ExtraDamageIfDefenderType {
+            energy_type: EnergyType::Grass,
+            extra_damage: 50,
+        },
+    );
     // map.insert("If your opponent's Active Pokémon is a [M] Pokémon, this attack does 30 more damage.", todo_implementation);
     map.insert(
         "If your opponent's Active Pokémon is affected by a Special Condition, this attack does 60 more damage.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2207,7 +2207,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per_heads: 30,
         },
     );
-    // map.insert("Flip a coin until you get tails. For each heads, discard the top card of your opponent's deck.", todo_implementation);
+    map.insert(
+        "Flip a coin until you get tails. For each heads, discard the top card of your opponent's deck.",
+        Mechanic::FlipUntilTailsDiscardOpponentDeck,
+    );
     map.insert(
         "Flip a coin. If heads, take 2 [R] Energy from your Energy Zone and attach it to this Pokémon.",
         Mechanic::CoinFlipSelfChargeActive {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1884,7 +1884,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("During your opponent's next turn, this Pokémon takes -80 damage from attacks from your opponent's Pokémon ex.", todo_implementation);
     // map.insert("Flip 2 coins. If both of them are heads, this attack does 20 more damage.", todo_implementation);
     // map.insert("Flip 2 coins. This attack does 40 more damage for each heads.", todo_implementation);
-    // map.insert("Flip 3 coins. For each heads, discard a random Energy from your opponent's Active Pokémon. If all of them are tails, this attack does nothing.", todo_implementation);
+    map.insert(
+        "Flip 3 coins. For each heads, discard a random Energy from your opponent's Active Pokémon. If all of them are tails, this attack does nothing.",
+        Mechanic::CoinFlipsDiscardEnergyFromOpponentActiveOrNothing { num_coins: 3 },
+    );
     // map.insert("Flip 3 coins. This attack does 30 damage for each heads.", todo_implementation);
     // map.insert("Flip a coin for each Tandemaus and Maushold you have in play. This attack does 60 damage for each heads.", todo_implementation);
     // map.insert("Flip a coin. If heads, discard your opponent's Active Pokémon.", todo_implementation);

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2276,7 +2276,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 60 more damage, and your opponent's Active Pokémon is now Paralyzed.", todo_implementation);
     // map.insert("If any of your [D] Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 80 more damage.", todo_implementation);
-    // map.insert("If this Pokémon evolved from Poliwhirl during this turn, this attack does 50 more damage.", todo_implementation);
+    map.insert(
+        "If this Pokémon evolved from Poliwhirl during this turn, this attack does 50 more damage.",
+        Mechanic::ExtraDamageIfEvolvedFromThisTurn {
+            pokemon_name: "Poliwhirl".to_string(),
+            extra_damage: 50,
+        },
+    );
     // map.insert("If this Pokémon has any [F] Energy attached, this attack does 60 more damage.", todo_implementation);
     map.insert(
         "If this Pokémon has at least 1 extra [F] Energy attached, this attack does 50 more damage.",

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -626,6 +626,8 @@ fn get_intimidating_fang_reduction(
 }
 
 fn get_ability_damage_reduction(
+    state: &State,
+    target_player: usize,
     receiving_pokemon: &crate::models::PlayedCard,
     is_from_active_attack: bool,
 ) -> u32 {
@@ -634,14 +636,36 @@ fn get_ability_damage_reduction(
     }
     // Reads the unified effect list, so Cloyster's Shell Armor (a passive ability) is handled the
     // same way as any stored effect.
-    receiving_pokemon
+    let effect_reduction: u32 = receiving_pokemon
         .get_effective_card_effects()
         .iter()
         .filter_map(|effect| match effect {
             CardEffect::ReduceDamageFromAttacks { amount } => Some(*amount),
             _ => None,
         })
-        .sum()
+        .sum();
+
+    // Magnezone's Resilience Link depends on the rest of the board, so it can't be derived as a
+    // CardEffect from the card alone.
+    let arceus_reduction = match get_ability_mechanic(&receiving_pokemon.card) {
+        Some(AbilityMechanic::ReduceDamageFromAttacksIfArceusInPlay { amount })
+            if has_arceus_in_play(state, target_player) =>
+        {
+            debug!("Resilience Link: Reducing damage by {}", amount);
+            *amount
+        }
+        _ => 0,
+    };
+
+    effect_reduction + arceus_reduction
+}
+
+/// Whether `player` has Arceus or Arceus ex in play (Active or Benched).
+fn has_arceus_in_play(state: &State, player: usize) -> bool {
+    state.enumerate_in_play_pokemon(player).any(|(_, pokemon)| {
+        let name = pokemon.get_name();
+        name == "Arceus" || name == "Arceus ex"
+    })
 }
 
 fn get_ability_damage_increase(
@@ -675,13 +699,7 @@ fn get_ability_damage_increase(
     if let Some(AbilityMechanic::IncreaseDamageIfArceusInPlay { amount }) =
         ability_mechanic_from_effect(&ability.effect)
     {
-        let has_arceus = state
-            .enumerate_in_play_pokemon(attacking_player)
-            .any(|(_, pokemon)| {
-                let name = pokemon.get_name();
-                name == "Arceus" || name == "Arceus ex"
-            });
-        if has_arceus {
+        if has_arceus_in_play(state, attacking_player) {
             debug!(
                 "IncreaseDamageIfArceusInPlay: Increasing damage by {}",
                 amount
@@ -1099,7 +1117,12 @@ pub(crate) fn modify_damage(
     let ability_damage_reduction = if skip_target_effects {
         0
     } else {
-        get_ability_damage_reduction(receiving_pokemon, is_from_active_attack)
+        get_ability_damage_reduction(
+            state,
+            target_player,
+            receiving_pokemon,
+            is_from_active_attack,
+        )
     };
     let ability_damage_increase = get_ability_damage_increase(
         state,

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -409,9 +409,24 @@ pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
 
     apply_soothing_shore_healing(player_ending_turn, state);
 
+    apply_leftovers_healing(player_ending_turn, state);
+
     apply_deceptive_needle_damage(player_ending_turn, state);
 
     apply_bad_dreams_damage(state);
+}
+
+/// Leftovers: At the end of your turn, if the Pokémon this card is attached to is in the Active
+/// Spot, heal 10 damage from that Pokémon.
+fn apply_leftovers_healing(player_ending_turn: usize, state: &mut State) {
+    let Some(active) = state.in_play_pokemon[player_ending_turn][0].as_mut() else {
+        return;
+    };
+    if !has_tool(active, CardId::A3b067Leftovers) {
+        return;
+    }
+    debug!("Leftovers: Healing 10 damage from the Active Pokémon");
+    active.heal(10);
 }
 
 /// Deceptive Needle: At the end of your turn, if the [D] Pokémon this card is attached to is in

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -181,6 +181,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::CanEvolveOnFirstTurnIfActive => false,
         AbilityMechanic::CounterattackDamage { .. } => false,
         AbilityMechanic::PoisonAttackerOnDamaged => false,
+        AbilityMechanic::AttachEnergyFromZoneToBenchedOnDamaged { .. } => false,
         AbilityMechanic::IncreaseAttackCostForOpponentActive { .. } => false,
         AbilityMechanic::IncreaseRetreatCostForOpponentActive { .. } => false,
         AbilityMechanic::PreventDamageWhileBenched => false,

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -98,6 +98,7 @@ fn can_use_ability_by_mechanic(
             can_use_dragonair_dragons_blessing(state, _in_play_index, card)
         }
         AbilityMechanic::ReduceDamageFromAttacks { .. } => false,
+        AbilityMechanic::ReduceDamageFromAttacksIfArceusInPlay { .. } => false,
         AbilityMechanic::ReduceOpponentActiveDamage { .. } => false,
         AbilityMechanic::IncreaseDamageWhenRemainingHpAtMost { .. } => false,
         AbilityMechanic::IncreaseDamageForTypeInPlay { .. } => false,

--- a/src/tools.rs
+++ b/src/tools.rs
@@ -40,6 +40,8 @@ static LEAF_CAPE_EFFECT: LazyLock<String> =
     LazyLock::new(|| tool_effect_text_from_card_id(CardId::A3147LeafCape));
 static ELECTRICAL_CORD_EFFECT: LazyLock<String> =
     LazyLock::new(|| tool_effect_text_from_card_id(CardId::A3a065ElectricalCord));
+static LEFTOVERS_EFFECT: LazyLock<String> =
+    LazyLock::new(|| tool_effect_text_from_card_id(CardId::A3b067Leftovers));
 static INFLATABLE_BOAT_EFFECT: LazyLock<String> =
     LazyLock::new(|| tool_effect_text_from_card_id(CardId::A4a067InflatableBoat));
 static STEEL_APRON_EFFECT: LazyLock<String> =
@@ -105,6 +107,7 @@ pub fn is_tool_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == POISON_BARB_EFFECT.as_str()
             || e == LEAF_CAPE_EFFECT.as_str()
             || e == ELECTRICAL_CORD_EFFECT.as_str()
+            || e == LEFTOVERS_EFFECT.as_str()
             || e == INFLATABLE_BOAT_EFFECT.as_str()
             || e == STEEL_APRON_EFFECT.as_str()
             || e == HEAVY_HELMET_EFFECT.as_str()

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -114,6 +114,8 @@ mod iron_moth_test;
 mod iron_thorns_test;
 #[path = "pokemon/iron_valiant_future_system_test.rs"]
 mod iron_valiant_future_system_test;
+#[path = "pokemon/jellicent_bouncy_body_test.rs"]
+mod jellicent_bouncy_body_test;
 #[path = "pokemon/jolteon_ex_test.rs"]
 mod jolteon_ex_test;
 #[path = "pokemon/klefki_dismantling_keys_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -42,6 +42,8 @@ mod chansey_blissey_test;
 mod charmeleon_ignition_test;
 #[path = "pokemon/coalossal_coal_drop_test.rs"]
 mod coalossal_coal_drop_test;
+#[path = "pokemon/coalossal_mountain_crush_test.rs"]
+mod coalossal_mountain_crush_test;
 #[path = "pokemon/comfey_flower_shield_test.rs"]
 mod comfey_flower_shield_test;
 #[path = "pokemon/corviknight_line_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -146,6 +146,8 @@ mod mega_kangaskhan_double_punching_family_test;
 mod mega_medicham_ex_test;
 #[path = "pokemon/mega_metagross_ex_gatling_slug_test.rs"]
 mod mega_metagross_ex_gatling_slug_test;
+#[path = "pokemon/mega_pidgeot_ex_giant_twister_test.rs"]
+mod mega_pidgeot_ex_giant_twister_test;
 #[path = "pokemon/mega_rayquaza_ex_mega_burst_test.rs"]
 mod mega_rayquaza_ex_mega_burst_test;
 #[path = "pokemon/mega_sceptile_terminating_tail_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -166,6 +166,8 @@ mod morpeko_test;
 mod ninetales_ember_dance_test;
 #[path = "pokemon/passimian_ex_offload_pass_test.rs"]
 mod passimian_ex_offload_pass_test;
+#[path = "pokemon/politoed_raid_test.rs"]
+mod politoed_raid_test;
 #[path = "pokemon/porygonz_buggy_beam_test.rs"]
 mod porygonz_buggy_beam_test;
 #[path = "pokemon/porygonz_cyberjack_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -40,6 +40,8 @@ mod celebi_time_recall_test;
 mod chansey_blissey_test;
 #[path = "pokemon/charmeleon_ignition_test.rs"]
 mod charmeleon_ignition_test;
+#[path = "pokemon/coalossal_coal_drop_test.rs"]
+mod coalossal_coal_drop_test;
 #[path = "pokemon/comfey_flower_shield_test.rs"]
 mod comfey_flower_shield_test;
 #[path = "pokemon/corviknight_line_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -134,6 +134,8 @@ mod lunala_ex_test;
 mod magneton_test;
 #[path = "pokemon/magnezone_mirror_shot_test.rs"]
 mod magnezone_mirror_shot_test;
+#[path = "pokemon/magnezone_resilience_link_test.rs"]
+mod magnezone_resilience_link_test;
 #[path = "pokemon/marshadow_revenge_test.rs"]
 mod marshadow_revenge_test;
 #[path = "pokemon/mega_camerupt_ex_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -168,6 +168,8 @@ mod morpeko_test;
 mod ninetales_ember_dance_test;
 #[path = "pokemon/passimian_ex_offload_pass_test.rs"]
 mod passimian_ex_offload_pass_test;
+#[path = "pokemon/pidgeot_twister_test.rs"]
+mod pidgeot_twister_test;
 #[path = "pokemon/politoed_raid_test.rs"]
 mod politoed_raid_test;
 #[path = "pokemon/porygonz_buggy_beam_test.rs"]

--- a/tests/pokemon/coalossal_coal_drop_test.rs
+++ b/tests/pokemon/coalossal_coal_drop_test.rs
@@ -1,0 +1,76 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+/// Coalossal's Coal Drop deals 100 damage, or 100 + 50 = 150 damage when the
+/// opponent's Active Pokémon is a [G] Pokémon.
+#[test]
+fn test_coal_drop_extra_damage_against_grass_defender() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Venusaur ex is a [G] Pokémon with 190 HP, weak to Fire (so no weakness bonus
+    // against Coalossal, a [F] Pokémon).
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B1147Coalossal).with_energy(vec![
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1147Coalossal, 0),
+        is_stack: false,
+    });
+
+    // Venusaur ex 190 HP - 150 (100 base + 50 [G] bonus) = 40.
+    let hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        hp, 40,
+        "Coal Drop should deal 150 damage to a [G] Active Pokémon"
+    );
+}
+
+/// Against a non-[G] defender, Coal Drop deals only its base 100 damage.
+#[test]
+fn test_coal_drop_base_damage_against_non_grass_defender() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Dusknoir is a [P] Pokémon with 150 HP, weak to Darkness.
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B1147Coalossal).with_energy(vec![
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::B1105Dusknoir)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1147Coalossal, 0),
+        is_stack: false,
+    });
+
+    // Dusknoir 150 HP - 100 (base damage only) = 50.
+    let hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        hp, 50,
+        "Coal Drop should deal only base 100 damage to a non-[G] Active Pokémon"
+    );
+}

--- a/tests/pokemon/coalossal_mountain_crush_test.rs
+++ b/tests/pokemon/coalossal_mountain_crush_test.rs
@@ -1,0 +1,71 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Runs Mountain Crush once with the given seed and returns
+/// `(damage dealt, cards milled from the opponent's deck)`.
+fn run_mountain_crush(seed: u64) -> (u32, usize) {
+    let mut game = get_initialized_game_with_board(
+        seed,
+        0,
+        3,
+        vec![
+            PlayedCard::from_id(CardId::B3094Coalossal).with_energy(vec![
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+                EnergyType::Colorless,
+            ]),
+        ],
+        // Dusknoir has 150 HP and is weak to Darkness, so the 90 damage neither
+        // knocks it out nor gets a weakness bonus from a [F] attacker.
+        vec![PlayedCard::from_id(CardId::B1105Dusknoir)],
+    );
+
+    let before = game.get_state_clone();
+    let deck_before = before.decks[1].cards.len();
+    let discard_before = before.discard_piles[1].len();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3094Coalossal, 0),
+        is_stack: false,
+    });
+
+    let after = game.get_state_clone();
+    let milled = deck_before - after.decks[1].cards.len();
+    assert_eq!(
+        after.discard_piles[1].len() - discard_before,
+        milled,
+        "every card milled off the top of the deck should land in the discard pile"
+    );
+
+    (150 - after.get_active(1).get_remaining_hp(), milled)
+}
+
+/// Mountain Crush always deals its 90 damage, and mills the opponent's deck for
+/// each heads of a flip-until-tails sequence (so sometimes 0 cards).
+#[test]
+fn test_mountain_crush_mills_opponent_deck_for_each_heads() {
+    let mut saw_no_mill = false;
+    let mut saw_mill = false;
+
+    for seed in 0..20 {
+        let (damage, milled) = run_mountain_crush(seed);
+        assert_eq!(damage, 90, "Mountain Crush should always deal 90 damage");
+        assert!(milled <= 8, "flip-until-tails is truncated at 8 heads");
+        if milled == 0 {
+            saw_no_mill = true;
+        } else {
+            saw_mill = true;
+        }
+    }
+
+    assert!(
+        saw_no_mill,
+        "an immediate tails should sometimes mill nothing"
+    );
+    assert!(saw_mill, "heads should sometimes mill at least one card");
+}

--- a/tests/pokemon/jellicent_bouncy_body_test.rs
+++ b/tests/pokemon/jellicent_bouncy_body_test.rs
@@ -1,0 +1,112 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Bouncy Body: when the Active Jellicent is damaged by an opponent's attack, its owner
+/// takes a [W] Energy from their Energy Zone and attaches it to a Benched Pokémon of
+/// their choice.
+#[test]
+fn test_bouncy_body_attaches_water_energy_to_chosen_bench() {
+    let mut game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B1105Dusknoir)
+            .with_energy(vec![EnergyType::Psychic, EnergyType::Colorless])],
+        vec![
+            PlayedCard::from_id(CardId::B1069Jellicent),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1105Dusknoir, 0),
+        is_stack: false,
+    });
+
+    // Jellicent's owner now chooses which Benched Pokémon receives the Energy.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 1, "Jellicent's owner makes the Bouncy Body choice");
+    assert_eq!(
+        choices.len(),
+        2,
+        "Bouncy Body should offer one choice per Benched Pokémon"
+    );
+    assert!(
+        choices
+            .iter()
+            .all(|choice| matches!(choice.action, SimpleAction::Attach { .. })),
+        "Bouncy Body choices should all be Energy attachments"
+    );
+
+    let charmander_choice = choices
+        .iter()
+        .find(|choice| {
+            matches!(
+                &choice.action,
+                SimpleAction::Attach { attachments, .. }
+                    if attachments == &vec![(1, EnergyType::Water, 2)]
+            )
+        })
+        .expect("Charmander on the bench should be a Bouncy Body target")
+        .clone();
+    game.apply_action(&charmander_choice);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.in_play_pokemon[1][2]
+            .as_ref()
+            .expect("Charmander should still be benched")
+            .attached_energy,
+        vec![EnergyType::Water],
+        "the chosen Benched Pokémon should get a [W] Energy"
+    );
+    assert!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("Bulbasaur should still be benched")
+            .attached_energy
+            .is_empty(),
+        "only the chosen Benched Pokémon should get Energy"
+    );
+    assert!(
+        state.get_active(1).attached_energy.is_empty(),
+        "Bouncy Body attaches to the Bench, never to Jellicent itself"
+    );
+}
+
+/// With no Benched Pokémon there is nowhere to put the Energy, so no choice is offered.
+#[test]
+fn test_bouncy_body_does_nothing_without_a_bench() {
+    let mut game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B1105Dusknoir)
+            .with_energy(vec![EnergyType::Psychic, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::B1069Jellicent)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1105Dusknoir, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // Jellicent has 120 HP and is weak to Lightning, so Hammer In's 80 damage leaves 40.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 40);
+    let (actor, choices) = state.generate_possible_actions();
+    assert_eq!(
+        actor, 0,
+        "no Bouncy Body choice should be queued for Jellicent's owner"
+    );
+    assert!(choices
+        .iter()
+        .all(|choice| !matches!(choice.action, SimpleAction::Attach { .. })));
+}

--- a/tests/pokemon/magnezone_resilience_link_test.rs
+++ b/tests/pokemon/magnezone_resilience_link_test.rs
@@ -1,0 +1,53 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Attacks Magnezone (A2a 055) with Dusknoir's 80-damage Hammer In and returns Magnezone's
+/// remaining HP. Magnezone is weak to Fire, so a [P] attacker gets no weakness bonus.
+fn hammer_in_magnezone(bench: Vec<PlayedCard>) -> u32 {
+    let mut defender_board = vec![PlayedCard::from_id(CardId::A2a055Magnezone)];
+    defender_board.extend(bench);
+
+    let mut game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B1105Dusknoir)
+            .with_energy(vec![EnergyType::Psychic, EnergyType::Colorless])],
+        defender_board,
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1105Dusknoir, 0),
+        is_stack: false,
+    });
+
+    game.get_state_clone().get_active(1).get_remaining_hp()
+}
+
+/// Resilience Link only reduces damage while its owner has Arceus (or Arceus ex) in play.
+#[test]
+fn test_resilience_link_reduces_damage_with_arceus_in_play() {
+    let hp = hammer_in_magnezone(vec![PlayedCard::from_id(CardId::A2a070Arceus)]);
+
+    // Magnezone 140 HP - (80 - 30) = 90.
+    assert_eq!(
+        hp, 90,
+        "Resilience Link should reduce the attack by 30 while Arceus is in play"
+    );
+}
+
+#[test]
+fn test_resilience_link_does_nothing_without_arceus_in_play() {
+    let hp = hammer_in_magnezone(vec![PlayedCard::from_id(CardId::A1001Bulbasaur)]);
+
+    // Magnezone 140 HP - 80 = 60.
+    assert_eq!(
+        hp, 60,
+        "Resilience Link should not reduce damage without Arceus in play"
+    );
+}

--- a/tests/pokemon/mega_pidgeot_ex_giant_twister_test.rs
+++ b/tests/pokemon/mega_pidgeot_ex_giant_twister_test.rs
@@ -1,0 +1,75 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Runs Giant Twister once with the given seed and returns
+/// `(damage dealt, energies discarded from the opponent's Active Pokémon)`.
+fn run_giant_twister(seed: u64) -> (u32, usize) {
+    let mut game = get_initialized_game_with_board(
+        seed,
+        0,
+        3,
+        vec![
+            PlayedCard::from_id(CardId::PB006MegaPidgeotEx).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        // Wailord ex has 250 HP and is weak to Lightning, so the 100 damage neither
+        // knocks it out nor gets a weakness bonus from a [C] attacker.
+        vec![
+            PlayedCard::from_id(CardId::B4037WailordEx).with_energy(vec![
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Water,
+            ]),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::PB006MegaPidgeotEx, 0),
+        is_stack: false,
+    });
+
+    let after = game.get_state_clone();
+    let defender = after.get_active(1);
+    (
+        250 - defender.get_remaining_hp(),
+        4 - defender.attached_energy.len(),
+    )
+}
+
+/// Giant Twister discards 1 Energy per heads of 3 coins, and does nothing at all
+/// (no damage, no discard) when all three coins are tails.
+#[test]
+fn test_giant_twister_discards_one_energy_per_heads_and_whiffs_on_all_tails() {
+    let mut saw_whiff = false;
+    let mut saw_hit = false;
+
+    for seed in 0..20 {
+        let (damage, discarded) = run_giant_twister(seed);
+        if discarded == 0 {
+            assert_eq!(
+                damage, 0,
+                "with all three coins tails Giant Twister should do nothing at all"
+            );
+            saw_whiff = true;
+        } else {
+            assert!(discarded <= 3, "Giant Twister only flips 3 coins");
+            assert_eq!(
+                damage, 100,
+                "Giant Twister should deal 100 damage on any heads"
+            );
+            saw_hit = true;
+        }
+    }
+
+    assert!(saw_whiff, "all three coins should sometimes come up tails");
+    assert!(saw_hit, "at least one heads should sometimes come up");
+}

--- a/tests/pokemon/pidgeot_twister_test.rs
+++ b/tests/pokemon/pidgeot_twister_test.rs
@@ -1,0 +1,64 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+};
+
+/// Runs Twister once with the given seed and returns
+/// `(damage dealt, energies discarded from the opponent's Active Pokémon)`.
+fn run_twister(seed: u64) -> (u32, usize) {
+    let mut game = get_initialized_game_with_board(
+        seed,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B1182Pidgeot)
+            .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+        // Dusknoir has 150 HP and is weak to Darkness, so the 80 damage neither knocks
+        // it out nor gets a weakness bonus from a [C] attacker.
+        vec![PlayedCard::from_id(CardId::B1105Dusknoir).with_energy(vec![
+            EnergyType::Psychic,
+            EnergyType::Psychic,
+            EnergyType::Psychic,
+        ])],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1182Pidgeot, 0),
+        is_stack: false,
+    });
+
+    let after = game.get_state_clone();
+    let defender = after.get_active(1);
+    (
+        150 - defender.get_remaining_hp(),
+        3 - defender.attached_energy.len(),
+    )
+}
+
+/// Twister discards 1 Energy per heads of 2 coins, and does nothing at all
+/// (no damage, no discard) when both coins are tails.
+#[test]
+fn test_twister_discards_one_energy_per_heads_and_whiffs_on_all_tails() {
+    let mut saw_whiff = false;
+    let mut saw_hit = false;
+
+    for seed in 0..20 {
+        let (damage, discarded) = run_twister(seed);
+        if discarded == 0 {
+            assert_eq!(
+                damage, 0,
+                "with both coins tails Twister should do nothing at all"
+            );
+            saw_whiff = true;
+        } else {
+            assert!(discarded <= 2, "Twister only flips 2 coins");
+            assert_eq!(damage, 80, "Twister should deal 80 damage on any heads");
+            saw_hit = true;
+        }
+    }
+
+    assert!(saw_whiff, "both coins should sometimes come up tails");
+    assert!(saw_hit, "at least one heads should sometimes come up");
+}

--- a/tests/pokemon/politoed_raid_test.rs
+++ b/tests/pokemon/politoed_raid_test.rs
@@ -1,0 +1,75 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+/// Politoed's Raid deals 50 damage, or 50 + 50 = 100 damage when Politoed evolved
+/// from Poliwhirl during this turn.
+#[test]
+fn test_raid_extra_damage_when_evolved_from_poliwhirl_this_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    // Snorlax has 150 HP and is weak to Fighting, so a [W] attack gets no weakness bonus.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3034Poliwhirl).with_energy(vec![EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.current_player = 0;
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::B3035Politoed));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Evolve {
+            evolution: get_card_by_enum(CardId::B3035Politoed),
+            in_play_idx: 0,
+            from_deck: false,
+        },
+        is_stack: false,
+    });
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3035Politoed, 0),
+        is_stack: false,
+    });
+
+    // Snorlax 150 HP - 100 (50 base + 50 evolution bonus) = 50.
+    let hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        hp, 50,
+        "Raid should deal 100 damage the turn Politoed evolves from Poliwhirl"
+    );
+}
+
+/// A Politoed that has been in play since a previous turn deals only base damage.
+#[test]
+fn test_raid_base_damage_when_not_evolved_this_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3035Politoed).with_energy(vec![EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3035Politoed, 0),
+        is_stack: false,
+    });
+
+    // Snorlax 150 HP - 50 (base damage only) = 100.
+    let hp = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(
+        hp, 100,
+        "Raid should deal only base 50 damage when Politoed did not evolve this turn"
+    );
+}

--- a/tests/tools.rs
+++ b/tests/tools.rs
@@ -2,6 +2,8 @@
 mod booster_capsule_test;
 #[path = "tools/deceptive_needle_test.rs"]
 mod deceptive_needle_test;
+#[path = "tools/leftovers_test.rs"]
+mod leftovers_test;
 #[path = "tools/lucky_egg_test.rs"]
 mod lucky_egg_test;
 #[path = "tools/lucky_ice_pop_test.rs"]

--- a/tests/tools/leftovers_test.rs
+++ b/tests/tools/leftovers_test.rs
@@ -1,0 +1,77 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::PlayedCard,
+    test_support::get_initialized_game,
+};
+
+fn end_turn(game: &mut deckgym::Game<'static>, actor: usize) {
+    game.apply_action(&Action {
+        actor,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+}
+
+#[test]
+fn test_leftovers_heals_active_holder_at_end_of_its_owners_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_damage(50)
+            .with_tool(get_card_by_enum(CardId::A3b067Leftovers))],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    game.set_state(state);
+
+    // Bulbasaur has 70 HP, so 50 damage leaves 20.
+    assert_eq!(game.get_state_clone().get_remaining_hp(0, 0), 20);
+
+    end_turn(&mut game, 0);
+
+    assert_eq!(
+        game.get_state_clone().get_remaining_hp(0, 0),
+        30,
+        "Leftovers should heal 10 from its Active holder at the end of its owner's turn"
+    );
+}
+
+#[test]
+fn test_leftovers_does_nothing_from_the_bench_or_on_the_opponents_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1033Charmander),
+            // Holder is benched rather than in the Active Spot.
+            PlayedCard::from_id(CardId::A1001Bulbasaur)
+                .with_damage(50)
+                .with_tool(get_card_by_enum(CardId::A3b067Leftovers)),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    game.set_state(state);
+
+    end_turn(&mut game, 0);
+    assert_eq!(
+        game.get_state_clone().get_remaining_hp(0, 1),
+        20,
+        "A benched holder should not be healed by Leftovers"
+    );
+
+    // Player 1's turn ending must not heal player 0's Pokémon either.
+    end_turn(&mut game, 1);
+    assert_eq!(
+        game.get_state_clone().get_remaining_hp(0, 1),
+        20,
+        "Leftovers should not heal at the end of the opponent's turn"
+    );
+}


### PR DESCRIPTION
Implements the cards requested for the optimizer. One commit per card so they can be reviewed independently.

## Cards

| Commit | Card | Effect | Implementation |
|---|---|---|---|
| `bf00f4e` | Coalossal (B1 147) | *Coal Drop* | Reuses the existing `ExtraDamageIfDefenderType` mechanic with Grass/50 — map entry only |
| `cecf080` | Politoed (B3 035) | *Raid* | New `ExtraDamageIfEvolvedFromThisTurn` mechanic |
| `3e5b5ca` | Coalossal (B3 094) | *Mountain Crush* | New `FlipUntilTailsDiscardOpponentDeck` mechanic on `geometric_until_tails` |
| `6b1627e` | Pidgeot (B1 182) | *Twister* | New `CoinFlipsDiscardEnergyFromOpponentActiveOrNothing` mechanic (2 coins) |
| `fd7d4e4` | Mega Pidgeot ex (P-B 006) | *Giant Twister* | Same mechanic with 3 coins — map entry only |
| `e7a1ce2` | Magnezone (A2a 055) | *Resilience Link* | New `ReduceDamageFromAttacksIfArceusInPlay` ability mechanic |
| `c94d92c` | Jellicent (B1 069, B1 234, B3 210) | *Bouncy Body* | New `AttachEnergyFromZoneToBenchedOnDamaged` ability mechanic |
| `48c79ac` | Leftovers (A3b 067) | Tool | End-of-turn healing wired into the `on_end_turn` hook |

Plus `79e636b`, which bumps the implemented-cards badge to 3340 / 3761 (88.8%).

## Notes for review

**Politoed's Raid is stricter than "evolved this turn."** The card reads *"If this Pokémon evolved **from Poliwhirl** during this turn"*, so `ExtraDamageIfEvolvedFromThisTurn` also checks the card directly underneath the active. A Politoed brought out with Rare Candy (skipping Poliwhirl) therefore gets no bonus. This is a judgement call about the card wording and worth confirming against the real game's ruling — the looser existing `ExtraDamageIfEvolvedThisTurn` would grant it.

**Twister / Giant Twister do nothing at all on all tails.** The "this attack does nothing" clause is modelled as a no-op outcome, so on all tails the attack deals no damage either, not just no discard.

**Magnezone's Resilience Link is not a derived `CardEffect`.** Unlike the other damage-reduction abilities it depends on the rest of the board (Arceus in play), so it can't be derived from the card alone and is resolved in `hooks::modify_damage`. The Arceus-in-play lookup is now shared with the existing `IncreaseDamageIfArceusInPlay`.

**Jellicent's Bouncy Body is queued before knockouts resolve**, so the bench choice is offered while the bench is still intact — promotions are inserted at the bottom of the stack and resolve afterwards.

## Refactors folded in

Three helpers were extracted so new mechanics could share existing logic rather than duplicate it:

- the deck-milling loop, now shared by `DamageAndDiscardOpponentDeck` and `FlipUntilTailsDiscardOpponentDeck`
- the random-energy-discard loop, now shared by `DiscardEnergyFromOpponentActive` and the Twister mechanic
- the Arceus-in-play board lookup, now shared by both Arceus-conditional ability mechanics

## Testing

Each card got Game-level integration tests written before the implementation, all failing beforehand. Every commit was verified with `cargo run --bin card_test` for that card's id (10,000 simulated games against every deck in `example_decks/`), `cargo fmt`, `cargo clippy --all-targets --all-features -- -D warnings`, and the full `cargo test --features "tui test-utils"` suite.

Coin-flip attacks (Mountain Crush, Twister, Giant Twister) are tested across a range of seeds, asserting the invariants that hold per branch and that both the whiff and hit branches are actually reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AbN8JpR3geWsxepB8iNzA6