### PR TITLE
Implement Zarude's Dark Vengeance attack (B3 114, P-B 060)

### DIFF
--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -294,6 +294,8 @@ fn apply_pokemon_checkup(
     mutated_state.knocked_out_by_opponent_attack_last_turn =
         mutated_state.knocked_out_by_opponent_attack_this_turn;
     mutated_state.knocked_out_by_opponent_attack_this_turn = false;
+    mutated_state.knocked_out_types_last_turn =
+        std::mem::take(&mut mutated_state.knocked_out_types_this_turn);
 }
 
 fn finish_turn_after_checkup(state: &mut State, rng: &mut StdRng) {
@@ -652,21 +654,16 @@ pub(crate) fn handle_knockouts(
             }
         }
 
-        state.discard_from_play(ko_receiver, ko_pokemon_idx);
-    }
-
-    // Set knocked_out_by_opponent_attack_this_turn flag
-    // Check if any of the current player's Pokémon were knocked out by an opponent's active attack
-    if is_from_active_attack {
-        // Only care about KOs from active attacks
-        for (ko_receiver, _) in knockouts.clone() {
-            let ko_initiator_of_this_damage = attacking_ref.0; // The player who caused the damage
-                                                               // If the receiver is NOT the initiator, it's an opponent KO
-            if ko_receiver != ko_initiator_of_this_damage {
-                state.knocked_out_by_opponent_attack_this_turn = true;
-                break; // Only need to set once
-            }
+        // Record KOs dealt by an opponent's active attack (for revenge attacks such as
+        // Marshadow's Revenge and Zarude's Dark Vengeance), along with the KO'd Pokemon's type.
+        if is_from_active_attack && ko_receiver != attacking_ref.0 {
+            let ko_pokemon_type = state.in_play_pokemon[ko_receiver][ko_pokemon_idx]
+                .as_ref()
+                .and_then(|pokemon| pokemon.get_energy_type());
+            state.record_knocked_out_by_opponent_attack(ko_pokemon_type);
         }
+
+        state.discard_from_play(ko_receiver, ko_pokemon_idx);
     }
 
     // If game ends because of knockouts, set winner and return so as to short-circuit promotion logic

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -625,9 +625,15 @@ fn forecast_effect_attack_by_mechanic(
             *damage_per_hit,
             *include_own_bench,
         ),
-        Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage } => {
-            extra_damage_if_knocked_out_last_turn_attack(state, attack.fixed_damage, *extra_damage)
-        }
+        Mechanic::ExtraDamageIfKnockedOutLastTurn {
+            energy_type,
+            extra_damage,
+        } => extra_damage_if_knocked_out_last_turn_attack(
+            state,
+            attack.fixed_damage,
+            *energy_type,
+            *extra_damage,
+        ),
         Mechanic::ExtraDamageIfAttackUsedDuringOwnLastTurn {
             attack_name,
             extra_damage,
@@ -2918,9 +2924,10 @@ fn damage_per_own_tool_attached(state: &State, damage_per: u32) -> AttackOutcome
 fn extra_damage_if_knocked_out_last_turn_attack(
     state: &State,
     base_damage: u32,
+    energy_type: Option<EnergyType>,
     extra_damage: u32,
 ) -> AttackOutcomes {
-    let damage = if state.knocked_out_by_opponent_attack_last_turn {
+    let damage = if state.was_knocked_out_by_opponent_attack_last_turn(energy_type) {
         base_damage + extra_damage
     } else {
         base_damage

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -350,7 +350,11 @@ pub enum Mechanic {
     },
     DamageEqualToSelfDamage,
     ExtraDamageEqualToSelfDamage,
+    /// Marshadow's Revenge and friends: extra damage if any of your Pokemon were Knocked Out by
+    /// an attack during the opponent's last turn. `energy_type` restricts which of your Pokemon
+    /// count (e.g. Zarude's Dark Vengeance only counts `[D]` Pokemon); `None` counts any.
     ExtraDamageIfKnockedOutLastTurn {
+        energy_type: Option<EnergyType>,
         extra_damage: u32,
     },
     ExtraDamageIfAttackUsedDuringOwnLastTurn {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -885,9 +885,9 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     // map.insert("If any of your Benched Pokémon have damage on them, this attack does 50 more damage.", todo_implementation);
-    map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 60 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage: 60 });
-    map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 40 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage: 40 });
-    map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 50 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { extra_damage: 50 });
+    map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 60 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { energy_type: None, extra_damage: 60 });
+    map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 40 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { energy_type: None, extra_damage: 40 });
+    map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 50 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { energy_type: None, extra_damage: 50 });
     map.insert("If the Defending Pokémon is a Basic Pokémon, it can't attack during your opponent's next turn.", Mechanic::BlockBasicAttack);
     // map.insert("If the Defending Pokémon tries to use an attack, your opponent flips a coin. If tails, that attack doesn't happen. This effect lasts until the Defending Pokémon leaves the Active Spot, and it doesn't stack.", todo_implementation);
     map.insert(
@@ -2287,7 +2287,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     // map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 60 more damage, and your opponent's Active Pokémon is now Paralyzed.", todo_implementation);
-    // map.insert("If any of your [D] Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 80 more damage.", todo_implementation);
+    map.insert("If any of your [D] Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 80 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { energy_type: Some(EnergyType::Darkness), extra_damage: 80 });
     map.insert(
         "If this Pokémon evolved from Poliwhirl during this turn, this attack does 50 more damage.",
         Mechanic::ExtraDamageIfEvolvedFromThisTurn {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -5,7 +5,7 @@ use log::{debug, trace};
 use rand::rngs::StdRng;
 use rand::{seq::SliceRandom, Rng};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::hash::Hash;
 
 use crate::{
@@ -69,6 +69,11 @@ pub struct State {
     pub has_used_stadium: [bool; 2], // Tracks if each player has used the stadium this turn
     pub(crate) knocked_out_by_opponent_attack_this_turn: bool,
     pub(crate) knocked_out_by_opponent_attack_last_turn: bool,
+    // Energy types of the Pokemon Knocked Out by an opponent's attack during that turn (e.g. for
+    // Zarude's "Dark Vengeance", which only counts [D] Pokemon). A Knocked Out Fossil has no
+    // energy type, so these can be empty while the flags above are true.
+    pub(crate) knocked_out_types_this_turn: BTreeSet<EnergyType>,
+    pub(crate) knocked_out_types_last_turn: BTreeSet<EnergyType>,
     // Name of the attack (if any) each player used during their current/previous own turn
     // (e.g. for Vanilluxe's "Sweets Relay": "If 1 of your Pokémon used Sweets Relay during
     // your last turn, this attack does more damage.").
@@ -105,6 +110,8 @@ impl State {
 
             knocked_out_by_opponent_attack_this_turn: false,
             knocked_out_by_opponent_attack_last_turn: false,
+            knocked_out_types_this_turn: BTreeSet::new(),
+            knocked_out_types_last_turn: BTreeSet::new(),
             attack_name_used_this_turn: [None, None],
             attack_name_used_last_turn: [None, None],
             attack_name_used_count: [BTreeMap::new(), BTreeMap::new()],
@@ -616,14 +623,41 @@ impl State {
     }
 
     /// Set the flag indicating a Pokemon was KO'd by opponent's attack last turn.
-    /// Used for testing Marshadow's Revenge attack and similar mechanics.
+    /// Used for testing Marshadow's Revenge attack and similar mechanics. The KO'd Pokemon's
+    /// energy type is left unknown, so type-restricted mechanics (e.g. Zarude's Dark Vengeance)
+    /// won't consider it; test those by playing out an actual KO.
     pub fn set_knocked_out_by_opponent_attack_last_turn(&mut self, value: bool) {
         self.knocked_out_by_opponent_attack_last_turn = value;
+        if !value {
+            self.knocked_out_types_last_turn.clear();
+        }
     }
 
     /// Get the flag indicating a Pokemon was KO'd by opponent's attack last turn.
     pub fn get_knocked_out_by_opponent_attack_last_turn(&self) -> bool {
         self.knocked_out_by_opponent_attack_last_turn
+    }
+
+    /// Whether one of the current player's Pokemon was KO'd by an opponent's attack last turn.
+    /// `energy_type` optionally restricts the check to KO'd Pokemon of that type.
+    pub(crate) fn was_knocked_out_by_opponent_attack_last_turn(
+        &self,
+        energy_type: Option<EnergyType>,
+    ) -> bool {
+        match energy_type {
+            Some(energy_type) => self.knocked_out_types_last_turn.contains(&energy_type),
+            None => self.knocked_out_by_opponent_attack_last_turn,
+        }
+    }
+
+    pub(crate) fn record_knocked_out_by_opponent_attack(
+        &mut self,
+        energy_type: Option<EnergyType>,
+    ) {
+        self.knocked_out_by_opponent_attack_this_turn = true;
+        if let Some(energy_type) = energy_type {
+            self.knocked_out_types_this_turn.insert(energy_type);
+        }
     }
 
     pub(crate) fn record_attack_used(&mut self, player: usize, attack_name: String) {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -242,6 +242,8 @@ mod wailord_ex_wondrous_waves_test;
 mod wailord_test;
 #[path = "pokemon/xerneas_geoburst_test.rs"]
 mod xerneas_geoburst_test;
+#[path = "pokemon/zarude_dark_vengeance_test.rs"]
+mod zarude_dark_vengeance_test;
 #[path = "pokemon/zekrom_bolt_strike_test.rs"]
 mod zekrom_bolt_strike_test;
 #[path = "pokemon/zorua_zoroark_ex_test.rs"]

--- a/tests/pokemon/zarude_dark_vengeance_test.rs
+++ b/tests/pokemon/zarude_dark_vengeance_test.rs
@@ -1,0 +1,100 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game, get_test_game_with_board},
+};
+
+/// Plays a full turn cycle in which player 1 Knocks Out player 0's Active `ko_victim` with
+/// Venusaur ex's Razor Leaf (60 damage), player 0 promotes Zarude, and then Zarude uses Dark
+/// Vengeance on the (still undamaged, 190 HP) Venusaur ex. Returns Venusaur ex's remaining HP.
+fn venusaur_hp_after_zarude_revenge(ko_victim: CardId) -> u32 {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![
+            PlayedCard::from_id(ko_victim),
+            PlayedCard::from_id(CardId::B3114Zarude)
+                .with_energy(vec![EnergyType::Darkness, EnergyType::Darkness]),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1004VenusaurEx).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+    );
+    state.current_player = 1;
+    state.turn_count = 4;
+    game.set_state(state);
+
+    // Player 1 Knocks Out player 0's Active Pokemon.
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(CardId::A1004VenusaurEx, 0),
+        is_stack: false,
+    });
+
+    // Player 0 promotes Zarude, its only Benched Pokemon.
+    game.play_until_stable();
+    assert_eq!(game.get_state_clone().get_active(0).get_name(), "Zarude");
+
+    // Player 1 ends the turn, so the Knock Out now counts as "during your opponent's last turn".
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3114Zarude, 0),
+        is_stack: false,
+    });
+
+    game.get_state_clone().get_remaining_hp(1, 0)
+}
+
+/// Without a Knock Out last turn, Dark Vengeance deals its base 40 damage.
+#[test]
+fn test_zarude_dark_vengeance_base_damage() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3114Zarude)
+            .with_energy(vec![EnergyType::Darkness, EnergyType::Darkness])],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3114Zarude, 0),
+        is_stack: false,
+    });
+
+    assert_eq!(
+        game.get_state_clone().get_remaining_hp(1, 0),
+        150,
+        "Dark Vengeance should deal 40 damage without a Knock Out last turn (190 - 40 = 150)"
+    );
+}
+
+/// A Darkness Pokemon Knocked Out during the opponent's last turn adds 80 damage.
+#[test]
+fn test_zarude_dark_vengeance_extra_damage_after_darkness_knockout() {
+    assert_eq!(
+        venusaur_hp_after_zarude_revenge(CardId::A1164Ekans),
+        70,
+        "Dark Vengeance should deal 120 damage after a Darkness Pokemon was Knocked Out (190 - 120 = 70)"
+    );
+}
+
+/// A Knock Out of a non-Darkness Pokemon does not trigger the bonus.
+#[test]
+fn test_zarude_dark_vengeance_ignores_non_darkness_knockout() {
+    assert_eq!(
+        venusaur_hp_after_zarude_revenge(CardId::A1053Squirtle),
+        150,
+        "Dark Vengeance should deal only 40 damage after a non-Darkness Pokemon was Knocked Out"
+    );
+}


### PR DESCRIPTION
Dark Vengeance does 80 more damage if any of your [D] Pokemon were
Knocked Out by damage from an attack during your opponent's last turn.

Generalizes the existing ExtraDamageIfKnockedOutLastTurn mechanic with an
optional energy_type filter (None keeps the untyped behavior used by
Marshadow's Revenge and friends). To answer the typed question, State now
also tracks the energy types of the Pokemon Knocked Out by an opponent's
attack, alongside the existing boolean flag; the two are recorded in the
same place and rotate together at checkup. A Knocked Out Fossil has no
energy type, so the type set can be empty while the flag is true.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01T2QR4dgKoCFHjSdXBrKLf8