### PR TITLE
Implement Rhyperior's Mountain Swing attack (A2 082, A2 169)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -853,7 +853,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfDefenderAsleep { extra_damage } => {
             extra_damage_if_defender_asleep(state, attack.fixed_damage, *extra_damage)
         }
-        Mechanic::DiscardTopSelfDeck => discard_top_self_deck(attack.fixed_damage),
+        Mechanic::DiscardTopSelfDeck { count } => {
+            discard_top_self_deck(attack.fixed_damage, *count)
+        }
         Mechanic::TieredCoinFlipDamage {
             num_coins,
             extra_damage_by_heads,
@@ -1938,10 +1940,12 @@ fn discard_opponent_active_tools_before_damage(damage: u32) -> AttackOutcomes {
     ))
 }
 
-fn discard_top_self_deck(damage: u32) -> AttackOutcomes {
-    active_damage_effect_doutcome(damage, |_, state, action| {
-        if let Some(card) = state.decks[action.actor].draw() {
-            state.discard_piles[action.actor].push(card);
+fn discard_top_self_deck(damage: u32, count: usize) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        for _ in 0..count {
+            if let Some(card) = state.decks[action.actor].draw() {
+                state.discard_piles[action.actor].push(card);
+            }
         }
     })
 }

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -524,7 +524,9 @@ pub enum Mechanic {
         extra_damage: u32,
     },
     /// Discard the top card of the attacker's own deck after dealing damage.
-    DiscardTopSelfDeck,
+    DiscardTopSelfDeck {
+        count: usize,
+    },
     /// Tiered coin flip damage: flip `num_coins` coins and deal fixed_damage +
     /// extra_damage_by_heads[heads_count] total damage.
     TieredCoinFlipDamage {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -208,7 +208,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             energy_type: EnergyType::Fire,
         },
     );
-    // map.insert("Discard the top 3 cards of your deck.", todo_implementation);
+    map.insert(
+        "Discard the top 3 cards of your deck.",
+        Mechanic::DiscardTopSelfDeck { count: 3 },
+    );
     map.insert(
         "Discard the top 3 cards of your opponent's deck.",
         Mechanic::DamageAndDiscardOpponentDeck { discard_count: 3 },
@@ -923,49 +926,49 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::DamagePerOwnToolAttached { damage_per: 40 },
     );
     // map.insert("If this Pokémon has any [W] Energy attached, this attack does 40 more damage.", todo_implementation);
