### PR TITLE
Implement victini victory star

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -262,4 +262,12 @@ pub enum AbilityMechanic {
     /// Active Spot, put a random card from your deck that evolves from this Pokémon onto this
     /// Pokémon to evolve it."
     QuickGrowth,
+    /// Victini's Victory Star: "Once during your turn, after you flip any coins for an attack of
+    /// 1 of your [R] Pokémon, you may ignore all results of those coin flips and begin flipping
+    /// those coins again. You can't use more than 1 Victory Star Ability each turn."
+    ///
+    /// Reactive rather than freely activated: it is never offered by normal ability move
+    /// generation, only pushed onto the move-generation stack by `apply_action` immediately
+    /// after an eligible [R] attack's coins are flipped. See `PendingCoinReflip`.
+    VictoryStarReflip,
 }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -304,7 +304,18 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::QuickGrowth => {
             panic!("QuickGrowth is triggered at the end of the opponent's turn")
         }
+        AbilityMechanic::VictoryStarReflip => victory_star_reflip(),
     }
+}
+
+/// Victini's Victory Star, chosen from the reflip prompt: discard the parked coin result and
+/// resolve the same attack again with fresh, independent coins.
+fn victory_star_reflip() -> Outcomes {
+    Outcomes::single_fn(move |rng, state, _action| {
+        if let Some(pending) = state.take_pending_coin_reflip() {
+            crate::actions::resolve_pending_coin_reflip(rng, state, pending, true);
+        }
+    })
 }
 
 fn discard_energy_to_increase_type_damage(

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -15,7 +15,7 @@ use crate::{
         get_retreat_cost, on_bench_from_hand, on_evolve, to_playable_card, DamageModifierContext,
     },
     models::{Card, EnergyType},
-    state::State,
+    state::{PendingCoinReflip, State},
     tools,
 };
 
