### PR TITLE
Implement conditional coin-flip attacks (Sandslash, Wugtrio, Lugia, Alolan Marowak, Drapion, Bellossom, Ambipom)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -16,6 +16,7 @@ use crate::{
         effect_mechanic_map::EFFECT_MECHANIC_MAP,
         Action,
     },
+    card_ids::CardId,
     combinatorics::generate_combinations,
     effects::{CardEffect, TurnEffect},
     hooks::{
@@ -23,6 +24,7 @@ use crate::{
         get_attack_cost, get_extra_random_spread_hits, get_retreat_cost, get_stage,
     },
     models::{Attack, Card, EnergyType, StatusCondition, TrainerType},
+    tools::has_tool,
     State,
 };
 
@@ -376,6 +378,18 @@ fn forecast_effect_attack_by_mechanic(
             damage_per_head,
             status,
         } => damage_for_each_heads_self_status_attack(*num_coins, *damage_per_head, *status),
+        Mechanic::ExtraDamageForEachHeadsWithToolBoost {
+            num_coins,
+            damage_per_head,
+            boosted_num_coins,
+            tool,
+        } => damage_for_each_heads_with_tool_boost_attack(
+            state,
+            *num_coins,
+            *damage_per_head,
+            *boosted_num_coins,
+            *tool,
+        ),
         Mechanic::DiscardSelfEnergyPerHeadsExtraDamage {
             num_coins,
             energy_type,
@@ -1476,6 +1490,24 @@ fn damage_for_each_heads_self_status_attack(
         active_damage_effect_outcome(heads as u32 * damage_per_head, move |_, state, action| {
             state.apply_status_condition(action.actor, 0, status);
         })
+    })
+}
+
+fn damage_for_each_heads_with_tool_boost_attack(
+    state: &State,
+    num_coins: usize,
+    damage_per_head: u32,
+    boosted_num_coins: usize,
+    tool: CardId,
+) -> AttackOutcomes {
+    let active = state.get_active(state.current_player);
+    let num_coins = if has_tool(active, tool) {
+        boosted_num_coins
+    } else {
+        num_coins
+    };
+    AttackOutcomes::binomial_by_heads(num_coins, move |heads| {
+        active_damage_outcome(heads as u32 * damage_per_head)
     })
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -371,6 +371,11 @@ fn forecast_effect_attack_by_mechanic(
             *num_coins,
             attack,
         ),
+        Mechanic::ExtraDamageForEachHeadsSelfStatus {
+            num_coins,
+            damage_per_head,
+            status,
+        } => damage_for_each_heads_self_status_attack(*num_coins, *damage_per_head, *status),
         Mechanic::DiscardSelfEnergyPerHeadsExtraDamage {
             num_coins,
             energy_type,
@@ -1459,6 +1464,18 @@ fn damage_for_each_heads_attack(
     };
     AttackOutcomes::binomial_by_heads(num_coins, move |heads_count| {
         active_damage_outcome(fixed_damage + damage_per_head * heads_count as u32)
+    })
+}
+
+fn damage_for_each_heads_self_status_attack(
+    num_coins: usize,
+    damage_per_head: u32,
+    status: StatusCondition,
+) -> AttackOutcomes {
+    AttackOutcomes::binomial_by_heads(num_coins, move |heads| {
+        active_damage_effect_outcome(heads as u32 * damage_per_head, move |_, state, action| {
+            state.apply_status_condition(action.actor, 0, status);
+        })
     })
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -725,6 +725,17 @@ fn forecast_effect_attack_by_mechanic(
             attack,
             *status,
         ),
+        Mechanic::ExtraDamageForEachHeadsWithStatusAtLeast {
+            num_coins,
+            damage_per_head,
+            status,
+            min_heads,
+        } => damage_for_each_heads_with_status_at_least_attack(
+            *num_coins,
+            *damage_per_head,
+            *status,
+            *min_heads,
+        ),
         Mechanic::DamageAndMultipleCardEffects {
             opponent,
             effects,
@@ -3647,6 +3658,23 @@ fn damage_for_each_heads_with_status_attack(
             heads as u32 * damage_per_head
         };
         active_damage_effect_outcome(damage, build_status_effect(status))
+    })
+}
+
+/// Alolan Marowak - Burning Bonemerang - Flips coins for damage and inflicts status if at least 1 heads
+fn damage_for_each_heads_with_status_at_least_attack(
+    num_coins: usize,
+    damage_per_head: u32,
+    status: StatusCondition,
+    min_heads: usize,
+) -> AttackOutcomes {
+    AttackOutcomes::binomial_by_heads(num_coins, move |heads| {
+        let damage = heads as u32 * damage_per_head;
+        if heads >= min_heads {
+            active_damage_effect_outcome(damage, build_status_effect(status))
+        } else {
+            active_damage_outcome(damage)
+        }
     })
 }
 

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -254,6 +254,15 @@ pub enum Mechanic {
         num_coins: usize,
         status: StatusCondition,
     },