-    map.insert("If this Pokémon has at least 1 extra [W] Energy attached, this attack does 40 more damage.", 
+    map.insert("If this Pokémon has at least 1 extra [W] Energy attached, this attack does 40 more damage.",
         Mechanic::ExtraDamageIfExtraEnergy {
             required_extra_energy: vec![EnergyType::Water],
             extra_damage: 40,
         },
     );
-    map.insert("If this Pokémon has at least 2 extra [F] Energy attached, this attack does 50 more damage.", 
+    map.insert("If this Pokémon has at least 2 extra [F] Energy attached, this attack does 50 more damage.",
         Mechanic::ExtraDamageIfExtraEnergy {
             required_extra_energy: vec![EnergyType::Fighting, EnergyType::Fighting],
             extra_damage: 50,
         },
     );
-    map.insert("If this Pokémon has at least 2 extra [F] Energy attached, this attack does 60 more damage.", 
+    map.insert("If this Pokémon has at least 2 extra [F] Energy attached, this attack does 60 more damage.",
         Mechanic::ExtraDamageIfExtraEnergy {
             required_extra_energy: vec![EnergyType::Fighting, EnergyType::Fighting],
             extra_damage: 60,
         },
     );
-    map.insert("If this Pokémon has at least 2 extra [L] Energy attached, this attack does 80 more damage.", 
+    map.insert("If this Pokémon has at least 2 extra [L] Energy attached, this attack does 80 more damage.",
         Mechanic::ExtraDamageIfExtraEnergy {
             required_extra_energy: vec![EnergyType::Lightning, EnergyType::Lightning],
             extra_damage: 80,
         },
     );
-    map.insert("If this Pokémon has at least 2 extra [R] Energy attached, this attack does 60 more damage.", 
+    map.insert("If this Pokémon has at least 2 extra [R] Energy attached, this attack does 60 more damage.",
         Mechanic::ExtraDamageIfExtraEnergy {
             required_extra_energy: vec![EnergyType::Fire, EnergyType::Fire],
             extra_damage: 60,
         },
     );
-    map.insert("If this Pokémon has at least 2 extra [W] Energy attached, this attack does 60 more damage.", 
+    map.insert("If this Pokémon has at least 2 extra [W] Energy attached, this attack does 60 more damage.",
         Mechanic::ExtraDamageIfExtraEnergy {
             required_extra_energy: vec![EnergyType::Water, EnergyType::Water],
             extra_damage: 60,
         },
     );
-    map.insert("If this Pokémon has at least 3 extra [G] Energy attached, this attack does 70 more damage.", 
+    map.insert("If this Pokémon has at least 3 extra [G] Energy attached, this attack does 70 more damage.",
         Mechanic::ExtraDamageIfExtraEnergy {
             required_extra_energy: vec![EnergyType::Grass, EnergyType::Grass, EnergyType::Grass],
             extra_damage: 70,
         },
     );
-    map.insert("If this Pokémon has at least 3 extra [W] Energy attached, this attack does 70 more damage.", 
+    map.insert("If this Pokémon has at least 3 extra [W] Energy attached, this attack does 70 more damage.",
         Mechanic::ExtraDamageIfExtraEnergy {
             required_extra_energy: vec![EnergyType::Water, EnergyType::Water, EnergyType::Water],
             extra_damage: 70,
@@ -1425,7 +1428,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             must_have_energy: false,
         },
     );
-    map.insert("This attack also does 20 damage to each of your opponent's Benched Pokémon that has any Energy attached.", 
+    map.insert("This attack also does 20 damage to each of your opponent's Benched Pokémon that has any Energy attached.",
         Mechanic::AlsoBenchDamage {
             opponent: true,
             damage: 20,
@@ -1557,7 +1560,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per_energy: 20,
         },
     );
-    map.insert("This attack does 20 more damage for each Energy attached to your opponent's Active Pokémon.", 
+    map.insert("This attack does 20 more damage for each Energy attached to your opponent's Active Pokémon.",
         Mechanic::ExtraDamagePerEnergy {
             include_fixed_damage: true,
             opponent: true,
@@ -2183,7 +2186,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("Discard a [W] Energy from this Pokémon, and this attack also does 40 damage to 1 of your opponent's Benched Pokémon.", todo_implementation);
     map.insert(
         "Discard the top card of your deck.",
-        Mechanic::DiscardTopSelfDeck,
+        Mechanic::DiscardTopSelfDeck { count: 1 },
     );
     // map.insert("During your next turn, attacks used by your [F] Pokémon do +30 damage to your opponent's Active Pokémon.", todo_implementation);
     // map.insert("During your next turn, this Pokémon's Psych Up attack does +30 damage.", todo_implementation);

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -190,6 +190,8 @@ mod psyduck_test;
 mod raichu_evoshock_test;
 #[path = "pokemon/rampardos_head_smash_test.rs"]
 mod rampardos_head_smash_test;
+#[path = "pokemon/rhyperior_test.rs"]
+mod rhyperior_test;
 #[path = "pokemon/roaring_moon_test.rs"]
 mod roaring_moon_test;
 #[path = "pokemon/rotom_ex_junk_spark_test.rs"]

--- a/tests/pokemon/rhyperior_test.rs
+++ b/tests/pokemon/rhyperior_test.rs
@@ -1,0 +1,60 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_mountain_swing_discard_three_cards_own_deck() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A2082Rhyperior).with_energy(vec![
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1003Venusaur)],
+    );
+
+    let top_card = get_card_by_enum(CardId::A1283Mew);
+    for _ in 0..3 {
+        state.decks[0].cards.insert(0, top_card.clone());
+    }
+    let own_deck_size_before = state.decks[0].cards.len();
+    let expected_discard_size = 3;
+    let venusaur_initial_health_points = 160;
+    let expected_damage_dealt = 150;
+
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A2082Rhyperior, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+
+    // Mountain Swing: 150 damage delt
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        venusaur_initial_health_points - expected_damage_dealt
+    );
+
+    // Own deck lenght became 0
+    assert_eq!(
+        state.decks[0].cards.len(),
+        own_deck_size_before - expected_discard_size
+    );
+    assert!(state.discard_piles[0].contains(&top_card));
+    assert!(state.discard_piles[0].len() == expected_discard_size);
+}


### PR DESCRIPTION
## What
Implements **Mountain Swing** for Rhyperior (A2 082 and A2 169):
- **150 damage** to the opponent's Active Pokémon
- **Discard the top 3 cards of your deck**

## How
- Parametrized `Mechanic::DiscardTopSelfDeck` with a `count` field (`src/actions/attacks/mechanic.rs`)
- Updated the match arm and the `discard_top_self_deck` helper to discard `count` cards in a loop (`src/actions/apply_attack_action.rs`)
- Wired the "Discard the top 3 cards of your deck." effect text to the mechanic, preserving the existing `count: 1` entry for the other card using this mechanic (`src/actions/effect_mechanic_map.rs`)

## Tests
- Added `tests/pokemon/rhyperior_test.rs` (TDD, written before the implementation) verifying damage and the top-3 discard
- `cargo test --features test-utils --test pokemon`: 327 passed
- `cargo clippy` and `cargo fmt`: clean
- `cargo run --bin card_test -- "A2 082"`: simulations complete without errors