@@ -35,7 +35,27 @@ use super::{
 /// and then chooses one of them to apply. This is so that bot implementations can re-use the
 /// `forecast_action` function.
 pub fn apply_action(rng: &mut StdRng, state: &mut State, action: &Action) {
-    let (probabilities, mut lazy_mutations) = forecast_action(state, action).into_branches();
+    let outcomes = forecast_action(state, action);
+
+    // Victini's Victory Star: if this is an eligible [R] coin-flip attack, sample the coins now
+    // but park the result instead of committing it, and let the player choose whether to re-flip.
+    if let Some(pending) = maybe_defer_for_victory_star(rng, state, action, &outcomes) {
+        let victini_idx = pending.victini_idx;
+        let actor = pending.actor;
+        state.set_pending_coin_reflip(pending);
+        state.move_generation_stack.push((
+            actor,
+            vec![
+                SimpleAction::Noop,
+                SimpleAction::UseAbility {
+                    in_play_idx: victini_idx,
+                },
+            ],
+        ));
+        return;
+    }
+
+    let (probabilities, mut lazy_mutations) = outcomes.into_branches();
     if probabilities.len() == 1 {
         lazy_mutations.remove(0)(rng, state, action);
     } else {
@@ -43,6 +63,103 @@ pub fn apply_action(rng: &mut StdRng, state: &mut State, action: &Action) {
         let chosen_index = dist.sample(rng);
         lazy_mutations.remove(chosen_index)(rng, state, action);
     }
+}
+
+/// Decides whether `action` should pause for a Victory Star decision, and if so pre-rolls the
+/// coins so the player is choosing with knowledge of the result (as the real card allows).
+///
+/// Returns `None` — meaning "resolve normally" — unless all of the following hold:
+///   - the action is an `Attack` that is not itself a stacked follow-up,
+///   - the attacking Pokémon is `[R]` (Fire),
+///   - the attack's outcomes actually involve coin flips,
+///   - the acting player has an unused Victini in play,
+///   - no reflip decision is already pending.
+fn maybe_defer_for_victory_star(
+    rng: &mut StdRng,
+    state: &State,
+    action: &Action,
+    outcomes: &Outcomes,
+) -> Option<PendingCoinReflip> {
+    let attack = match &action.action {
+        SimpleAction::Attack(attack) if !action.is_stack => attack,
+        _ => return None,
+    };
+    if state.pending_coin_reflip.is_some() {
+        return None;
+    }
+    if !outcomes.has_coin_flips() {
+        return None;
+    }
+    let attacker_is_fire = state.in_play_pokemon[action.actor][0]
+        .as_ref()
+        .and_then(|pokemon| pokemon.card.get_type())
+        .is_some_and(|energy_type| energy_type == EnergyType::Fire);
+    if !attacker_is_fire {
+        return None;
+    }
+    let victini_idx = state.available_victory_star_idx(action.actor)?;
+
+    // Roll the coins now; the chosen branch's sequence is what the player sees and may reject.
+    let original_flips = sample_coin_sequence(rng, outcomes)?;
+
+    Some(PendingCoinReflip {
+        actor: action.actor,
+        attack: attack.clone(),
+        original_flips,
+        victini_idx,
+    })
+}
+
+/// Samples a branch from `outcomes` by probability and returns its coin sequence.
+fn sample_coin_sequence(rng: &mut StdRng, outcomes: &Outcomes) -> Option<Vec<bool>> {
+    let probabilities = outcomes.branch_probabilities();
+    let chosen_index = if probabilities.len() == 1 {
+        0
+    } else {
+        WeightedIndex::new(&probabilities).ok()?.sample(rng)
+    };
+    outcomes.coin_sequence_at(chosen_index)
+}
+
+/// Resolves a parked Victory Star decision by re-forecasting the stored attack and either
+/// replaying the original coin sequence (`reflip == false`) or committing a fresh, independent
+/// roll (`reflip == true`).
+pub(crate) fn resolve_pending_coin_reflip(
+    rng: &mut StdRng,
+    state: &mut State,
+    pending: PendingCoinReflip,
+    reflip: bool,
+) {
+    let attack_action = Action {
+        actor: pending.actor,
+        action: SimpleAction::Attack(pending.attack.clone()),
+        is_stack: false,
+    };
+
+    if reflip {
+        state.mark_victory_star_used(pending.actor);
+    }
+
+    let outcomes = forecast_action(state, &attack_action);
+    let (probabilities, mut lazy_mutations) = if reflip {
+        // Fresh coins: resolve the re-forecast attack normally.
+        outcomes.into_branches()
+    } else {
+        // Declined: replay exactly what was already flipped.
+        match outcomes.force_sequence(&pending.original_flips) {
+            Ok(forced) => forced.into_branches(),
+            Err(original) => original.into_branches(),
+        }
+    };
+
+    let chosen_index = if probabilities.len() == 1 {
+        0
+    } else {
+        WeightedIndex::new(&probabilities)
+            .expect("attack outcomes should form a valid distribution")
+            .sample(rng)
+    };
+    lazy_mutations.remove(chosen_index)(rng, state, &attack_action);
 }
 
 /// This should be mostly a "router" function that calls the appropriate forecast function
@@ -72,8 +189,16 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::DiscardActiveStadium
         | SimpleAction::DiscardRandomOpponentActiveEnergy
         | SimpleAction::MoveRandomOpponentEnergyToActive { .. }
-        | SimpleAction::ApplyStatusToOpponentActive { .. }
-        | SimpleAction::Noop => forecast_deterministic_action(),
+        | SimpleAction::ApplyStatusToOpponentActive { .. } => forecast_deterministic_action(),
+        // Noop is the "decline" branch of Victini's Victory Star prompt when a coin result is
+        // parked; otherwise it is an ordinary no-op ("say no" to an optional effect).
+        SimpleAction::Noop => {
+            if state.pending_coin_reflip.is_some() {
+                forecast_decline_coin_reflip()
+            } else {
+                forecast_deterministic_action()
+            }
+        }
         SimpleAction::UseAbility { in_play_idx } => forecast_ability(state, action, *in_play_idx),
         SimpleAction::ApplyDamage {
             attacking_ref,
@@ -158,6 +283,15 @@ fn is_will_eligible_action(action: &SimpleAction) -> bool {
             | SimpleAction::Play { .. }
             | SimpleAction::UseStadium
     )
+}
+
+/// Declining Victini's Victory Star: replay the coin sequence that was already flipped.
+fn forecast_decline_coin_reflip() -> Outcomes {
+    Outcomes::single_fn(move |rng, state, _action| {
+        if let Some(pending) = state.take_pending_coin_reflip() {
+            resolve_pending_coin_reflip(rng, state, pending, false);
+        }
+    })
 }
 
 fn forecast_deterministic_action() -> Outcomes {

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -517,7 +517,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             AbilityMechanic::CheckupDamageToAllOpponentPokemon { amount: 10 },
         );
         // map.insert("If you don't have Regirock, Regice, and Registeel on your Bench, this Pokémon can't attack.", todo_implementation);
-        // map.insert("Once during your turn, after you flip any coins for an attack of 1 of your [R] Pokémon, you may ignore all results of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.", todo_implementation);
+        map.insert(
+            "Once during your turn, after you flip any coins for an attack of 1 of your [R] Pokémon, you may ignore all results of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.",
+            AbilityMechanic::VictoryStarReflip,
+        );
         map.insert(
             "Once during your turn, if this Pokémon is in the Active Spot, you may make your opponent's Active Pokémon Confused.",
             AbilityMechanic::ConfuseOpponentActive,

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -21,6 +21,7 @@ pub(crate) use apply_action::apply_action;
 pub(crate) use apply_action::apply_evolve;
 pub(crate) use apply_action::apply_place_card;
 pub(crate) use apply_action::forecast_action;
+pub(crate) use apply_action::resolve_pending_coin_reflip;
 pub(crate) use apply_action_helpers::handle_damage;
 pub(crate) use apply_action_helpers::handle_damage_only;
 pub(crate) use apply_action_helpers::handle_knockouts;

--- a/src/actions/outcomes.rs
+++ b/src/actions/outcomes.rs
@@ -253,6 +253,65 @@ impl Outcomes {
         Ok(Self { branches })
     }
 
+    /// Restricts the outcomes to the single branch whose coin metadata contains `sequence`,
+    /// collapsing it to probability 1.0. Used to *replay* an already-flipped coin result
+    /// deterministically (Victini's Victory Star, when the player declines the re-flip), as
+    /// opposed to `force_first_heads`, which biases a not-yet-flipped coin.
+    ///
+    /// Returns `Err(self)` when no branch carries that exact sequence, so callers can fall back
+    /// to the unmodified outcomes rather than constructing an empty distribution.
+    pub fn force_sequence(self, sequence: &[bool]) -> Result<Self, Self> {
+        let mut matched: Vec<OutcomeBranch> = vec![];
+        let mut passthrough: Vec<OutcomeBranch> = vec![];
+
+        for branch in self.branches {
+            let is_match = match &branch.coin_paths {
+                CoinPaths::None => false,
+                CoinPaths::Exact(seqs) => seqs.iter().any(|seq| seq.0 == sequence),
+            };
+            if is_match {
+                matched.push(OutcomeBranch {
+                    probability: 1.0,
+                    mutation: branch.mutation,
+                    coin_paths: CoinPaths::Exact(vec![CoinSeq(sequence.to_vec())]),
+                });
+            } else {
+                passthrough.push(branch);
+            }
+        }
+
+        // Exactly one branch should own any given coin sequence; anything else means the attack
+        // was re-forecast into a different shape than the one originally flipped.
+        if matched.len() == 1 {
+            Ok(Self { branches: matched })
+        } else {
+            passthrough.extend(matched);
+            Err(Self {
+                branches: passthrough,
+            })
+        }
+    }
+
+    /// The per-branch probabilities, without consuming the outcomes.
+    pub fn branch_probabilities(&self) -> Vec<f64> {
+        self.branches.iter().map(|b| b.probability).collect()
+    }
+
+    /// True if any branch carries real coin metadata, i.e. this action involves a coin flip.
+    pub fn has_coin_flips(&self) -> bool {
+        self.branches
+            .iter()
+            .any(|branch| matches!(branch.coin_paths, CoinPaths::Exact(_)))
+    }
+
+    /// The coin sequence owned by the branch at `index`, if it has coin metadata.
+    pub fn coin_sequence_at(&self, index: usize) -> Option<Vec<bool>> {
+        match self.branches.get(index).map(|b| &b.coin_paths) {
+            Some(CoinPaths::Exact(seqs)) => seqs.first().map(|seq| seq.0.clone()),
+            _ => None,
+        }
+    }
+
     pub(crate) fn binomial_coefficient(n: usize, k: usize) -> usize {
         if k > n {
             return 0;

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -199,6 +199,9 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::FutureSystem => false, // passive ability
         AbilityMechanic::TimeRecall => false,  // passive ability (consumed in attack generation)
         AbilityMechanic::QuickGrowth => false, // triggered at end of opponent's turn
+        // Reactive: only offered via the move-generation stack right after an eligible [R]
+        // coin-flip attack, never as a freely-selectable ability.
+        AbilityMechanic::VictoryStarReflip => false,
     }
 }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -13,7 +13,7 @@ use crate::{
     actions::{has_ability_mechanic, SimpleAction},
     deck::Deck,
     effects::TurnEffect,
-    models::{Card, EnergyType, StatusCondition},
+    models::{Attack, Card, EnergyType, StatusCondition},
     move_generation,
     stadiums::is_starting_plains_active,
     tools::has_tool,
@@ -36,6 +36,25 @@ pub enum GameOutcome {
 pub struct EnergyZone {
     pub current: Option<EnergyType>,
     pub next: Option<EnergyType>,
+}
+
+/// A coin-flip attack that has been flipped but not yet committed, parked while the acting player
+/// decides whether to use Victini's Victory Star to re-flip it.
+///
+/// Deliberately plain data: the attack is re-forecast from `attack` when the decision resolves,
+/// rather than storing a closure, so that `State` remains `Clone`/`Hash`/`Eq` for the
+/// search-based players (ExpectiMiniMax, MCTS) that clone and memoize states.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingCoinReflip {
+    /// The player who used the attack (and who may use Victory Star).
+    pub actor: usize,
+    /// The attack that was used, so it can be re-forecast on either branch.
+    pub attack: Attack,
+    /// The exact coin sequence that was originally flipped. Replayed verbatim if the player
+    /// declines, so declining is a faithful "keep what happened" rather than a second draw.
+    pub original_flips: Vec<bool>,
+    /// In-play index of the Victini offering the reflip.
+    pub victini_idx: usize,
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Default, Serialize, Deserialize)]
@@ -67,6 +86,16 @@ pub struct State {
     pub(crate) has_played_support: bool,
     pub(crate) has_retreated: bool,
     pub has_used_stadium: [bool; 2], // Tracks if each player has used the stadium this turn
+    // Tracks if each player has used a Victory Star Ability (Victini) this turn. The card text
+    // says "You can't use more than 1 Victory Star Ability each turn.", so this is per-player and
+    // not per-Victini.
+    #[serde(default)]
+    pub(crate) has_used_victory_star: [bool; 2],
+    // Set when an eligible coin-flip attack has been flipped but not yet committed, while the
+    // acting player decides whether to invoke Victory Star. Holds plain data only (no closures),
+    // so `State` stays Clone/Hash/Eq for the search-based players.
+    #[serde(default)]
+    pub(crate) pending_coin_reflip: Option<PendingCoinReflip>,
     pub(crate) knocked_out_by_opponent_attack_this_turn: bool,
     pub(crate) knocked_out_by_opponent_attack_last_turn: bool,
     // Energy types of the Pokemon Knocked Out by an opponent's attack during that turn (e.g. for
@@ -107,6 +136,8 @@ impl State {
             has_played_support: false,
             has_retreated: false,
             has_used_stadium: [false, false],
+            has_used_victory_star: [false, false],
+            pending_coin_reflip: None,
 
             knocked_out_by_opponent_attack_this_turn: false,
             knocked_out_by_opponent_attack_last_turn: false,
@@ -307,6 +338,7 @@ impl State {
         self.has_played_support = false;
         self.has_retreated = false;
         self.has_used_stadium[self.current_player] = false;
+        self.has_used_victory_star[self.current_player] = false;
     }
 
     /// Clear status conditions from energy-bearing Pokémon on a player's side.
@@ -327,6 +359,31 @@ impl State {
                 slot.cure_status_conditions();
             }
         }
+    }
+
+    /// In-play index of a Victini whose Victory Star is available to `player` this turn, if any.
+    /// Victory Star has no Active-Spot restriction, so a Victini anywhere in play qualifies.
+    pub(crate) fn available_victory_star_idx(&self, player: usize) -> Option<usize> {
+        if self.has_used_victory_star[player] {
+            return None;
+        }
+        self.enumerate_in_play_pokemon(player)
+            .find(|(_, pokemon)| {
+                has_ability_mechanic(&pokemon.card, &AbilityMechanic::VictoryStarReflip)
+            })
+            .map(|(idx, _)| idx)
+    }
+
+    pub(crate) fn set_pending_coin_reflip(&mut self, pending: PendingCoinReflip) {
+        self.pending_coin_reflip = Some(pending);
+    }
+
+    pub(crate) fn take_pending_coin_reflip(&mut self) -> Option<PendingCoinReflip> {
+        self.pending_coin_reflip.take()
+    }
+
+    pub(crate) fn mark_victory_star_used(&mut self, player: usize) {
+        self.has_used_victory_star[player] = true;
     }
 
     pub(crate) fn set_pending_will_first_heads(&mut self) {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -244,6 +244,8 @@ mod vanilluxe_test;
 mod vaporeon_ex_test;
 #[path = "pokemon/vespiquen_ex_chase_order_test.rs"]
 mod vespiquen_ex_chase_order_test;
+#[path = "pokemon/victini_victory_star_test.rs"]
+mod victini_victory_star_test;
 #[path = "pokemon/vulpix_tail_whip_test.rs"]
 mod vulpix_tail_whip_test;
 #[path = "pokemon/wailord_ex_wondrous_waves_test.rs"]

--- a/tests/pokemon/victini_victory_star_test.rs
+++ b/tests/pokemon/victini_victory_star_test.rs
@@ -1,0 +1,164 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board, get_test_game_with_board},
+};
+
+/// Victini's "Victory Star": "Once during your turn, after you flip any coins for an attack of
+/// 1 of your [R] Pokémon, you may ignore all results of those coin flips and begin flipping
+/// those coins again. You can't use more than 1 Victory Star Ability each turn."
+///
+/// After a coin-flip attack from an ally [R] Pokémon resolves, with an unused Victini in play,
+/// the engine should offer exactly two follow-up choices: decline (SimpleAction::Noop, keep the
+/// already-flipped result) or accept (SimpleAction::UseAbility on Victini, re-flip from scratch).
+/// This should NOT be offered when the attack has no coin flip at all, even if the attacker is
+/// Victini itself.
+#[test]
+fn test_victory_star_offers_reflip_choice_only_for_ally_fire_coin_flip_attacks() {
+    // Ponyta's Stomp: 10 fixed damage, "Flip a coin. If heads, this attack does 30 more damage."
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A1a010Ponyta).with_energy(vec![EnergyType::Fire]),
+            PlayedCard::from_id(CardId::B3025Victini),
+        ],
+        vec![PlayedCard::from_id(CardId::A1053Squirtle)],
+    );
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1a010Ponyta, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0, "Attacking player should be offered the reflip decision");
+    assert_eq!(
+        choices.len(),
+        2,
+        "Expected exactly a decline/accept pair, got: {:?}",
+        choices.iter().map(|c| &c.action).collect::<Vec<_>>()
+    );
+    assert!(
+        choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::Noop)),
+        "Should be able to decline and keep the original coin result"
+    );
+    assert!(
+        choices.iter().any(|c| matches!(
+            c.action,
+            SimpleAction::UseAbility { in_play_idx: 1 }
+        )),
+        "Should be able to invoke Victini's Victory Star (bench idx 1) to re-flip"
+    );
+}
+
+#[test]
+fn test_victory_star_not_offered_for_attacks_without_a_coin_flip() {
+    // Victini's own "V-Flame" attack has no effect text, i.e. no coin flip to reflip, even
+    // though Victini itself is a [R] Pokemon and is in play.
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3025Victini).with_energy(vec![
+            EnergyType::Fire,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1053Squirtle)],
+    );
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3025Victini, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // V-Flame does a flat 40 damage; no coin flip means no reflip decision should be queued.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 20);
+    assert!(
+        state.move_generation_stack.is_empty(),
+        "No reflip decision should be queued for a coin-less attack"
+    );
+}
+
+/// Declining Victory Star (SimpleAction::Noop) must exactly reproduce the coin result that was
+/// already flipped -- it is a pure "keep what happened" replay, not a second independent flip
+/// and not a forced-heads effect (unlike the Will trainer card). We verify this by comparing,
+/// for the same seed, a board with an (always-declined) Victini present against a baseline board
+/// with no Victini at all: the resulting damage must match for every seed, and across enough
+/// seeds we should see both the heads (40 dmg) and tails (10 dmg) results -- proving decline
+/// doesn't skew the original distribution.
+#[test]
+fn test_declining_victory_star_reproduces_original_coin_result() {
+    let mut saw_heads_damage = false;
+    let mut saw_tails_damage = false;
+
+    for seed in 0..50 {
+        // Baseline: no Victini in play at all.
+        let mut baseline_game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![PlayedCard::from_id(CardId::A1a010Ponyta).with_energy(vec![EnergyType::Fire])],
+            vec![PlayedCard::from_id(CardId::A1053Squirtle)],
+        );
+        baseline_game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1a010Ponyta, 0),
+            is_stack: false,
+        });
+        baseline_game.play_until_stable();
+        let baseline_hp = baseline_game.get_state_clone().get_active(1).get_remaining_hp();
+
+        // With Victini present, but always declining the reflip.
+        let mut game = get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![
+                PlayedCard::from_id(CardId::A1a010Ponyta).with_energy(vec![EnergyType::Fire]),
+                PlayedCard::from_id(CardId::B3025Victini),
+            ],
+            vec![PlayedCard::from_id(CardId::A1053Squirtle)],
+        );
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1a010Ponyta, 0),
+            is_stack: false,
+        });
+        game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::Noop,
+            is_stack: true,
+        });
+        game.play_until_stable();
+        let declined_hp = game.get_state_clone().get_active(1).get_remaining_hp();
+
+        assert_eq!(
+            declined_hp, baseline_hp,
+            "Seed {seed}: declining Victory Star should exactly reproduce the original flip"
+        );
+
+        match declined_hp {
+            50 => saw_tails_damage = true, // 60 - 10
+            20 => saw_heads_damage = true, // 60 - 40
+            other => panic!("Seed {seed}: unexpected resulting HP {other}"),
+        }
+    }
+
+    assert!(
+        saw_heads_damage,
+        "Expected to see the heads (40 dmg) result at least once across 50 seeds"
+    );
+    assert!(
+        saw_tails_damage,
+        "Expected to see the tails (10 dmg) result at least once across 50 seeds \
+         (if this fails, declining may be incorrectly forcing heads like Will does)"
+    );
+}