+    /// Alolan Marowak - Burning Bonemerang: flip 'num_coins'. This attack does 70 damage
+    /// for each heads. If at least 1 of them is heads, your opponent's Active Pokémon
+    /// is now Burned.
+    ExtraDamageForEachHeadsWithStatusAtLeast {
+        num_coins: usize,
+        damage_per_head: u32,
+        status: StatusCondition,
+        min_heads: usize,
+    },
     DamageAndMultipleCardEffects {
         opponent: bool,
         effects: Vec<CardEffect>,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -3,6 +3,8 @@ use crate::{
     models::{EnergyType, StatusCondition, TrainerType},
 };
 
+use crate::card_ids::CardId;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum BenchSide {
     YourBench,
@@ -269,6 +271,14 @@ pub enum Mechanic {
         damage_per_head: u32,
         status: StatusCondition,
         min_heads: usize,
+    },
+    /// Ambipom - Excited Tail: flip 'num_coins' coins; deal 'damage_per_head' per heads,
+    /// but frlip 'boosted_num_coins' coins instead if the attacker has 'tool' attached.
+    ExtraDamageForEachHeadsWithToolBoost {
+        num_coins: usize,
+        damage_per_head: u32,
+        boosted_num_coins: usize,
+        tool: CardId,
     },
     DamageAndMultipleCardEffects {
         opponent: bool,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -254,6 +254,13 @@ pub enum Mechanic {
         num_coins: usize,
         status: StatusCondition,
     },
+    /// Bellossom - Petal Dance: flip 'num_coins' coins; deal 'damage_per_head' per hedas,
+    /// then apply 'status' to the ATTACKER (unlike the opponent-targeting variants).
+    ExtraDamageForEachHeadsSelfStatus {
+        num_coins: usize,
+        damage_per_head: u32,
+        status: StatusCondition,
+    },
     /// Alolan Marowak - Burning Bonemerang: flip 'num_coins'. This attack does 70 damage
     /// for each heads. If at least 1 of them is heads, your opponent's Active Pokémon
     /// is now Burned.

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -631,7 +631,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             num_coins: 4,
         },
     );
-    // map.insert("Flip 4 coins. This attack does 40 damage for each heads. If at least 2 of them are heads, your opponent's Active Pokémon is now Poisoned.", todo_implementation);
+    map.insert("Flip 4 coins. This attack does 40 damage for each heads. If at least 2 of them are heads, your opponent's Active Pokémon is now Poisoned.", Mechanic::ExtraDamageForEachHeadsWithStatusAtLeast { num_coins: 4, damage_per_head: 40, status: StatusCondition::Poisoned, min_heads: 2 });
     map.insert(
         "Flip 4 coins. This attack does 50 damage for each heads.",
         Mechanic::ExtraDamageForEachHeads {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -547,7 +547,7 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             num_coins: 2,
         },
     );
-    // map.insert("Flip 2 coins. This attack does 70 damage for each heads. If at least 1 of them is heads, your opponent's Active Pokémon is now Burned.", todo_implementation);
+    map.insert("Flip 2 coins. This attack does 70 damage for each heads. If at least 1 of them is heads, your opponent's Active Pokémon is now Burned.", Mechanic::ExtraDamageForEachHeadsWithStatusAtLeast { num_coins: 2, damage_per_head: 70, status: StatusCondition::Burned, min_heads: 1 });
     map.insert(
         "Flip 2 coins. This attack does 70 damage for each heads.",
         Mechanic::ExtraDamageForEachHeads {
@@ -1889,12 +1889,26 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     // map.insert("During your opponent's next turn, if this Pokémon is in the Active Spot when your opponent's Active Pokémon retreats, this attack does 40 damage to the new Active Pokémon.", todo_implementation);
     // map.insert("During your opponent's next turn, this Pokémon takes -80 damage from attacks from your opponent's Pokémon ex.", todo_implementation);
     // map.insert("Flip 2 coins. If both of them are heads, this attack does 20 more damage.", todo_implementation);
-    // map.insert("Flip 2 coins. This attack does 40 more damage for each heads.", todo_implementation);
+    map.insert(
+        "Flip 2 coins. This attack does 40 more damage for each heads.",
+        Mechanic::ExtraDamageForEachHeads {
+            include_fixed_damage: true,
+            damage_per_head: 40,
+            num_coins: 2,
+        },
+    );
     map.insert(
         "Flip 3 coins. For each heads, discard a random Energy from your opponent's Active Pokémon. If all of them are tails, this attack does nothing.",
         Mechanic::CoinFlipsDiscardEnergyFromOpponentActiveOrNothing { num_coins: 3 },
     );
-    // map.insert("Flip 3 coins. This attack does 30 damage for each heads.", todo_implementation);
+    map.insert(
+        "Flip 3 coins. This attack does 30 damage for each heads.",
+        Mechanic::ExtraDamageForEachHeads {
+            include_fixed_damage: false,
+            damage_per_head: 30,
+            num_coins: 3,
+        },
+    );
     // map.insert("Flip a coin for each Tandemaus and Maushold you have in play. This attack does 60 damage for each heads.", todo_implementation);
     // map.insert("Flip a coin. If heads, discard your opponent's Active Pokémon.", todo_implementation);
     map.insert(

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -6,6 +6,7 @@ use std::sync::LazyLock;
 
 use crate::{
     actions::attacks::{BenchSide, CopyAttackSource, Mechanic},
+    card_ids::CardId,
     effects::{CardEffect, TurnEffect},
     models::{EnergyType, StatusCondition, TrainerType},
 };
@@ -522,7 +523,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             num_coins: 2,
         },
     );
-    // map.insert("Flip 2 coins. This attack does 30 damage for each heads. If this Pokémon has Lucky Mittens attached, flip 4 coins instead.", todo_implementation);
+    map.insert("Flip 2 coins. This attack does 30 damage for each heads. If this Pokémon has Lucky Mittens attached, flip 4 coins instead.",
+        Mechanic::ExtraDamageForEachHeadsWithToolBoost {
+            num_coins: 2,
+            damage_per_head: 30,
+            boosted_num_coins: 4,
+            tool: CardId::B1220LuckyMittens
+        },
+    );
     map.insert(
         "Flip 2 coins. This attack does 30 more damage for each heads.",
         Mechanic::ExtraDamageForEachHeads {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -614,7 +614,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             num_coins: 3,
         },
     );
-    // map.insert("Flip 3 coins. This attack does 60 damage for each heads. This Pokémon is now Confused.", todo_implementation);
+    map.insert(
+        "Flip 3 coins. This attack does 60 damage for each heads. This Pokémon is now Confused.",
+        Mechanic::ExtraDamageForEachHeadsSelfStatus {
+            num_coins: 3,
+            damage_per_head: 60,
+            status: StatusCondition::Confused,
+        },
+    );
     map.insert(
         "Flip 4 coins. This attack does 20 damage for each heads.",
         Mechanic::ExtraDamageForEachHeads {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -58,6 +58,8 @@ mod crawdaunt_unruly_claw_test;
 mod darkrai_ex_test;
 #[path = "pokemon/dragonair_dragons_blessing_test.rs"]
 mod dragonair_dragons_blessing_test;
+#[path = "pokemon/drapion_a2_test.rs"]
+mod drapion_a2_test;
 #[path = "pokemon/durant_test.rs"]
 mod durant_test;
 #[path = "pokemon/dusknoir_shadow_void_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -14,6 +14,8 @@ mod applin_share_test;
 mod arceus_ex_test;
 #[path = "pokemon/audino_test.rs"]
 mod audino_test;
+#[path = "pokemon/bellossom_a4_test.rs"]
+mod bellossom_a4_test;
 #[path = "pokemon/blastoise_double_splash_test.rs"]
 mod blastoise_double_splash_test;
 #[path = "pokemon/bombirdier_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -2,6 +2,8 @@
 mod additional_ability_logic_test;
 #[path = "pokemon/alcremie_test.rs"]
 mod alcremie_test;
+#[path = "pokemon/alolan_marowak_test.rs"]
+mod alolan_marowak_test;
 #[path = "pokemon/alolan_sandslash_spike_armor_test.rs"]
 mod alolan_sandslash_spike_armor_test;
 #[path = "pokemon/altaria_dragon_arcana_test.rs"]
@@ -132,6 +134,8 @@ mod legacy_ability_logic_test;
 mod lucario_b3_test;
 #[path = "pokemon/lucario_fighting_coach_test.rs"]
 mod lucario_fighting_coach_test;
+#[path = "pokemon/lugia_b2_test.rs"]
+mod lugia_b2_test;
 #[path = "pokemon/lunala_ex_test.rs"]
 mod lunala_ex_test;
 #[path = "pokemon/magneton_test.rs"]
@@ -206,6 +210,8 @@ mod roaring_moon_test;
 mod rotom_ex_junk_spark_test;
 #[path = "pokemon/salamence_test.rs"]
 mod salamence_test;
+#[path = "pokemon/sandslash_fury_swipes_test.rs"]
+mod sandslash_fury_swipes_test;
 #[path = "pokemon/sawk_test.rs"]
 mod sawk_test;
 #[path = "pokemon/shinx_hide_test.rs"]
@@ -250,6 +256,8 @@ mod vulpix_tail_whip_test;
 mod wailord_ex_wondrous_waves_test;
 #[path = "pokemon/wailord_test.rs"]
 mod wailord_test;
+#[path = "pokemon/wugtrio_b2a_test.rs"]
+mod wugtrio_b2a_test;
 #[path = "pokemon/xerneas_geoburst_test.rs"]
 mod xerneas_geoburst_test;
 #[path = "pokemon/zarude_dark_vengeance_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -8,6 +8,8 @@ mod alolan_marowak_test;
 mod alolan_sandslash_spike_armor_test;
 #[path = "pokemon/altaria_dragon_arcana_test.rs"]
 mod altaria_dragon_arcana_test;
+#[path = "pokemon/ambipom_b1_test.rs"]
+mod ambipom_b1_test;
 #[path = "pokemon/applin_share_test.rs"]
 mod applin_share_test;
 #[path = "pokemon/arceus_ex_test.rs"]

--- a/tests/pokemon/alolan_marowak_test.rs
+++ b/tests/pokemon/alolan_marowak_test.rs
@@ -1,0 +1,49 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_burning_bonemerang_coin_flips_damage_burn_effect_per_heads() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::A3027AlolanMarowak).with_energy(vec![
+                    EnergyType::Fire,
+                    EnergyType::Fire,
+                    EnergyType::Colorless,
+                ]),
+            ],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A3027AlolanMarowak, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // Flip 2 coins, Burning Bonemerang deals 70 damage for each heads, and if flipped at least 1 heads inflicts "burning" status to opponent's active Pokémon
+        let opponent_snorlax_remaining_hp = state.get_active(1).get_remaining_hp();
+        assert!(
+            [150, 80, 10].contains(&opponent_snorlax_remaining_hp),
+            "seed {seed }"
+        );
+        // Check for status "burned" on opponent's active Pokémon
+        assert_eq!(
+            opponent_snorlax_remaining_hp != 150,
+            state.get_active(1).is_burned(),
+            "seed {seed}"
+        );
+    }
+}

