### PR TITLE
Implement coin-flip resource-disruption attacks (Persian, Purrloin, Krookodile, Maushold, Tandemaus)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -823,6 +823,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::CoinFlipShuffleRandomOpponentHandCardIntoDeck => {
             coin_flip_shuffle_random_opponent_hand_card_into_deck()
         }
+        Mechanic::CoinFlipDiscardRandomOpponentHandCard => {
+            coin_flip_discard_random_opponent_hand_card(attack.fixed_damage)
+        }
         Mechanic::ExtraDamageIfCombinedActiveEnergyAtLeast {
             threshold,
             extra_damage,
@@ -3218,6 +3221,23 @@ fn coin_flip_shuffle_random_opponent_hand_card_into_deck() -> AttackOutcomes {
         }),
         // Tails: do nothing
         active_damage_outcome(0),
+    )
+}
+
+fn coin_flip_discard_random_opponent_hand_card(damage: u32) -> AttackOutcomes {
+    AttackOutcomes::binary_coin(
+        // Heads: damage + discard a random card from opponent's hand
+        active_damage_effect_outcome(damage, |rng, state, action| {
+            let opponent = (action.actor + 1) % 2;
+            if state.hands[opponent].is_empty() {
+                return;
+            }
+            let idx = rng.gen_range(0..state.hands[opponent].len());
+            let card = state.hands[opponent].remove(idx);
+            state.discard_piles[opponent].push(card);
+        }),
+        // Tails: do nothing
+        active_damage_outcome(damage),
     )
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -328,6 +328,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::CoinFlipsDiscardEnergyFromOpponentActiveOrNothing { num_coins } => {
             coin_flips_discard_energy_or_nothing(attack.fixed_damage, *num_coins)
         }
+        Mechanic::CoinFlipsDiscardEnergyFromOpponentActive { num_coins } => {
+            coin_flips_discard_energy_from_opponent_active(attack.fixed_damage, *num_coins)
+        }
         Mechanic::DiscardOpponentActiveToolsBeforeDamage => {
             discard_opponent_active_tools_before_damage(attack.fixed_damage)
         }
@@ -1898,6 +1901,16 @@ fn coin_flips_discard_energy_or_nothing(damage: u32, num_coins: usize) -> Attack
         if heads == 0 {
             return AttackOutcome::noop();
         }
+        active_damage_effect_outcome(damage, move |rng, state, action| {
+            discard_random_energy_from_opponent_active(rng, state, action.actor, heads);
+        })
+    })
+}
+
+/// Flip `num_coins` coins and discard a random Energy from the opponent's Active Pokémon for
+/// each heads (e.g. Maushold's Triple Gnawing). On all tails the attack does damage.
+fn coin_flips_discard_energy_from_opponent_active(damage: u32, num_coins: usize) -> AttackOutcomes {
+    AttackOutcomes::binomial_by_heads(num_coins, move |heads| {
         active_damage_effect_outcome(damage, move |rng, state, action| {
             discard_random_energy_from_opponent_active(rng, state, action.actor, heads);
         })

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -826,6 +826,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::CoinFlipDiscardRandomOpponentHandCard => {
             coin_flip_discard_random_opponent_hand_card(attack.fixed_damage)
         }
+        Mechanic::CoinFlipsShuffleOpponentHandCards { num_coins } => {
+            coin_flips_shuffle_opponent_hand_cards(attack.fixed_damage, *num_coins)
+        }
         Mechanic::ExtraDamageIfCombinedActiveEnergyAtLeast {
             threshold,
             extra_damage,
@@ -3239,6 +3242,23 @@ fn coin_flip_discard_random_opponent_hand_card(damage: u32) -> AttackOutcomes {
         // Tails: do nothing
         active_damage_outcome(damage),
     )
+}
+
+fn coin_flips_shuffle_opponent_hand_cards(damage: u32, num_coins: usize) -> AttackOutcomes {
+    AttackOutcomes::binomial_by_heads(num_coins, move |heads| {
+        active_damage_effect_outcome(damage, move |rng, state, action| {
+            let opponent = (action.actor + 1) % 2;
+            for _ in 0..heads {
+                if state.hands[opponent].is_empty() {
+                    break;
+                }
+                let idx = rng.gen_range(0..state.hands[opponent].len());
+                let card = state.hands[opponent].remove(idx);
+                state.decks[opponent].cards.push(card);
+            }
+            state.decks[opponent].shuffle(false, rng);
+        })
+    })
 }
 
 /// Teal Mask Ogerpon ex – Energized Leaves:

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -491,6 +491,9 @@ pub enum Mechanic {
         damage_per: u32,
     },
     CoinFlipShuffleRandomOpponentHandCardIntoDeck,
+    // Persian - Shadow Claw: flip a coin; if heads, discard a random card
+    // from the opponent's hand after dealing damage.
+    CoinFlipDiscardRandomOpponentHandCard,
     /// Teal Mask Ogerpon ex – Energized Leaves:
     /// If total energy on both Active Pokémon ≥ threshold, deal extra_damage more.
     ExtraDamageIfCombinedActiveEnergyAtLeast {

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -98,6 +98,11 @@ pub enum Mechanic {
     CoinFlipsDiscardEnergyFromOpponentActiveOrNothing {
         num_coins: usize,
     },
+    /// Maushold - Triple Gnawing: flip 'num_coins'; for each heads, discard a
+    /// random Energy form the opponent's Active Pokémon. Damage always applies.
+    CoinFlipsDiscardEnergyFromOpponentActive {
+        num_coins: usize,
+    },
     DiscardOpponentActiveToolsBeforeDamage,
     ExtraDamageIfEx {
         extra_damage: u32,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -491,9 +491,14 @@ pub enum Mechanic {
         damage_per: u32,
     },
     CoinFlipShuffleRandomOpponentHandCardIntoDeck,
-    // Persian - Shadow Claw: flip a coin; if heads, discard a random card
-    // from the opponent's hand after dealing damage.
+    /// Persian - Shadow Claw: flip a coin; if heads, discard a random card
+    /// from the opponent's hand after dealing damage.
     CoinFlipDiscardRandomOpponentHandCard,
+    /// Krookodile - Poaching Fangs: flip 'num_coins' cions; for each heads, shuffle
+    /// a random card from the opponent's hand into their deck.
+    CoinFlipsShuffleOpponentHandCards {
+        num_coins: usize,
+    },
     /// Teal Mask Ogerpon ex – Energized Leaves:
     /// If total energy on both Active Pokémon ≥ threshold, deal extra_damage more.
     ExtraDamageIfCombinedActiveEnergyAtLeast {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -701,7 +701,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Flip a coin. If heads, discard a random Energy from your opponent's Active Pokémon.",
         Mechanic::CoinFlipDiscardEnergyFromOpponentActive,
     );
-    // map.insert("Flip a coin. If heads, discard a random card from your opponent's hand.", todo_implementation);
+    map.insert(
+        "Flip a coin. If heads, discard a random card from your opponent's hand.",
+        Mechanic::CoinFlipDiscardRandomOpponentHandCard,
+    );
     map.insert(
         "Flip a coin. If heads, during your opponent's next turn, prevent all damage done to this Pokémon by attacks.",
         Mechanic::DamageAndCardEffect {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1953,7 +1953,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("If you have fewer Pokémon in play than your opponent, this attack does 80 more damage.", todo_implementation);
     // map.insert("If your opponent has gotten exactly 1 points, this attack does 40 more damage.", todo_implementation);
     // map.insert("If your opponent's Active Pokémon has damage on it, this attack does 50 more damage.", todo_implementation);
-    // map.insert("Put 3 random cards from among Tandemaus and Maushold from your deck onto your Bench.", todo_implementation);
+    map.insert(
+        "Put 3 random cards from among Tandemaus and Maushold from your deck onto your Bench.",
+        Mechanic::SearchToBenchByNames {
+            names: vec!["Tandemaus".to_string(), "Maushold".to_string()],
+            count: 3,
+        },
+    );
     map.insert(
         "Put a random card that evolves from Spewpa from your deck into your hand.",
         Mechanic::SearchToHandByEvolvesFrom {
@@ -2044,7 +2050,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             coin_flip: false,
         },
     );
-    // map.insert("Flip 3 coins. For each heads, discard a random Energy from your opponent's Active Pokémon.", todo_implementation);
+    map.insert("Flip 3 coins. For each heads, discard a random Energy from your opponent's Active Pokémon.", Mechanic::CoinFlipsDiscardEnergyFromOpponentActive { num_coins: 3 });
     // map.insert("If this Pokémon's remaining HP is 60 or less, this attack does nothing.", todo_implementation);
     map.insert(
         "If you have 4 or more [L] Energy in play, this attack does 70 more damage.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -564,7 +564,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             num_coins: 2,
         },
     );
-    // map.insert("Flip 3 coins. For each heads, a card is chosen at random from your opponent's hand. Your opponent reveals that card and shuffles it into their deck.", todo_implementation);
+    map.insert("Flip 3 coins. For each heads, a card is chosen at random from your opponent's hand. Your opponent reveals that card and shuffles it into their deck.", Mechanic::CoinFlipsShuffleOpponentHandCards { num_coins: 3 });
     map.insert("Flip 3 coins. Take an amount of [R] Energy from your Energy Zone equal to the number of heads and attach it to your Benched [R] Pokémon in any way you like.", Mechanic::MoltresExInfernoDance);
     map.insert(
         "Flip 3 coins. This attack does 10 damage for each heads.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1906,7 +1906,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             coin_flip: true,
         },
     );
-    // map.insert("Flip a coin. If heads, look at a random card from your opponent's hand and shuffle it into their deck.", todo_implementation);
+    map.insert("Flip a coin. If heads, look at a random card from your opponent's hand and shuffle it into their deck.", Mechanic::CoinFlipShuffleRandomOpponentHandCardIntoDeck);
     map.insert(
         "Flip a coin. If heads, take 2 [R] Energy from your Energy Zone and attach it to 1 of your Benched Pokémon.",
         Mechanic::CoinFlipChargeBench {

--- a/src/test_support.rs
+++ b/src/test_support.rs
@@ -1,8 +1,8 @@
 use crate::{
-    actions::SimpleAction,
+    actions::{Action, SimpleAction},
     card_ids::CardId,
     database::get_card_by_enum,
-    models::{Attack, PlayedCard},
+    models::{Attack, Card, PlayedCard, TrainerCard},
     players::{Player, RandomPlayer},
     Deck, Game,
 };
@@ -85,4 +85,21 @@ lazy_static! {
         Deck::from_file("example_decks/venusaur-exeggutor.txt").expect("Valid Deck Format");
     pub static ref DECK_B: Deck =
         Deck::from_file("example_decks/weezing-arbok.txt").expect("Valid Deck Format");
+}
+
+/// Returns the `TrainerCard` definition for a card id.
+pub fn trainer_from_id(card_id: CardId) -> TrainerCard {
+    match get_card_by_enum(card_id) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Expected trainer card"),
+    }
+}
+
+/// Plays a trainer card from hand via the public `Game` API.
+pub fn play_trainer(game: &mut Game<'static>, actor: usize, trainer_card: TrainerCard) {
+    game.apply_action(&Action {
+        actor,
+        action: SimpleAction::Play { trainer_card },
+        is_stack: false,
+    });
 }

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -174,6 +174,8 @@ mod morpeko_test;
 mod ninetales_ember_dance_test;
 #[path = "pokemon/passimian_ex_offload_pass_test.rs"]
 mod passimian_ex_offload_pass_test;
+#[path = "pokemon/persian_test.rs"]
+mod persian_test;
 #[path = "pokemon/pidgeot_twister_test.rs"]
 mod pidgeot_twister_test;
 #[path = "pokemon/politoed_raid_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -188,6 +188,8 @@ mod porygonz_cyberjack_test;
 mod primarina_melodious_healing_test;
 #[path = "pokemon/psyduck_test.rs"]
 mod psyduck_test;
+#[path = "pokemon/purrloin_test.rs"]
+mod purrloin_test;
 #[path = "pokemon/raichu_evoshock_test.rs"]
 mod raichu_evoshock_test;
 #[path = "pokemon/rampardos_head_smash_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -122,6 +122,8 @@ mod jolteon_ex_test;
 mod klefki_dismantling_keys_test;
 #[path = "pokemon/kommo_o_clanging_scales_test.rs"]
 mod kommo_o_clanging_scales_test;
+#[path = "pokemon/krookodile_a3a_poaching_fangs_test.rs"]
+mod krookodile_a3a_poaching_fangs_test;
 #[path = "pokemon/kubfu_training_test.rs"]
 mod kubfu_training_test;
 #[path = "pokemon/legacy_ability_logic_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -142,6 +142,8 @@ mod magnezone_mirror_shot_test;
 mod magnezone_resilience_link_test;
 #[path = "pokemon/marshadow_revenge_test.rs"]
 mod marshadow_revenge_test;
+#[path = "pokemon/maushold_b2a_test.rs"]
+mod maushold_b2a_test;
 #[path = "pokemon/mega_camerupt_ex_test.rs"]
 mod mega_camerupt_ex_test;
 #[path = "pokemon/mega_diancie_ex_test.rs"]
@@ -224,6 +226,8 @@ mod spewpa_signs_of_evolution_test;
 mod sunflora_quick_grow_beam_test;
 #[path = "pokemon/swift_shot_test.rs"]
 mod swift_shot_test;
+#[path = "pokemon/tandemaus_b2_test.rs"]
+mod tandemaus_b2_test;
 #[path = "pokemon/tapu_lele_energy_arrow_test.rs"]
 mod tapu_lele_energy_arrow_test;
 #[path = "pokemon/tepig_stoke_test.rs"]

--- a/tests/pokemon/krookodile_a3a_poaching_fangs_test.rs
+++ b/tests/pokemon/krookodile_a3a_poaching_fangs_test.rs
@@ -1,0 +1,115 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId::{self},
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game, play_trainer, trainer_from_id},
+};
+
+#[test]
+fn test_poaching_fangs_flip_coin_interact_opponent_hand_and_deck() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::A3a041Krookodile).with_energy(vec![
+                    EnergyType::Darkness,
+                    EnergyType::Darkness,
+                    EnergyType::Darkness,
+                ]),
+            ],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        state.hands[1] = vec![
+            get_card_by_enum(CardId::B3028Emboar).clone(),
+            get_card_by_enum(CardId::B3028Emboar).clone(),
+            get_card_by_enum(CardId::B3028Emboar).clone(),
+        ];
+        state.decks[1].cards = vec![get_card_by_enum(CardId::A3175Magearna).clone()];
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A3a041Krookodile, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+
+        // Poaching Fangs: 90 damage dealt
+        assert_eq!(state.get_active(1).get_remaining_hp(), 60, "seed {seed}");
+
+        // Assert that cards from opponent hand goes to their deck
+        assert_eq!(
+            state.hands[1].len() + state.decks[1].cards.len(),
+            4,
+            "seed {seed}"
+        );
+        assert!(
+            !state.decks[1].cards.is_empty() && state.hands[1].len() <= 3,
+            "seed {seed}"
+        );
+        let emboar = get_card_by_enum(CardId::B3028Emboar);
+        assert!(
+            state.hands[1].contains(&emboar) || state.decks[1].cards.contains(&emboar),
+            "seed {seed}: Emboar shoulnd't move outside oppoenet hand <-> deck"
+        );
+    }
+}
+
+#[test]
+fn test_poaching_fangs_interaction_trainer_will() {
+    // Trainer Will will force the first next coin flip to be heads
+    let will = trainer_from_id(CardId::A4156Will);
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A3a041Krookodile).with_energy(vec![
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.hands[0] = vec![get_card_by_enum(CardId::A4156Will).clone()];
+    state.hands[1] = vec![
+        get_card_by_enum(CardId::B3028Emboar).clone(),
+        get_card_by_enum(CardId::B3028Emboar).clone(),
+        get_card_by_enum(CardId::B3028Emboar).clone(),
+    ];
+    state.decks[1].cards = vec![get_card_by_enum(CardId::A3175Magearna).clone()];
+    game.set_state(state);
+
+    play_trainer(&mut game, 0, will.clone());
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3a041Krookodile, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+
+    // Poaching Fangs: 90 damage dealt
+    assert_eq!(state.get_active(1).get_remaining_hp(), 60);
+
+    // Will forces heads, thus forces Poaching Fangs to trigger
+    assert_eq!(state.hands[1].len() + state.decks[1].cards.len(), 4);
+    assert!(state.decks[1].cards.len() >= 2 && state.hands[1].len() <= 2);
+    let emboar = get_card_by_enum(CardId::B3028Emboar);
+    assert!(
+        state.hands[1].contains(&emboar) || state.decks[1].cards.contains(&emboar),
+        "Emboar shoulnd't move outside oppoenet hand <-> deck"
+    );
+}

--- a/tests/pokemon/maushold_b2a_test.rs
+++ b/tests/pokemon/maushold_b2a_test.rs
@@ -1,0 +1,102 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId::{self},
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game, play_trainer, trainer_from_id},
+};
+
+#[test]
+fn test_gnawing_flips_discard_opponent_active_energy() {
+    // Maushold's Triple Gnawing skill deals 60 dmg and flips 3 coins and discards opponenet active Pokémon energies
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B2a082Maushold)
+                .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Grass,
+                EnergyType::Grass,
+            ])],
+        );
+        let energy_before = state.get_active(1).attached_energy.len();
+        let discarded_before = state.discard_energies[1].len();
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B2a082Maushold, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+
+        // Triple Gnawing: 60 damage dealt
+        assert_eq!(state.get_active(1).get_remaining_hp(), 90, "seed {seed}");
+
+        // Assert whether opponent's active Pokémon gets discarded
+        let energy_after = state.get_active(1).attached_energy.len();
+        assert!(
+            energy_before.saturating_sub(3) <= energy_after && energy_after <= energy_before,
+            "seed {seed}"
+        );
+        assert_eq!(
+            state.discard_energies[1].len(),
+            discarded_before + (energy_before - energy_after),
+            "seed {seed}"
+        );
+    }
+}
+
+#[test]
+fn test_triple_gnawing_interaction_trainer_will() {
+    // Trainer Will will force the first next coin flip to be heads
+    let will = trainer_from_id(CardId::A4156Will);
+
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2a082Maushold)
+            .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![
+            EnergyType::Grass,
+            EnergyType::Grass,
+            EnergyType::Grass,
+        ])],
+    );
+    state.hands[0] = vec![get_card_by_enum(CardId::A4156Will).clone()];
+    let energy_before = state.get_active(1).attached_energy.len();
+    let discarded_before = state.discard_energies[1].len();
+    game.set_state(state);
+
+    play_trainer(&mut game, 0, will.clone());
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2a082Maushold, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+
+    // Triple Gnawing: 60 damage dealt
+    assert_eq!(state.get_active(1).get_remaining_hp(), 90);
+
+    // Will forces heads, thus forces Triple Gnawing to trigger once
+    let energy_after = state.get_active(1).attached_energy.len();
+    assert!(energy_before.saturating_sub(3) <= energy_after && energy_after <= energy_before,);
+    assert_eq!(
+        state.discard_energies[1].len(),
+        discarded_before + (energy_before - energy_after),
+    );
+}