--- a/tests/pokemon/victini_victory_star_test.rs
+++ b/tests/pokemon/victini_victory_star_test.rs
@@ -35,7 +35,10 @@ fn test_victory_star_offers_reflip_choice_only_for_ally_fire_coin_flip_attacks()
     });
 
     let (actor, choices) = game.get_state_clone().generate_possible_actions();
-    assert_eq!(actor, 0, "Attacking player should be offered the reflip decision");
+    assert_eq!(
+        actor, 0,
+        "Attacking player should be offered the reflip decision"
+    );
     assert_eq!(
         choices.len(),
         2,
@@ -49,10 +52,9 @@ fn test_victory_star_offers_reflip_choice_only_for_ally_fire_coin_flip_attacks()
         "Should be able to decline and keep the original coin result"
     );
     assert!(
-        choices.iter().any(|c| matches!(
-            c.action,
-            SimpleAction::UseAbility { in_play_idx: 1 }
-        )),
+        choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::UseAbility { in_play_idx: 1 })),
         "Should be able to invoke Victini's Victory Star (bench idx 1) to re-flip"
     );
 }
@@ -62,10 +64,8 @@ fn test_victory_star_not_offered_for_attacks_without_a_coin_flip() {
     // Victini's own "V-Flame" attack has no effect text, i.e. no coin flip to reflip, even
     // though Victini itself is a [R] Pokemon and is in play.
     let mut game = get_test_game_with_board(
-        vec![PlayedCard::from_id(CardId::B3025Victini).with_energy(vec![
-            EnergyType::Fire,
-            EnergyType::Colorless,
-        ])],
+        vec![PlayedCard::from_id(CardId::B3025Victini)
+            .with_energy(vec![EnergyType::Fire, EnergyType::Colorless])],
         vec![PlayedCard::from_id(CardId::A1053Squirtle)],
     );
     let mut state = game.get_state_clone();
@@ -114,7 +114,10 @@ fn test_declining_victory_star_reproduces_original_coin_result() {
             is_stack: false,
         });
         baseline_game.play_until_stable();
