### PR TITLE
Implement 7 card skills: Eelektross, Hydrapple, Luxray, Sylveon, Porygon2, Abomasnow, Mamoswine

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -69,6 +69,10 @@ pub enum AbilityMechanic {
         amount: u32,
         only_turn_energy: bool,
     },
+    /// Porygon2's Buggy Evolution: "Whenever you attach an Energy from your Energy Zone to this
+    /// Pokémon, put a random card from your deck that evolves from this Pokémon onto this
+    /// Pokémon to evolve it."
+    EvolveFromDeckOnZoneEnergyAttachToSelf,
     AttachEnergyFromDiscardToSelfAndDamage {
         energy_type: EnergyType,
         self_damage: u32,

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -13,6 +13,11 @@ pub enum AbilityMechanic {
     HealOneYourPokemon {
         amount: u32,
     },
+    /// Sylveon's Soothing Ribbon: "Once during your turn, if this Pokémon has a Pokémon Tool
+    /// attached, you may heal `amount` damage from 1 of your Pokémon."
+    HealOneYourPokemonIfHasTool {
+        amount: u32,
+    },
     HealOneYourPokemonExAndDiscardRandomEnergy {
         amount: u32,
     },

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -90,6 +90,12 @@ pub enum AbilityMechanic {
     ReduceDamageFromAttacksIfArceusInPlay {
         amount: u32,
     },
+    /// Abomasnow's Vigor Link: "If you have Arceus or Arceus ex in play, attacks used by this
+    /// Pokémon cost `amount` less [C] Energy." Depends on the board, so it's resolved in
+    /// `hooks::get_attack_cost` rather than being a plain `CardEffect`.
+    ReduceAttackCostIfArceusInPlay {
+        amount: u8,
+    },
     ReduceOpponentActiveDamage {
         amount: u32,
     },

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -96,6 +96,13 @@ pub enum AbilityMechanic {
     ReduceAttackCostIfArceusInPlay {
         amount: u8,
     },
+    /// Mamoswine's Thick Fat: "This Pokémon takes `amount` less damage from attacks from
+    /// Pokémon of any of `attacker_types`." Depends on the attacker's type, so it's resolved in
+    /// `hooks::modify_damage` rather than being a plain `CardEffect`.
+    ReduceDamageFromAttacksByAttackerType {
+        amount: u32,
+        attacker_types: Vec<EnergyType>,
+    },
     ReduceOpponentActiveDamage {
         amount: u32,
     },

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -106,6 +106,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::DamageOpponentActiveOnZoneAttachToSelf { .. } => {
             panic!("DamageOpponentActiveOnZoneAttachToSelf is a passive ability")
         }
+        AbilityMechanic::EvolveFromDeckOnZoneEnergyAttachToSelf => {
+            panic!("EvolveFromDeckOnZoneEnergyAttachToSelf is a passive ability")
+        }
         AbilityMechanic::AttachEnergyFromDiscardToSelfAndDamage {
             energy_type,
             self_damage,

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -46,6 +46,7 @@ fn forecast_ability_by_mechanic(
             energy_type,
         } => heal_all_your_pokemon(*amount, *energy_type),
         AbilityMechanic::HealOneYourPokemon { amount } => heal_one_your_pokemon(*amount),
+        AbilityMechanic::HealOneYourPokemonIfHasTool { amount } => heal_one_your_pokemon(*amount),
         AbilityMechanic::HealOneYourPokemonExAndDiscardRandomEnergy { amount } => {
             heal_one_your_pokemon_ex_and_discard_random_energy(*amount)
         }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -136,6 +136,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::ReduceAttackCostIfArceusInPlay { .. } => {
             panic!("ReduceAttackCostIfArceusInPlay is a passive ability")
         }
+        AbilityMechanic::ReduceDamageFromAttacksByAttackerType { .. } => {
+            panic!("ReduceDamageFromAttacksByAttackerType is a passive ability")
+        }
         AbilityMechanic::ReduceOpponentActiveDamage { .. } => {
             panic!("ReduceOpponentActiveDamage is a passive ability")
         }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -133,6 +133,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::ReduceDamageFromAttacksIfArceusInPlay { .. } => {
             panic!("ReduceDamageFromAttacksIfArceusInPlay is a passive ability")
         }
+        AbilityMechanic::ReduceAttackCostIfArceusInPlay { .. } => {
+            panic!("ReduceAttackCostIfArceusInPlay is a passive ability")
+        }
         AbilityMechanic::ReduceOpponentActiveDamage { .. } => {
             panic!("ReduceOpponentActiveDamage is a passive ability")
         }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -573,9 +573,19 @@ fn forecast_effect_attack_by_mechanic(
             extra_damage_per_retreat_cost(state, attack.fixed_damage, *damage_per_energy)
         }
         Mechanic::DamagePerEnergyAll {
+            include_fixed_damage,
             opponent,
             damage_per_energy,
-        } => damage_per_energy_all(state, *opponent, *damage_per_energy),
+        } => damage_per_energy_all(
+            state,
+            if *include_fixed_damage {
+                attack.fixed_damage
+            } else {
+                0
+            },
+            *opponent,
+            *damage_per_energy,
+        ),
         Mechanic::DamageToAnyOpponentPerTargetEnergy { damage_per_energy } => {
             damage_to_any_opponent_per_target_energy(*damage_per_energy)
         }
@@ -2762,7 +2772,12 @@ fn extra_damage_per_retreat_cost(
     active_damage_doutcome(damage)
 }
 
-fn damage_per_energy_all(state: &State, opponent: bool, damage_per_energy: u32) -> AttackOutcomes {
+fn damage_per_energy_all(
+    state: &State,
+    base_damage: u32,
+    opponent: bool,
+    damage_per_energy: u32,
+) -> AttackOutcomes {
     let target = if opponent {
         (state.current_player + 1) % 2
     } else {
@@ -2773,7 +2788,7 @@ fn damage_per_energy_all(state: &State, opponent: bool, damage_per_energy: u32) 
         .flatten()
         .map(|pokemon| pokemon.get_effective_attached_energy(state, target).len() as u32)
         .sum();
-    let damage = total_energy * damage_per_energy;
+    let damage = base_damage + total_energy * damage_per_energy;
     active_damage_doutcome(damage)
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -771,6 +771,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamagePerOwnPoint { damage_per_point } => {
             extra_damage_per_own_point_attack(state, attack.fixed_damage, *damage_per_point)
         }
+        Mechanic::ExtraDamagePerOpponentPoint { damage_per_point } => {
+            extra_damage_per_opponent_point_attack(state, attack.fixed_damage, *damage_per_point)
+        }
         Mechanic::ExtraDamageIfCardInDiscard {
             card_name,
             extra_damage,
@@ -3950,6 +3953,18 @@ fn extra_damage_per_own_point_attack(
     damage_per_point: u32,
 ) -> AttackOutcomes {
     let points = state.points[state.current_player] as u32;
+    let total_damage = base_damage + (points * damage_per_point);
+    active_damage_doutcome(total_damage)
+}
+
+/// Luxray's Revenge Blast: Extra damage per point the opponent has gotten
+fn extra_damage_per_opponent_point_attack(
+    state: &State,
+    base_damage: u32,
+    damage_per_point: u32,
+) -> AttackOutcomes {
+    let opponent = (state.current_player + 1) % 2;
+    let points = state.points[opponent] as u32;
     let total_damage = base_damage + (points * damage_per_point);
     active_damage_doutcome(total_damage)
 }

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -408,6 +408,7 @@ pub enum Mechanic {
         damage_per_energy: u32,
     },
     DamagePerEnergyAll {
+        include_fixed_damage: bool,
         opponent: bool,
         damage_per_energy: u32,
     },

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -279,6 +279,9 @@ pub enum Mechanic {
     ExtraDamagePerOwnPoint {
         damage_per_point: u32,
     },
+    ExtraDamagePerOpponentPoint {
+        damage_per_point: u32,
+    },
     ExtraDamageIfCardInDiscard {
         card_name: String,
         extra_damage: u32,

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -413,7 +413,13 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             AbilityMechanic::ReduceDamageFromAttacks { amount: 20 },
         );
         // map.insert("This Pokémon takes -30 damage from attacks from [F] Pokémon.", todo_implementation);
-        // map.insert("This Pokémon takes -30 damage from attacks from [R] or [W] Pokémon.", todo_implementation);
+        map.insert(
+            "This Pokémon takes -30 damage from attacks from [R] or [W] Pokémon.",
+            AbilityMechanic::ReduceDamageFromAttacksByAttackerType {
+                amount: 30,
+                attacker_types: vec![EnergyType::Fire, EnergyType::Water],
+            },
+        );
         // map.insert("When this Pokémon is Knocked Out, flip a coin. If heads, your opponent can't get any points for it.", todo_implementation);
         map.insert(
             "When this Pokémon is first damaged by an attack after coming into play, prevent that damage.",

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -169,7 +169,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "If this Pokémon would be Knocked Out by damage from an attack, flip a coin. If heads, this Pokémon is not Knocked Out, and its remaining HP becomes 10.",
             AbilityMechanic::CoinFlipToSurviveKnockOut,
         );
-        // map.insert("If you have Arceus or Arceus ex in play, attacks used by this Pokémon cost 1 less [C] Energy.", todo_implementation);
+        map.insert(
+            "If you have Arceus or Arceus ex in play, attacks used by this Pokémon cost 1 less [C] Energy.",
+            AbilityMechanic::ReduceAttackCostIfArceusInPlay { amount: 1 },
+        );
         map.insert(
             "If you have Arceus or Arceus ex in play, attacks used by this Pokémon do +30 damage to your opponent's Active Pokémon.",
             AbilityMechanic::IncreaseDamageIfArceusInPlay { amount: 30 },

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -189,6 +189,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "Once during your turn, if this Pokémon is in the Active Spot, you may heal 30 damage from 1 of your Pokémon.",
             AbilityMechanic::HealOneYourPokemon { amount: 30 },
         );
+        map.insert(
+            "Once during your turn, if this Pokémon has a Pokémon Tool attached, you may heal 30 damage from 1 of your Pokémon.",
+            AbilityMechanic::HealOneYourPokemonIfHasTool { amount: 30 },
+        );
         // map.insert("Once during your turn, if this Pokémon is in the Active Spot, you may look at a random Supporter card from your opponent's hand. Use the effect of that card as the effect of this Ability.", todo_implementation);
         map.insert("Once during your turn, if this Pokémon is in the Active Spot, you may make your opponent's Active Pokémon Poisoned.", AbilityMechanic::PoisonOpponentActive);
         map.insert(

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -431,7 +431,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
                 amount: 20,
             },
         );
-        // map.insert("Whenever you attach an Energy from your Energy Zone to this Pokémon, put a random card from your deck that evolves from this Pokémon onto this Pokémon to evolve it.", todo_implementation);
+        map.insert(
+            "Whenever you attach an Energy from your Energy Zone to this Pokémon, put a random card from your deck that evolves from this Pokémon onto this Pokémon to evolve it.",
+            AbilityMechanic::EvolveFromDeckOnZoneEnergyAttachToSelf,
+        );
         map.insert(
             "You must discard a card from your hand in order to use this Ability. Once during your turn, you may draw a card.",
             AbilityMechanic::DiscardFromHandToDrawCard,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -488,6 +488,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Flip 2 coins. If both of them are heads, this attack does 80 more damage.",
         Mechanic::ExtraDamageIfBothHeads { extra_damage: 80 },
     );
+    map.insert(
+        "Flip 2 coins. If both of them are heads, this attack does 100 more damage.",
+        Mechanic::ExtraDamageIfBothHeads { extra_damage: 100 },
+    );
     // map.insert("Flip 2 coins. If both of them are heads, your opponent's Active Pokémon is Knocked Out.", todo_implementation);
     // map.insert("Flip 2 coins. If both of them are tails, this attack does nothing.", todo_implementation);
     map.insert(

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2175,6 +2175,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per_point: 30,
         },
     );
+    map.insert(
+        "This attack does 50 more damage for each point your opponent has gotten.",
+        Mechanic::ExtraDamagePerOpponentPoint {
+            damage_per_point: 50,
+        },
+    );
 
     // B3 Mechanics
     // map.insert("1 attack from among the Pokémon in your opponent's hand and deck is chosen at random, and you use the chosen attack as this attack.", todo_implementation);

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1511,6 +1511,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     map.insert(
         "This attack does 20 damage for each Energy attached to all of your opponent's Pokémon.",
         Mechanic::DamagePerEnergyAll {
+            include_fixed_damage: false,
+            opponent: true,
+            damage_per_energy: 20,
+        },
+    );
+    map.insert(
+        "This attack does 20 more damage for each Energy attached to all of your opponent's Pokémon.",
+        Mechanic::DamagePerEnergyAll {
+            include_fixed_damage: true,
             opponent: true,
             damage_per_energy: 20,
         },

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -644,6 +644,7 @@ fn get_ability_damage_reduction(
     state: &State,
     target_player: usize,
     receiving_pokemon: &crate::models::PlayedCard,
+    attacking_pokemon: &crate::models::PlayedCard,
     is_from_active_attack: bool,
 ) -> u32 {
     if !is_from_active_attack {
@@ -672,7 +673,23 @@ fn get_ability_damage_reduction(
         _ => 0,
     };
 
-    effect_reduction + arceus_reduction
+    // Mamoswine's Thick Fat depends on the attacker's type, so it can't be derived as a
+    // CardEffect from the card alone.
+    let attacker_type_reduction = match get_ability_mechanic(&receiving_pokemon.card) {
+        Some(AbilityMechanic::ReduceDamageFromAttacksByAttackerType {
+            amount,
+            attacker_types,
+        }) if attacking_pokemon
+            .get_energy_type()
+            .is_some_and(|t| attacker_types.contains(&t)) =>
+        {
+            debug!("Thick Fat: Reducing damage by {}", amount);
+            *amount
+        }
+        _ => 0,
+    };
+
+    effect_reduction + arceus_reduction + attacker_type_reduction
 }
 
 /// Whether `player` has Arceus or Arceus ex in play (Active or Benched).
@@ -1136,6 +1153,7 @@ pub(crate) fn modify_damage(
             state,
             target_player,
             receiving_pokemon,
+            attacking_pokemon,
             is_from_active_attack,
         )
     };

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -1380,8 +1380,31 @@ pub(crate) fn get_attack_cost(
     }
 
     modified_cost = future_system_cost(modified_cost, state, attacking_player);
+    modified_cost = vigor_link_cost(modified_cost, state, attacking_player);
 
     modified_cost
+}
+
+/// Abomasnow's Vigor Link: "If you have Arceus or Arceus ex in play, attacks used by this
+/// Pokémon cost 1 less [C] Energy."
+fn vigor_link_cost(mut cost: Vec<EnergyType>, state: &State, player: usize) -> Vec<EnergyType> {
+    let Some(active) = state.in_play_pokemon[player][0].as_ref() else {
+        return cost;
+    };
+    let reduction = match get_ability_mechanic(&active.card) {
+        Some(AbilityMechanic::ReduceAttackCostIfArceusInPlay { amount })
+            if has_arceus_in_play(state, player) =>
+        {
+            *amount
+        }
+        _ => 0,
+    };
+    for _ in 0..reduction {
+        if let Some(pos) = cost.iter().position(|e| *e == EnergyType::Colorless) {
+            cost.remove(pos);
+        }
+    }
+    cost
 }
 
 fn future_system_cost(mut cost: Vec<EnergyType>, state: &State, player: usize) -> Vec<EnergyType> {

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -57,6 +57,9 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::HealOneYourPokemon { .. } => {
             is_active && can_use_espeon_ex_psychic_healing(state, card)
         }
+        AbilityMechanic::HealOneYourPokemonIfHasTool { .. } => {
+            can_use_sylveon_soothing_ribbon(state, card)
+        }
         AbilityMechanic::HealOneYourPokemonExAndDiscardRandomEnergy { .. } => {
             can_use_heal_one_your_pokemon_ex_and_discard_random_energy(state, card)
         }
@@ -376,6 +379,15 @@ fn can_use_victreebel_fragrance_trap(state: &State, card: &PlayedCard) -> bool {
 
 fn can_use_espeon_ex_psychic_healing(state: &State, card: &PlayedCard) -> bool {
     if card.ability_used {
+        return false;
+    }
+    state
+        .enumerate_in_play_pokemon(state.current_player)
+        .any(|(_, pokemon)| pokemon.is_damaged())
+}
+
+fn can_use_sylveon_soothing_ribbon(state: &State, card: &PlayedCard) -> bool {
+    if card.ability_used || !card.has_tool_attached() {
         return false;
     }
     state

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -94,6 +94,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::AttachEnergyFromZoneToSelfAndEndTurn { .. } => !card.ability_used,
         AbilityMechanic::AttachEnergyFromZoneToSelfAndDamage { .. } => !card.ability_used,
         AbilityMechanic::DamageOpponentActiveOnZoneAttachToSelf { .. } => false,
+        AbilityMechanic::EvolveFromDeckOnZoneEnergyAttachToSelf => false,
         AbilityMechanic::AttachEnergyFromDiscardToSelfAndDamage { energy_type, .. } => {
             !card.ability_used && state.discard_energies[state.current_player].contains(energy_type)
         }

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -103,6 +103,7 @@ fn can_use_ability_by_mechanic(
         }
         AbilityMechanic::ReduceDamageFromAttacks { .. } => false,
         AbilityMechanic::ReduceDamageFromAttacksIfArceusInPlay { .. } => false,
+        AbilityMechanic::ReduceAttackCostIfArceusInPlay { .. } => false,
         AbilityMechanic::ReduceOpponentActiveDamage { .. } => false,
         AbilityMechanic::IncreaseDamageWhenRemainingHpAtMost { .. } => false,
         AbilityMechanic::IncreaseDamageForTypeInPlay { .. } => false,

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -104,6 +104,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::ReduceDamageFromAttacks { .. } => false,
         AbilityMechanic::ReduceDamageFromAttacksIfArceusInPlay { .. } => false,
         AbilityMechanic::ReduceAttackCostIfArceusInPlay { .. } => false,
+        AbilityMechanic::ReduceDamageFromAttacksByAttackerType { .. } => false,
         AbilityMechanic::ReduceOpponentActiveDamage { .. } => false,
         AbilityMechanic::IncreaseDamageWhenRemainingHpAtMost { .. } => false,
         AbilityMechanic::IncreaseDamageForTypeInPlay { .. } => false,

--- a/src/state/energy.rs
+++ b/src/state/energy.rs
@@ -1,10 +1,10 @@
 use crate::{
     actions::{
-        abilities::AbilityMechanic, ability_mechanic_from_effect, get_ability_mechanic,
-        handle_damage_only, handle_knockouts,
+        abilities::AbilityMechanic, ability_mechanic_from_effect, apply_evolve,
+        get_ability_mechanic, handle_damage_only, handle_knockouts,
     },
     effects::TurnEffect,
-    hooks::DamageModifierContext,
+    hooks::{can_evolve_into, DamageModifierContext},
     models::{EnergyType, StatusCondition},
     State,
 };
@@ -173,6 +173,32 @@ impl State {
                     .expect("Pokemon should be there if attaching energy to it");
                 pokemon.heal(20);
             }
+
+            // Check for Porygon2's Buggy Evolution ability
+            if matches!(
+                mechanic,
+                AbilityMechanic::EvolveFromDeckOnZoneEnergyAttachToSelf
+            ) && from_zone
+            {
+                self.evolve_from_deck_on_self(actor, in_play_idx);
+            }
         }
+    }
+
+    fn evolve_from_deck_on_self(&mut self, actor: usize, in_play_idx: usize) {
+        let holder = self.in_play_pokemon[actor][in_play_idx]
+            .as_ref()
+            .expect("Pokemon should be there if evolving it");
+        // The deck is already randomly ordered from prior shuffles, so the first matching card
+        // is as good as a random pick; `apply_evolve` (from_deck: true) removes it from the deck.
+        let Some(evolution_card) = self.decks[actor]
+            .cards
+            .iter()
+            .find(|card| can_evolve_into(card, holder))
+            .cloned()
+        else {
+            return;
+        };
+        apply_evolve(actor, self, &evolution_card, in_play_idx, true);
     }
 }

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -1,3 +1,5 @@
+#[path = "pokemon/abomasnow_vigor_link_test.rs"]
+mod abomasnow_vigor_link_test;
 #[path = "pokemon/additional_ability_logic_test.rs"]
 mod additional_ability_logic_test;
 #[path = "pokemon/alcremie_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -232,6 +232,8 @@ mod spewpa_signs_of_evolution_test;
 mod sunflora_quick_grow_beam_test;
 #[path = "pokemon/swift_shot_test.rs"]
 mod swift_shot_test;
+#[path = "pokemon/sylveon_soothing_ribbon_test.rs"]
+mod sylveon_soothing_ribbon_test;
 #[path = "pokemon/tandemaus_b2_test.rs"]
 mod tandemaus_b2_test;
 #[path = "pokemon/tapu_lele_energy_arrow_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -190,6 +190,8 @@ mod persian_test;
 mod pidgeot_twister_test;
 #[path = "pokemon/politoed_raid_test.rs"]
 mod politoed_raid_test;
+#[path = "pokemon/porygon2_buggy_evolution_test.rs"]
+mod porygon2_buggy_evolution_test;
 #[path = "pokemon/porygonz_buggy_beam_test.rs"]
 mod porygonz_buggy_beam_test;
 #[path = "pokemon/porygonz_cyberjack_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -100,6 +100,8 @@ mod ho_oh_ex_phoenix_turbo_test;
 mod honchkrow_evil_admonition_test;
 #[path = "pokemon/houndstone_last_respects_test.rs"]
 mod houndstone_last_respects_test;
+#[path = "pokemon/hydrapple_fickle_beam_test.rs"]
+mod hydrapple_fickle_beam_test;
 #[path = "pokemon/iron_bundle_ex_test.rs"]
 mod iron_bundle_ex_test;
 #[path = "pokemon/iron_bundle_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -64,6 +64,8 @@ mod dusknoir_shadow_void_test;
 mod dustox_select_powder_test;
 #[path = "pokemon/dustox_variety_powder_test.rs"]
 mod dustox_variety_powder_test;
+#[path = "pokemon/eelektross_energy_crush_test.rs"]
+mod eelektross_energy_crush_test;
 #[path = "pokemon/emboar_flare_storm_test.rs"]
 mod emboar_flare_storm_test;
 #[path = "pokemon/emolga_dedenne_ex_tool_damage_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -136,6 +136,8 @@ mod lucario_b3_test;
 mod lucario_fighting_coach_test;
 #[path = "pokemon/lunala_ex_test.rs"]
 mod lunala_ex_test;
+#[path = "pokemon/luxray_revenge_blast_test.rs"]
+mod luxray_revenge_blast_test;
 #[path = "pokemon/magneton_test.rs"]
 mod magneton_test;
 #[path = "pokemon/magnezone_mirror_shot_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -148,6 +148,8 @@ mod magneton_test;
 mod magnezone_mirror_shot_test;
 #[path = "pokemon/magnezone_resilience_link_test.rs"]
 mod magnezone_resilience_link_test;
+#[path = "pokemon/mamoswine_thick_fat_test.rs"]
+mod mamoswine_thick_fat_test;
 #[path = "pokemon/marshadow_revenge_test.rs"]
 mod marshadow_revenge_test;
 #[path = "pokemon/maushold_b2a_test.rs"]

--- a/tests/pokemon/abomasnow_vigor_link_test.rs
+++ b/tests/pokemon/abomasnow_vigor_link_test.rs
@@ -1,0 +1,42 @@
+use deckgym::{
+    actions::SimpleAction,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::get_test_game_with_board,
+};
+
+/// Abomasnow's Vigor Link: "If you have Arceus or Arceus ex in play, attacks used by this
+/// Pokémon cost 1 less [C] Energy." Mega Punch normally needs [W][W][C]; with the discount it
+/// should be usable with just [W][W].
+#[test]
+fn test_abomasnow_vigor_link_discounts_attack_cost_with_arceus_in_play() {
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A2a021Abomasnow)
+                .with_energy(vec![EnergyType::Water, EnergyType::Water]),
+            PlayedCard::from_id(CardId::A2a071ArceusEx),
+        ],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(choices
+        .iter()
+        .any(|choice| matches!(&choice.action, SimpleAction::Attack(attack) if attack.title == "Mega Punch")));
+}
+
+#[test]
+fn test_abomasnow_vigor_link_no_discount_without_arceus() {
+    let game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A2a021Abomasnow)
+            .with_energy(vec![EnergyType::Water, EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(!choices
+        .iter()
+        .any(|choice| matches!(&choice.action, SimpleAction::Attack(attack) if attack.title == "Mega Punch")));
+}

--- a/tests/pokemon/eelektross_energy_crush_test.rs
+++ b/tests/pokemon/eelektross_energy_crush_test.rs
@@ -1,0 +1,47 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+#[test]
+fn test_eelektross_energy_crush_scales_with_all_opponent_energy() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4058Eelektross)
+            .with_energy(vec![EnergyType::Lightning, EnergyType::Colorless])],
+        vec![
+            PlayedCard::from_id(CardId::B2b111MegaCharizardXEx)
+                .with_energy(vec![EnergyType::Fire, EnergyType::Fire]),
+            PlayedCard::from_id(CardId::A1033Charmander).with_energy(vec![EnergyType::Fire]),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4058Eelektross, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // Base 50 damage + 20 more damage per Energy across all opponent's Pokemon (3 total) = 110
+    assert_eq!(state.get_active(1).get_remaining_hp(), 220 - 110);
+}
+
+#[test]
+fn test_eelektross_energy_crush_base_damage_when_opponent_has_no_energy() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4058Eelektross)
+            .with_energy(vec![EnergyType::Lightning, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::B2b111MegaCharizardXEx)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4058Eelektross, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 220 - 50);
+}

--- a/tests/pokemon/hydrapple_fickle_beam_test.rs
+++ b/tests/pokemon/hydrapple_fickle_beam_test.rs
@@ -1,0 +1,47 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_hydrapple_fickle_beam_both_heads_deals_bonus_damage() {
+    let mut saw_base_damage = false;
+    let mut saw_bonus_damage = false;
+
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B4127Hydrapple)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Fire])],
+            vec![PlayedCard::from_id(CardId::B4037WailordEx)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B4127Hydrapple, 0),
+            is_stack: false,
+        });
+
+        let state = game.get_state_clone();
+        let damage_dealt = 250 - state.get_active(1).get_remaining_hp();
+        match damage_dealt {
+            100 => saw_base_damage = true,
+            200 => saw_bonus_damage = true,
+            other => panic!("Unexpected damage dealt: {other} (seed {seed})"),
+        }
+    }
+
+    assert!(
+        saw_base_damage,
+        "Fickle Beam should sometimes deal only its base 100 damage"
+    );
+    assert!(
+        saw_bonus_damage,
+        "Fickle Beam should sometimes deal 100 bonus damage when both coins are heads"
+    );
+}