--- a/tests/pokemon/persian_test.rs
+++ b/tests/pokemon/persian_test.rs
@@ -79,5 +79,5 @@ fn test_shadow_claw_interaction_trainer_will() {
     assert_eq!(state.get_active(1).get_remaining_hp(), 150 - 40);
 
     // Will forces heads, thus forces Shadow Claw to trigger
-    assert!(state.hands[1].len() == 0);
+    assert!(state.hands[1].is_empty());
 }

--- a/tests/pokemon/persian_test.rs
+++ b/tests/pokemon/persian_test.rs
@@ -74,16 +74,10 @@ fn test_shadow_claw_interaction_trainer_will() {
     game.play_until_stable();
 
     let state = game.get_state_clone();
-    let snorlax_initial_health_points = 150;
-    let expected_damage_dealt = 40;
-    let hand_len_before = 1;
 
     // Shadow Claw: 40 damage dealt
-    assert_eq!(
-        state.get_active(1).get_remaining_hp(),
-        snorlax_initial_health_points - expected_damage_dealt
-    );
+    assert_eq!(state.get_active(1).get_remaining_hp(), 150 - 40);
 
-    // Opponent hand got smaller
-    assert!(state.hands[1].len() == hand_len_before - 1);
+    // Will forces heads, thus forces Shadow Claw to trigger
+    assert!(state.hands[1].len() == 0);
 }