-        let baseline_hp = baseline_game.get_state_clone().get_active(1).get_remaining_hp();
+        let baseline_hp = baseline_game
+            .get_state_clone()
+            .get_active(1)
+            .get_remaining_hp();
 
         // With Victini present, but always declining the reflip.
         let mut game = get_initialized_game_with_board(
@@ -160,5 +163,151 @@ fn test_declining_victory_star_reproduces_original_coin_result() {
         saw_tails_damage,
         "Expected to see the tails (10 dmg) result at least once across 50 seeds \
          (if this fails, declining may be incorrectly forcing heads like Will does)"
+    );
+}
+
+/// Accepting Victory Star must produce a genuinely NEW, independent coin roll -- not a replay of
+/// the sequence that was just rejected. Two things are asserted across many seeds:
+///   1. Both outcomes (heads = 40 dmg, tails = 10 dmg) occur after reflipping, proving the coin
+///      is actually re-rolled rather than fixed.
+///   2. For at least some seeds, the reflipped result DIFFERS from what declining would have
+///      produced on that same seed -- proving the reflip is independent of the original flip.
+/// Snorlax (150 HP, not Weak to [R]) absorbs either result without a knockout or weakness math.
+#[test]
+fn test_accepting_victory_star_reflips_with_independent_coins() {
+    let mut saw_heads_after_reflip = false;
+    let mut saw_tails_after_reflip = false;
+    let mut saw_reflip_change_the_result = false;
+
+    for seed in 0..200 {
+        let board = || {
+            (
+                vec![
+                    PlayedCard::from_id(CardId::A1a010Ponyta).with_energy(vec![EnergyType::Fire]),
+                    PlayedCard::from_id(CardId::B3025Victini),
+                ],
+                vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+            )
+        };
+
+        // Path A: decline the reflip (keep the original coin).
+        let (player_board, opponent_board) = board();
+        let mut declined_game =
+            get_initialized_game_with_board(seed, 0, 3, player_board, opponent_board);
+        declined_game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1a010Ponyta, 0),
+            is_stack: false,
+        });
+        declined_game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::Noop,
+            is_stack: true,
+        });
+        declined_game.play_until_stable();
+        let declined_hp = declined_game
+            .get_state_clone()
+            .get_active(1)
+            .get_remaining_hp();
+
+        // Path B: accept the reflip (fresh coin) from the identical starting seed/board.
+        let (player_board, opponent_board) = board();
+        let mut reflip_game =
+            get_initialized_game_with_board(seed, 0, 3, player_board, opponent_board);
+        reflip_game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A1a010Ponyta, 0),
+            is_stack: false,
+        });
+        reflip_game.apply_action(&Action {
+            actor: 0,
+            action: SimpleAction::UseAbility { in_play_idx: 1 },
+            is_stack: true,
+        });
+        reflip_game.play_until_stable();
+        let reflip_hp = reflip_game
+            .get_state_clone()
+            .get_active(1)
+            .get_remaining_hp();
+
+        match reflip_hp {
+            140 => saw_tails_after_reflip = true, // 150 - 10
+            110 => saw_heads_after_reflip = true, // 150 - 40
+            other => panic!("Seed {seed}: unexpected HP after reflip: {other}"),
+        }
+        if reflip_hp != declined_hp {
+            saw_reflip_change_the_result = true;
+        }
+    }
+
+    assert!(
+        saw_heads_after_reflip && saw_tails_after_reflip,
+        "Reflip should yield both heads and tails across 200 seeds \
+         (heads seen: {saw_heads_after_reflip}, tails seen: {saw_tails_after_reflip})"
+    );
+    assert!(
+        saw_reflip_change_the_result,
+        "Reflipping should sometimes change the outcome vs. declining; if it never does, \
+         the 'reflip' is replaying the original coin instead of rolling a new one"
+    );
+}
+
+/// "You can't use more than 1 Victory Star Ability each turn." After the ability is used once,
+/// a second eligible [R] coin-flip attack in the same turn must resolve immediately with no
+/// reflip prompt. Driven purely through public API: attack, accept the reflip, then attack again
+/// (Mega Kangaskhan-style repeat attacks aren't needed -- we re-issue the attack action directly)
+/// and assert the follow-up decision is gone.
+#[test]
+fn test_victory_star_can_only_be_used_once_per_turn() {
+    let mut game = get_initialized_game_with_board(
+        7,
+        0,
+        3,
+        vec![
+            PlayedCard::from_id(CardId::A1a010Ponyta).with_energy(vec![EnergyType::Fire]),
+            PlayedCard::from_id(CardId::B3025Victini),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    // First attack: the prompt should appear, and we accept it.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1a010Ponyta, 0),
+        is_stack: false,
+    });
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::UseAbility { in_play_idx: 1 })),
+        "First eligible attack should offer Victory Star"
+    );
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 1 },
+        is_stack: true,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert!(
+        state.move_generation_stack.is_empty(),
+        "Reflip should have fully resolved"
+    );
+
+    // Second eligible attack in the SAME turn: no prompt this time.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1a010Ponyta, 0),
+        is_stack: false,
+    });
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !choices
+            .iter()
+            .any(|c| matches!(c.action, SimpleAction::UseAbility { in_play_idx: 1 })),
+        "Victory Star should not be offered twice in one turn, got: {:?}",
+        choices.iter().map(|c| &c.action).collect::<Vec<_>>()
     );
 }