--- a/tests/pokemon/luxray_revenge_blast_test.rs
+++ b/tests/pokemon/luxray_revenge_blast_test.rs
@@ -1,0 +1,53 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+#[test]
+fn test_luxray_revenge_blast_scales_with_opponent_points() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4053Luxray).with_energy(vec![
+            EnergyType::Lightning,
+            EnergyType::Lightning,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::B2b111MegaCharizardXEx)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.points = [0, 2];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4053Luxray, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // Base 80 damage + 50 more damage per opponent point (2 points) = 180
+    assert_eq!(state.get_active(1).get_remaining_hp(), 220 - 180);
+}
+
+#[test]
+fn test_luxray_revenge_blast_no_bonus_when_opponent_has_no_points() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4053Luxray).with_energy(vec![
+            EnergyType::Lightning,
+            EnergyType::Lightning,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::B2b111MegaCharizardXEx)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4053Luxray, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 220 - 80);
+}

--- a/tests/pokemon/mamoswine_thick_fat_test.rs
+++ b/tests/pokemon/mamoswine_thick_fat_test.rs
@@ -1,0 +1,44 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Mamoswine's Thick Fat: "This Pokémon takes -30 damage from attacks from [R] or [W] Pokémon."
+#[test]
+fn test_mamoswine_thick_fat_reduces_damage_from_fire_attacker() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1033Charmander).with_energy(vec![EnergyType::Fire])],
+        vec![PlayedCard::from_id(CardId::A2160Mamoswine)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1033Charmander, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // Ember does 30 damage; Thick Fat reduces damage from [R]/[W] attackers by 30.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 160);
+}
+
+#[test]
+fn test_mamoswine_thick_fat_no_reduction_from_non_fire_water_attacker() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A2160Mamoswine)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1001Bulbasaur, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // Vine Whip does 40 damage; Thick Fat doesn't apply to [G] attackers.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 120);
+}

