### PR TITLE
Implement Nidoqueen's Lovestrike and Kabutops's Leech Life (5 cards)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -579,6 +579,15 @@ fn forecast_effect_attack_by_mechanic(
             pokemon_name,
             *extra_damage,
         ),
+        Mechanic::ExtraDamagePerPokemonWithNameOnBench {
+            pokemon_name,
+            damage_per,
+        } => extra_damage_per_pokemon_with_name_on_bench(
+            state,
+            attack.fixed_damage,
+            pokemon_name,
+            *damage_per,
+        ),
         Mechanic::DamageEqualToSelfDamage => damage_equal_to_self_damage(state),
         Mechanic::ExtraDamageEqualToSelfDamage => {
             extra_damage_equal_to_self_damage(state, attack.fixed_damage)
@@ -2988,6 +2997,19 @@ fn extra_damage_if_pokemon_on_bench(
     } else {
         active_damage_doutcome(base)
     }
+}
+
+fn extra_damage_per_pokemon_with_name_on_bench(
+    state: &State,
+    base: u32,
+    pokemon_name: &str,
+    damage_per: u32,
+) -> AttackOutcomes {
+    let count = state
+        .enumerate_bench_pokemon(state.current_player)
+        .filter(|(_, p)| p.get_name() == pokemon_name)
+        .count();
+    active_damage_doutcome(base + (count as u32) * damage_per)
 }
 
 fn damage_equal_to_self_damage(state: &State) -> AttackOutcomes {

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -43,6 +43,9 @@ use super::{
     SimpleAction,
 };
 
+use std::cell::Cell;
+use std::rc::Rc;
+
 // This is a reducer of all actions relating to attacks.
 //
 // `is_sub_attack` is true when this attack is being resolved as a sub-action off the
@@ -4086,10 +4089,27 @@ fn damage_reduced_by_self_damage_attack(state: &State, attack: &Attack) -> Attac
 
 /// Kabutops - Leech Life: heal the same aount of damage dealt.
 fn heal_equal_to_damage_dealt_attack(damage: u32) -> AttackOutcomes {
-    active_damage_effect_doutcome(damage, move |_, state, action| {
-        let active = state.get_active_mut(action.actor);
-        active.heal(damage);
-    })
+    let hp_before = Rc::new(Cell::new(0));
+    AttackOutcomes::single(AttackOutcome::damage_with_pre_and_post(
+        vec![(damage, true, 0)],
+        {
+            let hp_before = Rc::clone(&hp_before);
+            move |_, state, action| {
+                let opponent = (action.actor + 1) % 2;
+                hp_before.set(state.get_active(opponent).get_remaining_hp());
+            }
+        },
+        {
+            let hp_before = Rc::clone(&hp_before);
+            move |_, state, action| {
+                let opponent = (action.actor + 1) % 2;
+                let dealt = hp_before
+                    .get()
+                    .saturating_sub(state.get_active(opponent).get_remaining_hp());
+                state.get_active_mut(action.actor).heal(dealt);
+            }
+        },
+    ))
 }
 
 #[cfg(test)]

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -981,6 +981,7 @@ fn forecast_effect_attack_by_mechanic(
             attack_name,
             damage_per,
         } => damage_per_own_pokemon_with_attack_name(state, attack_name, *damage_per),
+        Mechanic::HealEqualToDamageDealt => heal_equal_to_damage_dealt_attack(attack.fixed_damage),
     }
 }
 
@@ -4081,6 +4082,14 @@ fn damage_reduced_by_self_damage_attack(state: &State, attack: &Attack) -> Attac
     let damage_taken = active.get_damage_counters();
     let actual_damage = attack.fixed_damage.saturating_sub(damage_taken);
     active_damage_doutcome(actual_damage)
+}
+
+/// Kabutops - Leech Life: heal the same aount of damage dealt.
+fn heal_equal_to_damage_dealt_attack(damage: u32) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let active = state.get_active_mut(action.actor);
+        active.heal(damage);
+    })
 }
 
 #[cfg(test)]

--- a/src/actions/attack_outcome.rs
+++ b/src/actions/attack_outcome.rs
@@ -144,6 +144,20 @@ impl AttackOutcome {
             }
         })
     }