### PR DESCRIPTION
<html><head></head><body><h1>Implement Victini's Victory Star (B3 025, P-B 049)</h1>
<p>Implements the <code>Victory Star</code> ability, which was previously commented out as <code>todo_implementation</code> in <code>effect_ability_mechanic_map.rs</code>:</p>
<blockquote>
<p>Once during your turn, after you flip any coins for an attack of 1 of your [R] Pokémon, you may ignore all results of those coin flips and begin flipping those coins again. You can't use more than 1 Victory Star Ability each turn.</p>
</blockquote>
<p>Both printings share the same effect text, so the single map entry covers B3 025 and the P-B 049 promo. Victini's own attack (<code>V-Flame</code>, flat 40) needed no work.</p>
<h2>Why this needed a new pattern</h2>
<p>Every other "Once during your turn" ability in the engine is a self-contained instant effect resolved through a single <code>UseAbility</code> action. Victory Star is different: it reacts to and modifies the outcome of a <em>different</em> action — an ally's attack — after that attack's coins have already been flipped.</p>
<p>The closest existing precedent is Will (<code>TurnEffect::ForceFirstHeads</code>), but that's a pre-commitment that biases a not-yet-flipped coin. Reusing it here would have been a meaningfully different and stronger effect: guaranteeing heads is not the same as re-rolling once, and the gap widens on multi-coin attacks. Since the engine exists to produce accurate win rates for deck optimization, an approximation that makes Victini simulate as overpowered seemed worse than the extra plumbing.</p>
<h2>Approach</h2>
<p>The decision is surfaced through the existing <code>move_generation_stack</code>, so one logical attack can span multiple <code>apply_action</code> calls — the same mechanism <code>copy_attack</code> and the various target-selection effects already use.</p>
<p><strong>Interception</strong> happens in <code>apply_action</code>, alongside the existing Will hook. <code>maybe_defer_for_victory_star</code> returns <code>None</code> (resolve normally) unless all of the following hold:</p>
<ul>
<li>the action is an <code>Attack</code> and not itself a stacked follow-up</li>
<li>the attacking Pokémon is <code>[R]</code></li>
<li>the attack's <code>Outcomes</code> actually carry coin metadata (<code>CoinPaths::Exact</code>)</li>
<li>the acting player has an unused Victini in play</li>
<li>no reflip is already pending</li>
</ul>
<p>When it does apply, the coins are sampled immediately, the result is parked, and <code>[Noop, UseAbility { victini_idx }]</code> is pushed onto the stack. Non-qualifying attacks bail out before any of this and are unaffected.</p>
<p><strong>Pre-rolling before the prompt is deliberate.</strong> The physical card lets you see the flip and then decide, so the choice has to be informed to simulate correctly. Deciding blind would model a different (and worse) ability.</p>
<p><strong>State stays plain data.</strong> <code>PendingCoinReflip</code> holds the actor, the <code>Attack</code>, the flipped <code>Vec&lt;bool&gt;</code>, and Victini's index — no closures — so <code>State</code> keeps its <code>Clone</code>/<code>Hash</code>/<code>Eq</code> derives and the search-based players (ExpectiMiniMax, MCTS) continue to work. Resolution re-forecasts the stored attack rather than resuming a suspended computation.</p>
<p><strong>Resolving the choice:</strong></p>
<ul>
<li><em>Decline</em> (<code>Noop</code>) → re-forecast, then <code>Outcomes::force_sequence(original_flips)</code> collapses to the branch that owns the exact sequence already flipped. A faithful replay, not a second draw.</li>
<li><em>Accept</em> (<code>UseAbility</code>) → mark the once-per-turn flag, re-forecast, roll fresh independent coins.</li>
</ul>
<p><code>force_sequence</code> is the replay counterpart to the existing <code>force_first_heads</code>, and returns <code>Err(self)</code> on no match so callers fall back to unmodified outcomes rather than building an empty distribution.</p>
<p><strong>Move generation</strong> returns <code>false</code> for <code>VictoryStarReflip</code>, keeping it out of the normal ability menu — it only ever appears via the stack.</p>
<h2>Changes</h2>