--- a/tests/pokemon/porygon2_buggy_evolution_test.rs
+++ b/tests/pokemon/porygon2_buggy_evolution_test.rs
@@ -1,0 +1,62 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_test_game_with_board,
+};
+
+/// Porygon2's Buggy Evolution: "Whenever you attach an Energy from your Energy Zone to this
+/// Pokémon, put a random card from your deck that evolves from this Pokémon onto this Pokémon
+/// to evolve it."
+#[test]
+fn test_porygon2_buggy_evolution_evolves_on_zone_energy_attach() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A4136Porygon2).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.decks[0].cards = vec![get_card_by_enum(CardId::A2129PorygonZ).clone()];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attach {
+            attachments: vec![(1, EnergyType::Colorless, 0)],
+            is_turn_energy: false,
+        },
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(0).get_name(), "Porygon-Z");
+    // Energy carries over from Porygon2 plus the newly attached one.
+    assert_eq!(state.get_active(0).attached_energy.len(), 2);
+    assert!(state.decks[0].cards.is_empty());
+}
+
+#[test]
+fn test_porygon2_buggy_evolution_stays_porygon2_without_evolution_card_in_deck() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A4136Porygon2).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.decks[0].cards = vec![get_card_by_enum(CardId::A1033Charmander).clone()];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Attach {
+            attachments: vec![(1, EnergyType::Colorless, 0)],
+            is_turn_energy: false,
+        },
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(0).get_name(), "Porygon2");
+    assert_eq!(state.get_active(0).attached_energy.len(), 2);
+}