--- a/tests/pokemon/ambipom_b1_test.rs
+++ b/tests/pokemon/ambipom_b1_test.rs
@@ -1,0 +1,72 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_excited_tail_without_lucky_mittens() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B1186Ambipom)
+                .with_energy(vec![EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B1186Ambipom, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // Flip 2 coins, each heads deals 30 dmg.
+        let opponent_snorlax_remaining_hp = state.get_active(1).get_remaining_hp();
+        assert!(
+            [150, 120, 90].contains(&opponent_snorlax_remaining_hp),
+            "seed {seed }"
+        );
+    }
+}
+
+#[test]
+fn test_excited_tail_with_lucky_mittens() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B1186Ambipom)
+                .with_energy(vec![EnergyType::Colorless])
+                .with_tool(get_card_by_enum(CardId::B1220LuckyMittens))],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B1186Ambipom, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // Lucky Mittens interacts with Excited Tail causing to flip 4 coins, each heads deals 30 dmg.
+        let opponent_snorlax_remaining_hp = state.get_active(1).get_remaining_hp();
+        assert!(
+            [150, 120, 90, 60, 30].contains(&opponent_snorlax_remaining_hp),
+            "seed {seed }"
+        );
+    }
+}

--- a/tests/pokemon/bellossom_a4_test.rs
+++ b/tests/pokemon/bellossom_a4_test.rs
@@ -1,0 +1,43 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_petal_dance_coin_self_confused_and_flips_damage_per_heads() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::A4163Bellossom)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Grass])],
+            vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A4163Bellossom, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // Flip 3 coins, each heads deals 60 dmg, Bellossom is now confused.
+        let opponent_venusaur_ex_remaining_hp = state.get_active(1).get_remaining_hp();
+        assert!(
+            [190, 130, 70, 10].contains(&opponent_venusaur_ex_remaining_hp),
+            "seed {seed }"
+        );
+        // Check for Bellossom status "Confused"
+        assert!(
+            state.get_active(0).is_confused(),
+            "seed {seed}: Petal Dance should always confuse whos attacking"
+        );
+    }
+}