+
+    /// Damage with both a pre-damage and a post-damage effect. The two effects can share state
+    /// via a captured 'Rc' (e.g. to heal based on the damage acutally dealt after modifier).
+    pub fn damage_with_pre_and_post<F, G>(targets: Vec<DamageTarget>, pre: F, post: G) -> Self
+    where
+        F: Fn(&mut StdRng, &mut State, &Action) + 'static,
+        G: Fn(&mut StdRng, &mut State, &Action) + 'static,
+    {
+        Self {
+            damage: targets,
+            pre_damage_effect: Some(Rc::new(pre)),
+            post_damage_effect: Some(Rc::new(post)),
+        }
+    }
 }
 
 /// A probability distribution over `AttackOutcome`s, mirroring `Outcomes` but with damage

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -548,6 +548,8 @@ pub enum Mechanic {
     /// Coalossal's Mountain Crush: deal the attack's `fixed_damage`, then flip a coin until
     /// tails, discarding the top card of the opponent's deck for each heads.
     FlipUntilTailsDiscardOpponentDeck,
+    /// Kabutops - Leech Life: heal the same amount of damage dealt.
+    HealEqualToDamageDealt,
     MegaAmpharosExLightningLancer,
     OminousClaw,
     DarknessClaw,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -436,6 +436,12 @@ pub enum Mechanic {
         pokemon_name: String,
         extra_damage: u32,
     },
+    /// Nidoqueen - Lovestrike: +'damage_per' for EACH benched Pokémon named 'pokemon_name'
+    /// (unlike 'ExtraDamageIfPokemonBench', which is a flat bonus for a single presence).
+    ExtraDamagePerPokemonWithNameOnBench {
+        pokemon_name: String,
+        damage_per: u32,
+    },
     DamageEqualToSelfDamage,
     ExtraDamageEqualToSelfDamage,
     /// Marshadow's Revenge and friends: extra damage if any of your Pokemon were Knocked Out by

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1820,7 +1820,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             bench_only: false,
         },
     );
-    // map.insert("This attack does 50 more damage for each of your Benched Nidoking.", todo_implementation);
+    map.insert(
+        "This attack does 50 more damage for each of your Benched Nidoking.",
+        Mechanic::ExtraDamagePerPokemonWithNameOnBench {
+            pokemon_name: "Nidoking".to_string(),
+            damage_per: 50,
+        },
+    );
     map.insert(
         "This attack does 60 damage to 1 of your opponent's Pokémon.",
         Mechanic::DirectDamage {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -949,7 +949,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Heal 50 damage from 1 of your Benched Pokémon.",
         Mechanic::HealOneYourBenchedPokemon { amount: 50 },
     );
-    // map.insert("Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon.", todo_implementation);
+    map.insert("Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon.", Mechanic::HealEqualToDamageDealt);
     map.insert(
         "If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 20 more damage.",
         Mechanic::ExtraDamageIfAttackUsedDuringOwnLastTurn {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -150,6 +150,8 @@ mod iron_valiant_future_system_test;
 mod jellicent_bouncy_body_test;
 #[path = "pokemon/jolteon_ex_test.rs"]
 mod jolteon_ex_test;
+#[path = "pokemon/kabutops_test.rs"]
+mod kabutops_test;
 #[path = "pokemon/klefki_dismantling_keys_test.rs"]
 mod klefki_dismantling_keys_test;
 #[path = "pokemon/kommo_o_clanging_scales_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -218,6 +218,8 @@ mod milotic_ex_aqua_charge_test;
 mod miraidon_ex_test;
 #[path = "pokemon/morpeko_test.rs"]
 mod morpeko_test;
+#[path = "pokemon/nidoqueen_test.rs"]
+mod nidoqueen_test;
 #[path = "pokemon/ninetales_ember_dance_test.rs"]
 mod ninetales_ember_dance_test;
 #[path = "pokemon/oricorio_yveltal_test.rs"]

--- a/tests/pokemon/kabutops_test.rs
+++ b/tests/pokemon/kabutops_test.rs
@@ -1,6 +1,7 @@
 use deckgym::{
     actions::Action,
     card_ids::CardId::{self},
+    database::get_card_by_enum,
     models::{EnergyType, PlayedCard},
     test_support::{attack_action, get_initialized_game},
 };
@@ -53,5 +54,118 @@ fn test_leech_life_heals_equals_to_damage_dealt() {
     assert_eq!(
         state.get_active(0).get_remaining_hp(),
         hp_after_opponent_attacks + 50
+    );
+}
+
+#[test]
+fn test_leech_life_heals_equals_to_damage_dealt_considers_reducing_damage_item() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1159Kabutops).with_energy(vec![EnergyType::Fighting])],
+        vec![PlayedCard::from_id(CardId::B4197WailordEx)
+            .with_energy(vec![
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Water,
+            ])
+            .with_tool(get_card_by_enum(CardId::B1219HeavyHelmet))],
+    );
+    game.set_state(state);
+
+    // Opponent attacks first: Wailord Ex damages Kabutops for 100 dmg
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(CardId::B4197WailordEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let hp_after_opponent_attacks = state.get_active(0).get_remaining_hp();
+    assert!(hp_after_opponent_attacks < 120);
+
+    // Own Kabutops attacks and heals by "Leech life" - 20 dmg (due Heavy Helmet effect)
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1159Kabutops, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+
+    // Wailord Ex took 30 damage
+    assert_eq!(state.get_active(1).get_remaining_hp(), 220);
+    // Leech Life: heals Kabutops for 30 dmg
+    assert_eq!(
+        state.get_active(0).get_remaining_hp(),
+        hp_after_opponent_attacks + 30
+    );
+}
+
+#[test]
+fn test_leech_life_heals_equals_to_damage_dealt_with_weakness() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1159Kabutops).with_energy(vec![EnergyType::Fighting])],
+        vec![
+            PlayedCard::from_id(CardId::A4b376PikachuEx)
+                .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning]),
+            PlayedCard::from_id(CardId::A1097Magnemite),
+            PlayedCard::from_id(CardId::A1097Magnemite),
+            PlayedCard::from_id(CardId::A1097Magnemite),
+        ],
+    );
+    game.set_state(state);
+
+    // Opponent attacks first: Pikachu Ex damages Kabutops for 90 dmg
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(CardId::A4b376PikachuEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let hp_after_opponent_attacks = state.get_active(0).get_remaining_hp();
+    assert!(hp_after_opponent_attacks < 120);
+
+    // Own Kabutops attacks and heals by "Leech life" + 20 dmg
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1159Kabutops, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+
+    // Pikachu Ex took 70 damage
+    assert_eq!(state.get_active(1).get_remaining_hp(), 50);
+    // Leech Life: heals Kabutops for 70 dmg
+    assert_eq!(
+        state.get_active(0).get_remaining_hp(),
+        hp_after_opponent_attacks + 70
     );
 }