--- a/tests/pokemon/persian_test.rs
+++ b/tests/pokemon/persian_test.rs
@@ -1,0 +1,89 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game, play_trainer, trainer_from_id},
+};
+
+#[test]
+fn test_persian_shadow_claw_flips_coin_possible_opponent_discard() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::A1197Persian)
+                .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        state.hands[1] = vec![get_card_by_enum(CardId::B3028Emboar).clone()];
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1197Persian, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let snorlax_initial_health_points = 150;
+        let expected_damage_dealt = 40;
+        let hand_len_before = 1;
+
+        // Shadow Claw: 40 damage dealt
+        assert_eq!(
+            state.get_active(1).get_remaining_hp(),
+            snorlax_initial_health_points - expected_damage_dealt
+        );
+
+        // Assert whether opponents hand got smaller
+        assert!(
+            state.hands[1].len() == hand_len_before || state.hands[1].len() == hand_len_before - 1
+        );
+    }
+}
+
+#[test]
+fn test_shadow_claw_interaction_trainer_will() {
+    // Trainer Will will force the first next coin flip to be heads
+    let will = trainer_from_id(CardId::A4156Will);
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1197Persian)
+            .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.hands[0] = vec![get_card_by_enum(CardId::A4156Will).clone()];
+    state.hands[1] = vec![get_card_by_enum(CardId::B3028Emboar).clone()];
+    game.set_state(state);
+
+    play_trainer(&mut game, 0, will.clone());
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1197Persian, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    let snorlax_initial_health_points = 150;
+    let expected_damage_dealt = 40;
+    let hand_len_before = 1;
+
+    // Shadow Claw: 40 damage dealt
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        snorlax_initial_health_points - expected_damage_dealt
+    );
+
+    // Opponent hand got smaller
+    assert!(state.hands[1].len() == hand_len_before - 1);
+}