--- a/tests/pokemon/drapion_a2_test.rs
+++ b/tests/pokemon/drapion_a2_test.rs
@@ -1,0 +1,47 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_cross_poison_coin_flips_damage_per_heads_poison_effect() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::A2106Drapion).with_energy(vec![
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+            ])],
+            vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A2106Drapion, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // Flip 4 coins, each heads deals 40 dmg, if at least 2 heads happened opponent's active Pokémon becomes Poisoned
+        let opponent_venusaur_ex_remaining_hp = state.get_active(1).get_remaining_hp();
+        assert!(
+            [190, 150, 110, 70, 30].contains(&opponent_venusaur_ex_remaining_hp),
+            "seed {seed }"
+        );
+        // Check for status "Poisoned" on opponent's active Pokémon
+        assert_eq!(
+            opponent_venusaur_ex_remaining_hp <= 110,
+            state.get_active(1).is_poisoned(),
+            "seed {seed}"
+        );
+    }
+}

--- a/tests/pokemon/lugia_b2_test.rs
+++ b/tests/pokemon/lugia_b2_test.rs
@@ -1,0 +1,42 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_lugia_aeroblast_added_damage_per_heads() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B2131Lugia).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ])],
+            vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B2131Lugia, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // For every heads for 2 coin flips, Aeroblast deals 40* damage each plus 80 base damage
+        let opponent_venusaur_ex_remaining_hp = state.get_active(1).get_remaining_hp();
+        assert!(
+            opponent_venusaur_ex_remaining_hp >= 30 || opponent_venusaur_ex_remaining_hp <= 110,
+            "seed {seed}"
+        );
+    }
+}