--- a/tests/pokemon/sylveon_soothing_ribbon_test.rs
+++ b/tests/pokemon/sylveon_soothing_ribbon_test.rs
@@ -1,0 +1,49 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::PlayedCard,
+    test_support::get_test_game_with_board,
+};
+
+/// Sylveon's Soothing Ribbon: "Once during your turn, if this Pokémon has a Pokémon Tool
+/// attached, you may heal 30 damage from 1 of your Pokémon."
+#[test]
+fn test_sylveon_soothing_ribbon_heals_when_tool_attached() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3b030Sylveon)
+            .with_tool(get_card_by_enum(CardId::A2148RockyHelmet))
+            .with_remaining_hp(70)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 0 },
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let heal_action = choices
+        .into_iter()
+        .find(|a| matches!(a.action, SimpleAction::Heal { in_play_idx: 0, .. }))
+        .expect("Soothing Ribbon should offer to heal Sylveon");
+    game.apply_action(&heal_action);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(0).get_remaining_hp(), 100);
+}
+
+#[test]
+fn test_sylveon_soothing_ribbon_unusable_without_tool() {
+    let game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3b030Sylveon).with_remaining_hp(70)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let (_actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(!choices
+        .iter()
+        .any(|a| matches!(a.action, SimpleAction::UseAbility { in_play_idx: 0 })));
+}