--- a/tests/pokemon/purrloin_test.rs
+++ b/tests/pokemon/purrloin_test.rs
@@ -1,0 +1,111 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId::{self},
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game, play_trainer, trainer_from_id},
+};
+
+#[test]
+fn test_whiny_voice_flip_coin_interact_opponent_hand_and_decd() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B2104Purrloin).with_energy(vec![EnergyType::Darkness])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        state.hands[1] = vec![get_card_by_enum(CardId::B3028Emboar).clone()];
+        state.decks[1].cards = vec![get_card_by_enum(CardId::A3175Magearna).clone()];
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B2104Purrloin, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+
+        // Whiny Voice: 0 damage dealt
+        assert_eq!(state.get_active(1).get_remaining_hp(), 150, "seed {seed}");
+
+        // Assert whether opponents card in hand went to shuffeld deck
+        assert_eq!(
+            state.hands[1].len() + state.decks[1].cards.len(),
+            2,
+            "seed {seed}"
+        );
+        assert_eq!(
+            state.hands[1].len() + state.decks[1].cards.len(),
+            2,
+            "seed {seed}: Emboar should be on decks when heads"
+        );
+        assert!(
+            state.decks[1].cards == vec![get_card_by_enum(CardId::A3175Magearna).clone()]
+                || state.decks[1].cards
+                    == vec![
+                        get_card_by_enum(CardId::A3175Magearna).clone(),
+                        get_card_by_enum(CardId::B3028Emboar).clone()
+                    ]
+                || state.decks[1].cards
+                    == vec![
+                        get_card_by_enum(CardId::B3028Emboar).clone(),
+                        get_card_by_enum(CardId::A3175Magearna).clone()
+                    ]
+        )
+    }
+}
+
+#[test]
+fn test_whiny_voice_interaction_trainer_will() {
+    // Trainer Will will force the first next coin flip to be heads
+    let will = trainer_from_id(CardId::A4156Will);
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2104Purrloin).with_energy(vec![EnergyType::Darkness])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    state.hands[0] = vec![get_card_by_enum(CardId::A4156Will).clone()];
+    state.hands[1] = vec![get_card_by_enum(CardId::B3028Emboar).clone()];
+    state.decks[1].cards = vec![get_card_by_enum(CardId::A3175Magearna).clone()];
+    game.set_state(state);
+
+    play_trainer(&mut game, 0, will.clone());
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2104Purrloin, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+
+    // Whiny Voice: 0 damage dealt
+    assert_eq!(state.get_active(1).get_remaining_hp(), 150);
+
+    // Will forces heads, thus forces Whiny Voice to trigger
+    assert_eq!(state.hands[1].len() + state.decks[1].cards.len(), 2);
+    assert_eq!(state.hands[1].len() + state.decks[1].cards.len(), 2);
+    assert!(
+        state.decks[1].cards
+            == vec![
+                get_card_by_enum(CardId::A3175Magearna).clone(),
+                get_card_by_enum(CardId::B3028Emboar).clone()
+            ]
+            || state.decks[1].cards
+                == vec![
+                    get_card_by_enum(CardId::B3028Emboar).clone(),
+                    get_card_by_enum(CardId::A3175Magearna).clone()
+                ]
+    )
+}