File | Change
-- | --
state/mod.rs | PendingCoinReflip struct; has_used_victory_star + pending_coin_reflip fields; helpers; per-turn reset
actions/outcomes.rs | force_sequence, has_coin_flips, coin_sequence_at, branch_probabilities
actions/apply_action.rs | Deferral check, coin pre-roll, resolve_pending_coin_reflip, Noop routing
actions/abilities/mechanic.rs | AbilityMechanic::VictoryStarReflip
actions/effect_ability_mechanic_map.rs | Map entry (replaces the commented-out TODO)
actions/apply_abilities_action.rs | Mechanic implementation
move_generation/move_generation_abilities.rs | Excluded from normal ability generation


<h2>Tests</h2>
<p><code>tests/pokemon/victini_victory_star_test.rs</code>, all at the <code>Game</code> public API level per <code>SKILL.md</code>:</p>
<ol>
<li><strong>Prompt appears</strong> for an ally <code>[R]</code> coin-flip attack (Ponyta's Stomp) with Victini in play — exactly a decline/accept pair.</li>
<li><strong>No prompt</strong> for a coin-less attack (Victini's own V-Flame), so non-coin attacks don't gain branching.</li>
<li><strong>Declining replays the original flip</strong> — compared against a no-Victini baseline across 50 seeds; results match every seed, and both heads and tails appear (guarding against accidentally reimplementing Will's forced heads).</li>
<li><strong>Accepting re-rolls independently</strong> — runs decline and accept from the <em>same</em> seed across 200 seeds; asserts both outcomes occur <em>and</em> that the paths diverge on at least some seeds. A reflip that secretly replayed the original would pass everything else but fail this.</li>
<li><strong>Once per turn</strong> — after using Victory Star, a second eligible attack in the same turn gets no prompt.</li>
</ol>
<p>Full suite passes, and <code>cargo run --bin card_test -- "B3 025"</code> (10k random games against <code>example_decks/</code>) completes without errors. <code>card_status</code> now reports both Victini printings as Complete.</p>
<h2>Open question: interaction with Will</h2>
<p>Will forces the first coin of an eligible action to heads. If a player uses Will and then reflips that same attack with Victory Star, should the new flip also be forced?</p>
<p>As implemented, <strong>no</strong> — Will's pending flag is consumed by the original flip, so the reflip is unforced. That seemed the more natural reading ("ignore all results of those coin flips and begin flipping those coins again" describes a fresh flip, and Will's effect was already spent), but I couldn't find a ruling to confirm it and there's no test pinning the behavior either way. Happy to add one and flip the logic if the actual game behaves differently — flagging it rather than leaving it silently decided.</p></body></html>