--- a/tests/pokemon/sandslash_fury_swipes_test.rs
+++ b/tests/pokemon/sandslash_fury_swipes_test.rs
@@ -1,0 +1,39 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_sandslash_fury_swipes_heads_or_nothing() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::B2078Sandslash).with_energy(vec![EnergyType::Fighting])
+            ],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B2078Sandslash, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // For every heads for 3 coin flips, Fury Sipes deals 30* damage each
+        let opponent_snorlax_remaining_hp = state.get_active(1).get_remaining_hp();
+        assert!(
+            opponent_snorlax_remaining_hp >= 60 || opponent_snorlax_remaining_hp <= 150,
+            "seed {seed}"
+        );
+    }
+}

--- a/tests/pokemon/wugtrio_b2a_test.rs
+++ b/tests/pokemon/wugtrio_b2a_test.rs
@@ -1,0 +1,37 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_wugtrio_triple_whip_heads_or_nothing() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B2a026Wugtrio).with_energy(vec![EnergyType::Water])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B2a026Wugtrio, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // For every heads for 3 coin flips, Triple Whip deals 30* damage each
+        let opponent_snorlax_remaining_hp = state.get_active(1).get_remaining_hp();
+        assert!(
+            opponent_snorlax_remaining_hp >= 60 || opponent_snorlax_remaining_hp <= 150,
+            "seed {seed}"
+        );
+    }
+}