--- a/tests/pokemon/purrloin_test.rs
+++ b/tests/pokemon/purrloin_test.rs
@@ -95,7 +95,6 @@ fn test_whiny_voice_interaction_trainer_will() {
 
     // Will forces heads, thus forces Whiny Voice to trigger
     assert_eq!(state.hands[1].len() + state.decks[1].cards.len(), 2);
-    assert_eq!(state.hands[1].len() + state.decks[1].cards.len(), 2);
     assert!(
         state.decks[1].cards
             == vec![

--- a/tests/pokemon/tandemaus_b2_test.rs
+++ b/tests/pokemon/tandemaus_b2_test.rs
@@ -1,0 +1,68 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_flock_puts_tandemaus_and_maushold_from_deck_to_bench() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B2142Tandemaus)
+                .with_energy(vec![EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        // Deck with 3 eligible cards (2 Tandemaus + 1 Maushold) + 2 fillers.
+        // The 3 eligible cards fit exactly in the 3 free bench slots.
+        state.decks[0].cards = vec![
+            get_card_by_enum(CardId::B2142Tandemaus).clone(),
+            get_card_by_enum(CardId::B2142Tandemaus).clone(),
+            get_card_by_enum(CardId::B2a082Maushold).clone(),
+            get_card_by_enum(CardId::A1001Bulbasaur).clone(),
+            get_card_by_enum(CardId::A1001Bulbasaur).clone(),
+        ];
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B2142Tandemaus, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+
+        // Flock deals no damage
+        assert_eq!(state.get_active(1).get_remaining_hp(), 150, "seed {seed}");
+
+        // All 3 eligible cards moved from the deck to the bench
+        assert_eq!(state.enumerate_bench_pokemon(0).count(), 3, "seed {seed}");
+
+        // Every benched card is a Tandemaus or a Maushold
+        for (_, pokemon) in state.enumerate_bench_pokemon(0) {
+            let name = pokemon.get_name();
+            assert!(
+                name == "Tandemaus" || name == "Maushold",
+                "seed {seed}: Flock may only put Tandemaus/Maushold on the bench, got {name}"
+            );
+        }
+
+        // Conservation: no Tandemaus/Maushold was left behind in the deck
+        let leftover_in_deck = state.decks[0]
+            .cards
+            .iter()
+            .filter(|card| {
+                let name = card.get_name();
+                name == "Tandemaus" || name == "Maushold"
+            })
+            .count();
+        assert_eq!(leftover_in_deck, 0, "seed {seed}");
+    }
+}


### PR DESCRIPTION
Implements a family of **coin-flip attacks that disrupt the opponent's resources** — hand, deck, and energy — across 8 cards:

- **Persian — Shadow Claw** (A1 197, B1 313): flip a coin; heads discards a random card from the opponent's hand
- **Purrloin — Whiny Voice** (B2 104, B2 174): flip a coin; heads shuffles a random card from the opponent's hand into their deck
- **Krookodile — Poaching Fangs** (A3a 041): flip 3 coins; each heads shuffles a random card from the opponent's hand into their deck
- **Maushold — Triple Gnawing** (B2a 082, B2a 099): flip 3 coins; each heads discards a random Energy from the opponent's Active
- **Tandemaus — Flock** (B2 142): put 3 random Tandemaus/Maushold from your deck onto your Bench

## How
- New mechanics in `src/actions/attacks/mechanic.rs`:
  - `CoinFlipDiscardRandomOpponentHandCard`
  - `CoinFlipsShuffleOpponentHandCards { num_coins }`
  - `CoinFlipsDiscardEnergyFromOpponentActive { num_coins }`
- **Reused** existing mechanics where the effect already existed: `CoinFlipShuffleRandomOpponentHandCardIntoDeck` (Purrloin) and `SearchToBenchByNames` (Tandemaus) — no new logic needed
- Implemented match arms + helpers in `src/actions/apply_attack_action.rs`, reusing the shared `discard_random_energy_from_opponent_active` helper for Maushold
- Wired effect texts in `src/actions/effect_mechanic_map.rs` (one entry per effect text covers all card versions)
- Moved the repeatedly copy-pasted test helpers `trainer_from_id` / `play_trainer` into `src/test_support.rs`

## Tests
- TDD at the public `Game` API level: `tests/pokemon/persian_test.rs`, `purrloin_test.rs`, `krookodile_a3a_poaching_fangs_test.rs`, `maushold_b2a_test.rs`, `tandemaus_b2_test.rs`
- Coin flips verified with seeded seed-loops (`0..50`) plus the Will trainer to force heads deterministically; invariants check conservation (cards/energies are never lost)
- `cargo test --features test-utils --test pokemon`: 336 passed
- `cargo clippy` and `cargo fmt`: clean
- `cargo run --bin card_test`: simulations complete without errors