--- a/tests/pokemon/kabutops_test.rs
+++ b/tests/pokemon/kabutops_test.rs
@@ -1,0 +1,57 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId::{self},
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_leech_life_heals_equals_to_damage_dealt() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1159Kabutops).with_energy(vec![EnergyType::Fighting])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+    );
+    game.set_state(state);
+
+    // Opponent attacks first: Bulbasaur damages Kabutos for 30 dmg
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(CardId::A1001Bulbasaur, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    let hp_after_opponent_attacks = state.get_active(0).get_remaining_hp();
+    assert!(hp_after_opponent_attacks < 140);
+
+    // Own Kabutops attacks and heals by "Leech lilfe"
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1159Kabutops, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+
+    // Bulbasaur took 50 damage
+    assert_eq!(state.get_active(1).get_remaining_hp(), 20);
+    // Leech Life: heals equals 50 dmg
+    assert_eq!(
+        state.get_active(0).get_remaining_hp(),
+        hp_after_opponent_attacks + 50
+    );
+}

--- a/tests/pokemon/nidoqueen_test.rs
+++ b/tests/pokemon/nidoqueen_test.rs
@@ -1,0 +1,40 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId::{self},
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_lovestrike_checks_for_benched_nidokings() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.current_player = 0;
+    state.turn_count = 1;
+
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A1168Nidoqueen).with_energy(vec![
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+            ]),
+            PlayedCard::from_id(CardId::A1171Nidoking),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1168Nidoqueen, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+
+    // Lovestrike: deals 80 dmg + 50 per each benched Nidoking (1 benched)
+    assert_eq!(state.get_active(1).get_remaining_hp(), 20);
+}


### PR DESCRIPTION
## What
Implements two deterministic attack effects across 5 cards:

- **Nidoqueen — Lovestrike** (A1 168, A1 240, A4 225): `80` base damage + `50` more damage for **each** benched Nidoking
- **Kabutops — Leech Life** (A1 159, B2 221): `50` damage, then heal this Pokémon the **same amount of damage dealt**

## How
- New mechanics in `src/actions/attacks/mechanic.rs`:
  - `ExtraDamagePerPokemonWithNameOnBench { pokemon_name, damage_per }` — counts benched Pokémon by name (unlike the existing flat `ExtraDamageIfPokemonOnBench`)
  - `HealEqualToDamageDealt` — heals the attacker after the damage is applied
- Implemented match arms and helpers in `src/actions/apply_attack_action.rs`
- Wired effect texts in `src/actions/effect_mechanic_map.rs` (one entry per effect text covers all card versions)

## Tests
- TDD at the public `Game` API level: `tests/pokemon/nidoqueen_test.rs`, `tests/pokemon/kabutops_test.rs`
- Nidoqueen: verifies the per-Nidoking damage scaling from the bench
- Kabutops: damages the attacker through actual gameplay (opponent attacks first, since `heal`/`apply_damage` are crate-private), then asserts the attacker is healed by the damage dealt
- `cargo test --features test-utils --test pokemon`: 341 passed
- `cargo clippy` and `cargo fmt`: clean
- `cargo run --bin card_test -- "A1 168"` and `-- "A1 159"`: simulations complete without errors