### PR DESCRIPTION
## What
Implements **coin-flip attacks with conditional effects** across 9 cards:

- **Sandslash / Wugtrio** (B2 078, B2a 026): flip 3 coins, 30 damage per heads
- **Lugia** (B2 131): flip 2 coins, +40 damage per heads (on top of base 80)
- **Alolan Marowak** (A3 027, A3 160): flip 2 coins, 70 per heads; opponent's Active is **Burned** if at least 1 heads
- **Drapion** (A2 106): flip 4 coins, 40 per heads; opponent's Active is **Poisoned** if at least 2 heads
- **Bellossom** (A4 003, A4 163): flip 3 coins, 60 per heads; **this Pokémon** is Confused
- **Ambipom** (B1 186): flip 2 coins, 30 per heads; **flip 4 coins instead** if Lucky Mittens is attached

## How
- Reused the existing `ExtraDamageForEachHeads` mechanic for the plain per-heads variants (Sandslash/Wugtrio, Lugia)
- New mechanic `ExtraDamageForEachHeadsWithStatusAtLeast { num_coins, damage_per_head, status, min_heads }` — applies a status to the opponent only when `heads >= min_heads` (covers Alolan Marowak `≥1` and Drapion `≥2`)
- New mechanic `ExtraDamageForEachHeadsSelfStatus { num_coins, damage_per_head, status }` — applies a status to the **attacker** (Bellossom)
- New mechanic `ExtraDamageForEachHeadsWithToolBoost { num_coins, damage_per_head, boosted_num_coins, tool: CardId }` — the **first mechanic to carry a `CardId`**: checks `has_tool` at forecast time to switch the coin count (Ambipom + Lucky Mittens)
- Wired effect texts in `src/actions/effect_mechanic_map.rs` (one entry per effect text covers all card versions)

## Tests
- TDD at the public `Game` API level: `tests/pokemon/{sandslash_fury_swipes,wugtrio_b2a,lugia_b2,alolan_marowak,drapion_a2,bellossom_a4,ambipom_b1}_test.rs`
- Seed-loops (`0..50`) assert damage ranges and the **logical equivalence** of the conditional status (e.g. poisoned ⟺ heads ≥ 2 ⟺ damage threshold); Ambipom is tested both with and without Lucky Mittens
- `cargo test --features test-utils --test pokemon`: 347 passed
- `cargo clippy` and `cargo fmt`: clean
- `cargo run --bin card_test` for all 7 effect texts: simulations complete without errors