### PR DESCRIPTION
## Summary

Implements the missing attack/ability effects for the requested cards, one commit per card:

- **Eelektross (B4 058, Ruler of the Skies)** — Energy Crush: generalized the existing `DamagePerEnergyAll` mechanic with an `include_fixed_damage` flag (same shape as `ExtraDamagePerEnergy`) to cover "X more damage for each Energy attached to all of your opponent's Pokémon."
- **Hydrapple (B4 127, Ruler of the Skies)** — Fickle Beam: reused the existing `ExtraDamageIfBothHeads` mechanic.
- **Luxray (B4 053, Ruler of the Skies)** — Revenge Blast: added `ExtraDamagePerOpponentPoint`, mirroring the existing `ExtraDamagePerOwnPoint`.
- **Sylveon (B3b 030 / B3b 073, Everyday Wonders)** — Soothing Ribbon: added `HealOneYourPokemonIfHasTool`, mirroring `HealOneYourPokemon` but gated on the holder having a Pokémon Tool attached instead of being in the Active Spot.
- **Porygon2 (A4 136, Wisdom of Sea and Sky)** — Buggy Evolution: added a passive `EvolveFromDeckOnZoneEnergyAttachToSelf` mechanic wired into the existing energy-attach hook (alongside Komala's and Cresselia's self-targeted triggers). Since the deck is already randomly ordered from prior shuffles, taking the first matching evolution card is equivalent to a random pick, avoiding a wider rng-threading refactor of the energy-attach path.
- **Abomasnow (A2a 021, Triumphant Light)** — Vigor Link: added a passive `ReduceAttackCostIfArceusInPlay` mechanic wired into `hooks::get_attack_cost`, mirroring the existing Future System cost discount.
- **Mamoswine (A2 160, Space-Time Smackdown)** — Thick Fat: added a passive `ReduceDamageFromAttacksByAttackerType` mechanic; threaded the attacking Pokémon into `get_ability_damage_reduction` so the reduction can be gated on the attacker's type, mirroring how Resilience Link is gated on the board's Arceus count.

Note: Krookodile (Extradimensional Crisis, A3a 041) was already fully implemented, so no changes were needed for it.

## Test plan

- [x] Added focused `Game`-API-level tests per card under `tests/pokemon/`
- [x] `cargo test --features test-utils --test pokemon --test tools --test mechanics --test stadiums --test trainers` — all green
- [x] `cargo run --bin card_status` confirms all 8 requested cards show `✓ Complete`
- [x] `cargo fmt` and `cargo clippy --all-targets --all-features -- -D warnings` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0145SQTTK5BnQeYrLXQLGkhD

---
_Generated by [Claude Code](https://claude.ai/code/session_0145SQTTK5BnQeYrLXQLGkhD)_