### PR TITLE
Implement coin-flip, status, and energy-discard attack mechanics (25 cards)

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -244,6 +244,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::HealAllYourPokemon { amount } => {
             heal_all_your_pokemon_attack(attack.fixed_damage, *amount)
         }
+        Mechanic::HealAllBenchedPokemon { amount, only_basic } => {
+            heal_all_benched_pokemon_attack(attack.fixed_damage, *amount, *only_basic)
+        }
         Mechanic::CoinFlipSelfHeal { amount } => {
             coin_flip_self_heal_attack(attack.fixed_damage, *amount)
         }
@@ -317,6 +320,16 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ChanceStatusAttack { condition } => {
             damage_chance_status_attack(attack.fixed_damage, *condition)
         }
+        Mechanic::CoinFlipStatusOutcome {
+            heads_status,
+            tails_status,
+        } => coin_flip_status_outcome_attack(attack.fixed_damage, *heads_status, *tails_status),
+        Mechanic::ChanceMultipleStatusAttack { conditions } => {
+            damage_chance_multiple_status_attack(attack.fixed_damage, conditions.clone())
+        }
+        Mechanic::CoinFlipStatusSelfOrOpponent { status } => {
+            coin_flip_status_self_or_opponent_attack(attack.fixed_damage, *status)
+        }
         Mechanic::ChooseStatusToInflict { options } => {
             damage_and_choose_status_attack(attack.fixed_damage, options.clone())
         }
@@ -325,6 +338,12 @@ fn forecast_effect_attack_by_mechanic(
         }
         Mechanic::DiscardEnergyFromOpponentActive => {
             damage_and_discard_energy(attack.fixed_damage, 1)
+        }
+        Mechanic::DiscardOpponentActiveEnergyOfType { energy_type } => {
+            damage_and_discard_opponent_active_energy_of_type(attack.fixed_damage, *energy_type)
+        }
+        Mechanic::DiscardRandomEnergyBothActive => {
+            discard_random_energy_both_active(attack.fixed_damage)
         }
         Mechanic::CoinFlipDiscardEnergyFromOpponentActive => mawile_crunch(),
         Mechanic::CoinFlipsDiscardEnergyFromOpponentActiveOrNothing { num_coins } => {
@@ -360,8 +379,14 @@ fn forecast_effect_attack_by_mechanic(
             extra_damage,
             self_damage,
         } => extra_or_self_damage_attack(attack.fixed_damage, *extra_damage, *self_damage),
+        Mechanic::CoinFlipDamageOrHealOpponent { damage, heal } => {
+            coin_flip_damage_or_heal_opponent_attack(*damage, *heal)
+        }
         Mechanic::CoinFlipSelfDamage { self_damage } => {
             coinflip_self_damage_attack(attack.fixed_damage, *self_damage)
+        }
+        Mechanic::CoinFlipSelfDiscardRandomEnergy { count } => {
+            coin_flip_self_discard_random_energy(attack.fixed_damage, *count)
         }
         Mechanic::ExtraDamageForEachHeads {
             include_fixed_damage,
@@ -390,6 +415,9 @@ fn forecast_effect_attack_by_mechanic(
             *boosted_num_coins,
             *tool,
         ),
+        Mechanic::CoinFlipPerPokemonInPlay { damage_per_head } => {
+            coin_flip_per_pokemon_in_play_attack(state, *damage_per_head)
+        }
         Mechanic::DiscardSelfEnergyPerHeadsExtraDamage {
             num_coins,
             energy_type,
@@ -486,6 +514,10 @@ fn forecast_effect_attack_by_mechanic(
             *duration,
         ),
         Mechanic::DrawCard { amount } => draw_and_damage_outcome(attack.fixed_damage, *amount),
+        Mechanic::DrawPerPokemonWithName { name } => {
+            draw_per_pokemon_with_name_attack(state, attack.fixed_damage, name)
+        }
+        Mechanic::CoinFlipSetOpponentHpTo { hp } => coin_flip_set_opponent_hp(*hp),
         Mechanic::SelfDiscardAllEnergy => damage_and_discard_all_energy(attack.fixed_damage),
         Mechanic::SelfDiscardAllTypeEnergy { energy_type } => {
             discard_all_energy_of_type_attack(attack.fixed_damage, *energy_type)
@@ -502,7 +534,9 @@ fn forecast_effect_attack_by_mechanic(
             energy_type,
             damage,
         } => discard_all_energy_of_type_then_damage_any_opponent_pokemon(*energy_type, *damage),
-        Mechanic::SelfDiscardRandomEnergy => damage_and_discard_random_energy(attack.fixed_damage),
+        Mechanic::SelfDiscardRandomEnergy { count } => {
+            damage_and_discard_random_energy(attack.fixed_damage, *count)
+        }
         Mechanic::AlsoBenchDamage {
             opponent,
             damage,
@@ -1524,6 +1558,17 @@ fn damage_for_each_heads_with_tool_boost_attack(
     })
 }
 
+/// Croagunk / Toxicroak: flip one coin per Pokémon the attacker has in play, dealing
+/// `damage_per_head` per heads.
+fn coin_flip_per_pokemon_in_play_attack(state: &State, damage_per_head: u32) -> AttackOutcomes {
+    let num_coins = state
+        .enumerate_in_play_pokemon(state.current_player)
+        .count();
+    AttackOutcomes::binomial_by_heads(num_coins, move |heads| {
+        active_damage_outcome(heads as u32 * damage_per_head)
+    })
+}
+
 /// Deal damage and attach energy to a pokemon of choice in the bench.
 pub(crate) fn energy_bench_attack(
     energies: Vec<EnergyType>,
@@ -1617,6 +1662,17 @@ fn extra_or_self_damage_attack(
     )
 }
 
+/// Delibird – Present: heads deals `damage` to the opponent's Active, tails heals `heal` from it.
+fn coin_flip_damage_or_heal_opponent_attack(damage: u32, heal: u32) -> AttackOutcomes {
+    AttackOutcomes::binary_coin(
+        active_damage_outcome(damage),
+        AttackOutcome::effect_only(move |_, state, action| {
+            let opponent = (action.actor + 1) % 2;
+            state.get_active_mut(opponent).heal(heal);
+        }),
+    )
+}
+
 /// Deal damage, then let the player choose which Special Condition to inflict on the
 /// opponent's Active Pokémon (e.g. Dustox's Select Powder).
 fn damage_and_choose_status_attack(damage: u32, options: Vec<StatusCondition>) -> AttackOutcomes {
@@ -1637,6 +1693,50 @@ fn damage_chance_status_attack(damage: u32, status: StatusCondition) -> AttackOu
     AttackOutcomes::binary_coin(
         active_damage_effect_outcome(damage, build_status_effect(status)),
         active_damage_outcome(damage),
+    )
+}
+
+/// Lanturn ex – Flash Cannon: heads inflicts `heads_status`, tails inflicts `tails_status`,
+/// both on the opponent's Active.
+fn coin_flip_status_outcome_attack(
+    damage: u32,
+    heads_status: StatusCondition,
+    tails_status: StatusCondition,
+) -> AttackOutcomes {
+    AttackOutcomes::binary_coin(
+        active_damage_effect_outcome(damage, build_status_effect(heads_status)),
+        active_damage_effect_outcome(damage, build_status_effect(tails_status)),
+    )
+}
+
+/// Tentacruel – Tentacle Dance / Drapion / Amoonguss: heads inflicts ALL of `conditions` on
+/// the opponent's Active.
+fn damage_chance_multiple_status_attack(
+    damage: u32,
+    conditions: Vec<StatusCondition>,
+) -> AttackOutcomes {
+    AttackOutcomes::binary_coin(
+        active_damage_effect_outcome(damage, move |_, state, action| {
+            let opponent = (action.actor + 1) % 2;
+            for &status in &conditions {
+                state.apply_status_condition(opponent, 0, status);
+            }
+        }),
+        active_damage_outcome(damage),
+    )
+}
+
+/// Psyduck – Confusion Wave: heads inflicts `status` on the opponent's Active, tails inflicts
+/// it on the attacker itself.
+fn coin_flip_status_self_or_opponent_attack(
+    damage: u32,
+    status: StatusCondition,
+) -> AttackOutcomes {
+    AttackOutcomes::binary_coin(
+        active_damage_effect_outcome(damage, build_status_effect(status)),
+        active_damage_effect_outcome(damage, move |_, state, action| {
+            state.apply_status_condition(action.actor, 0, status);
+        }),
     )
 }
 
@@ -2217,6 +2317,24 @@ fn heal_all_pokemon(state: &mut State, player: usize, amount: u32) {
     }
 }
 
+/// Heal `amount` from each of the player's Benched Pokémon; when `only_basic` is true, only
+/// Basic Pokémon are healed (Alomomola heals all, Ho-Oh heals only Basic).
+fn heal_all_benched_pokemon_attack(damage: u32, amount: u32, only_basic: bool) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let benched: Vec<usize> = state
+            .enumerate_bench_pokemon(action.actor)
+            .filter(|(_, pokemon)| !only_basic || pokemon.card.is_basic())
+            .map(|(idx, _)| idx)
+            .collect();
+        for idx in benched {
+            state.in_play_pokemon[action.actor][idx]
+                .as_mut()
+                .expect("Benched Pokémon should exist")
+                .heal(amount);
+        }
+    })
+}
+
 fn coin_flip_self_heal_attack(damage: u32, heal: u32) -> AttackOutcomes {
     AttackOutcomes::binary_coin(
         active_damage_effect_outcome(damage, move |_, state, action| {
@@ -2477,13 +2595,112 @@ fn randomize_opponent_next_energy_attack(damage: u32) -> AttackOutcomes {
     })
 }
 
-fn damage_and_discard_random_energy(damage: u32) -> AttackOutcomes {
+fn damage_and_discard_random_energy(damage: u32, count: usize) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |rng, state, action| {
         let active = state.get_active(action.actor);
-        if !active.attached_energy.is_empty() {
+        let mut to_discard = Vec::new();
+        let mut remaining = active.attached_energy.clone();
+        for _ in 0..count {
+            if remaining.is_empty() {
+                break;
+            }
+            let idx = rng.gen_range(0..remaining.len());
+            to_discard.push(remaining.swap_remove(idx));
+        }
+        if !to_discard.is_empty() {
+            state.discard_from_active(action.actor, &to_discard);
+        }
+    })
+}
+
+/// Deal damage and discard one Energy of `energy_type` from the opponent's Active
+/// (e.g. Dedenne, Surskit).
+fn damage_and_discard_opponent_active_energy_of_type(
+    damage: u32,
+    energy_type: EnergyType,
+) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        let to_discard: Vec<EnergyType> = state
+            .get_active(opponent)
+            .attached_energy
+            .iter()
+            .filter(|&&e| e == energy_type)
+            .take(1)
+            .copied()
+            .collect();
+        if !to_discard.is_empty() {
+            state.discard_from_active(opponent, &to_discard);
+        }
+    })
+}
+
+/// Deal damage and discard a random Energy from BOTH Active Pokémon (e.g. Oricorio, Yveltal).
+fn discard_random_energy_both_active(damage: u32) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |rng, state, action| {
+        let players = [action.actor, (action.actor + 1) % 2];
+        for player in players {
+            let active = state.get_active(player);
+            if active.attached_energy.is_empty() {
+                continue;
+            }
             let idx = rng.gen_range(0..active.attached_energy.len());
             let energy = active.attached_energy[idx];
-            state.discard_from_active(action.actor, &[energy]);
+            state.discard_from_active(player, &[energy]);
+        }
+    })
+}
+
+/// Flip a coin; on tails discard `count` random Energy from the attacker (e.g. Entei).
+fn coin_flip_self_discard_random_energy(damage: u32, count: usize) -> AttackOutcomes {
+    AttackOutcomes::binary_coin(
+        active_damage_outcome(damage),
+        active_damage_effect_outcome(damage, move |rng, state, action| {
+            let active = state.get_active(action.actor);
+            let mut to_discard = Vec::new();
+            let mut remaining = active.attached_energy.clone();
+            for _ in 0..count {
+                if remaining.is_empty() {
+                    break;
+                }
+                let idx = rng.gen_range(0..remaining.len());
+                to_discard.push(remaining.swap_remove(idx));
+            }
+            if !to_discard.is_empty() {
+                state.discard_from_active(action.actor, &to_discard);
+            }
+        }),
+    )
+}
+
+/// Flip a coin; on heads set the opponent's Active remaining HP to `hp` (e.g. Xatu).
+fn coin_flip_set_opponent_hp(hp: u32) -> AttackOutcomes {
+    AttackOutcomes::binary_coin(
+        active_damage_effect_outcome(0, move |_, state, action| {
+            let opponent = (action.actor + 1) % 2;
+            let active = state.get_active_mut(opponent);
+            let current = active.get_remaining_hp();
+            if current > hp {
+                active.apply_damage(current - hp);
+            } else {
+                active.heal(hp - current);
+            }
+        }),
+        active_damage_outcome(0),
+    )
+}
+
+/// Draw a card for each of your Pokémon in play named `name` (e.g. Poochyena).
+fn draw_per_pokemon_with_name_attack(state: &State, damage: u32, name: &str) -> AttackOutcomes {
+    let count = state
+        .enumerate_in_play_pokemon(state.current_player)
+        .filter(|(_, p)| p.get_name() == name)
+        .count() as u8;
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        if count > 0 {
+            state
+                .move_generation_stack
+                .push((action.actor, vec![SimpleAction::DrawCard { amount: count }]));
         }
     })
 }

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -33,6 +33,12 @@ pub enum Mechanic {
     HealAllYourPokemon {
         amount: u32,
     },
+    /// Heal `amount` from each Benched Pokémon; if `only_basic` is true, only Basic Pokémon
+    /// (Alomomola heals all, Ho-Oh heals only Basic).
+    HealAllBenchedPokemon {
+        amount: u32,
+        only_basic: bool,
+    },
     CoinFlipSelfHeal {
         amount: u32,
     },
@@ -74,6 +80,22 @@ pub enum Mechanic {
     ChanceStatusAttack {
         condition: StatusCondition,
     },
+    /// Flip a coin; heads inflicts `heads_status`, tails inflicts `tails_status`, both on the
+    /// opponent's Active (e.g. Lanturn ex).
+    CoinFlipStatusOutcome {
+        heads_status: StatusCondition,
+        tails_status: StatusCondition,
+    },
+    /// Flip a coin; heads inflicts ALL of `conditions` on the opponent's Active (e.g.
+    /// Tentacruel's Poisoned and Paralyzed).
+    ChanceMultipleStatusAttack {
+        conditions: Vec<StatusCondition>,
+    },
+    /// Flip a coin; heads inflicts `status` on the opponent's Active, tails inflicts it on the
+    /// attacking Pokémon itself (e.g. Psyduck's Confusion Wave).
+    CoinFlipStatusSelfOrOpponent {
+        status: StatusCondition,
+    },
     /// Deal damage, then let the player choose one of these Special Conditions to
     /// inflict on the opponent's Active Pokémon (e.g. Dustox's Select Powder).
     ChooseStatusToInflict {
@@ -93,6 +115,12 @@ pub enum Mechanic {
         damage_per_hit: u32,
     },
     DiscardEnergyFromOpponentActive,
+    /// Discard one `energy_type` Energy from the opponent's Active (e.g. Dedenne, Surskit).
+    DiscardOpponentActiveEnergyOfType {
+        energy_type: EnergyType,
+    },
+    /// Discard a random Energy from BOTH Active Pokémon (e.g. Oricorio, Yveltal).
+    DiscardRandomEnergyBothActive,
     CoinFlipDiscardEnergyFromOpponentActive,
     /// Pidgeot's Twister / Mega Pidgeot ex's Giant Twister: flip `num_coins` coins and discard a
     /// random Energy from the opponent's Active Pokémon for each heads. If every coin is tails
@@ -129,8 +157,19 @@ pub enum Mechanic {
         extra_damage: u32,
         self_damage: u32,
     },
+    /// Flip a coin; heads deals `damage` to the opponent's Active, tails heals `heal` from it
+    /// (e.g. Delibird's Present).
+    CoinFlipDamageOrHealOpponent {
+        damage: u32,
+        heal: u32,
+    },
     CoinFlipSelfDamage {
         self_damage: u32,
+    },
+    /// Flip a coin; on tails discard `count` random Energy from the attacking Pokémon
+    /// (e.g. Entei).
+    CoinFlipSelfDiscardRandomEnergy {
+        count: usize,
     },
     ExtraDamageForEachHeads {
         include_fixed_damage: bool,
@@ -280,6 +319,11 @@ pub enum Mechanic {
         boosted_num_coins: usize,
         tool: CardId,
     },
+    /// Croagunk / Toxicroak: flip one coin for each of your Pokémon in play, dealing
+    /// `damage_per_head` for each heads.
+    CoinFlipPerPokemonInPlay {
+        damage_per_head: u32,
+    },
     DamageAndMultipleCardEffects {
         opponent: bool,
         effects: Vec<CardEffect>,
@@ -336,6 +380,14 @@ pub enum Mechanic {
     DrawCard {
         amount: u8,
     },
+    /// Draw a card for each of your Pokémon in play named `name` (e.g. Poochyena).
+    DrawPerPokemonWithName {
+        name: String,
+    },
+    /// Flip a coin; on heads set the opponent's Active remaining HP to `hp` (e.g. Xatu).
+    CoinFlipSetOpponentHpTo {
+        hp: u32,
+    },
     SelfDiscardAllEnergy,
     SelfDiscardAllTypeEnergy {
         energy_type: EnergyType,
@@ -351,7 +403,9 @@ pub enum Mechanic {
         energy_type: EnergyType,
         damage: u32,
     },
-    SelfDiscardRandomEnergy,
+    SelfDiscardRandomEnergy {
+        count: usize,
+    },
     AlsoBenchDamage {
         opponent: bool,
         damage: u32,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -130,7 +130,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Discard 2 cards from your hand. If you can't discard 2 cards, this attack does nothing.",
         Mechanic::DiscardHandCards { count: 2 },
     );
-    // map.insert("Discard 2 random Energy from this Pokémon.", todo_implementation);
+    map.insert(
+        "Discard 2 random Energy from this Pokémon.",
+        Mechanic::SelfDiscardRandomEnergy { count: 2 },
+    );
     map.insert("Discard 3 [W] Energy from this Pokémon. This attack also does 20 damage to each of your opponent's Benched Pokémon.", Mechanic::PalkiaExDimensionalStorm);
     map.insert(
         "Discard Fire[R] Energy from this Pokémon. Your opponent's Active Pokémon is now Burned.",
@@ -151,7 +154,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             energies: vec![EnergyType::Lightning],
         },
     );
-    // map.insert("Discard a [L] Energy from your opponent's Active Pokémon.", todo_implementation);
+    map.insert(
+        "Discard a [L] Energy from your opponent's Active Pokémon.",
+        Mechanic::DiscardOpponentActiveEnergyOfType {
+            energy_type: EnergyType::Lightning,
+        },
+    );
     map.insert(
         "Discard a [M] Energy from this Pokémon.",
         Mechanic::SelfDiscardEnergy {
@@ -178,10 +186,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Discard a random Energy from among the Energy attached to all Pokémon (both yours and your opponent's).",
         Mechanic::DiscardRandomGlobalEnergy { count: 1 },
     );
-    // map.insert("Discard a random Energy from both Active Pokémon.", todo_implementation);
+    map.insert(
+        "Discard a random Energy from both Active Pokémon.",
+        Mechanic::DiscardRandomEnergyBothActive,
+    );
     map.insert(
         "Discard a random Energy from this Pokémon.",
-        Mechanic::SelfDiscardRandomEnergy,
+        Mechanic::SelfDiscardRandomEnergy { count: 1 },
     );
     map.insert(
         "Discard a random Energy from your opponent's Active Pokémon.",
@@ -225,6 +236,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("Discard up to 2 Pokémon Tool cards from your hand. This attack does 50 damage for each card you discarded in this way.", todo_implementation);
     map.insert("Draw a card.", Mechanic::DrawCard { amount: 1 });
+    map.insert(
+        "Draw a card for each Poochyena you have in play.",
+        Mechanic::DrawPerPokemonWithName {
+            name: "Poochyena".to_string(),
+        },
+    );
     // map.insert("Draw cards until you have the same number of cards in your hand as your opponent.", todo_implementation);
     map.insert(
         "During your next turn, this Pokémon can't attack.",
@@ -576,6 +593,22 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             num_coins: 2,
         },
     );
+    map.insert(
+        "Flip 2 coins. This attack does 60 damage for each heads.",
+        Mechanic::ExtraDamageForEachHeads {
+            include_fixed_damage: false,
+            damage_per_head: 60,
+            num_coins: 2,
+        },
+    );
+    map.insert(
+        "Flip 3 coins. This attack does 80 damage for each heads.",
+        Mechanic::ExtraDamageForEachHeads {
+            include_fixed_damage: false,
+            damage_per_head: 80,
+            num_coins: 3,
+        },
+    );
     map.insert("Flip 3 coins. For each heads, a card is chosen at random from your opponent's hand. Your opponent reveals that card and shuffles it into their deck.", Mechanic::CoinFlipsShuffleOpponentHandCards { num_coins: 3 });
     map.insert("Flip 3 coins. Take an amount of [R] Energy from your Energy Zone equal to the number of heads and attach it to your Benched [R] Pokémon in any way you like.", Mechanic::MoltresExInfernoDance);
     map.insert(
@@ -668,8 +701,18 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     map.insert("Flip a coin for each Energy attached to this Pokémon. This attack does 50 damage for each heads.", Mechanic::CelebiExPowerfulBloom);
-    // map.insert("Flip a coin for each Pokémon you have in play. This attack does 20 damage for each heads.", todo_implementation);
-    // map.insert("Flip a coin for each Pokémon you have in play. This attack does 40 damage for each heads.", todo_implementation);
+    map.insert(
+        "Flip a coin for each Pokémon you have in play. This attack does 20 damage for each heads.",
+        Mechanic::CoinFlipPerPokemonInPlay {
+            damage_per_head: 20,
+        },
+    );
+    map.insert(
+        "Flip a coin for each Pokémon you have in play. This attack does 40 damage for each heads.",
+        Mechanic::CoinFlipPerPokemonInPlay {
+            damage_per_head: 40,
+        },
+    );
     map.insert(
         "Flip a coin for each [M] Energy attached to this Pokémon. This attack does 50 damage for each heads.",
         Mechanic::CoinFlipPerSpecificEnergyType {
@@ -780,7 +823,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Flip a coin. If heads, this attack does 60 more damage.",
         Mechanic::CoinFlipExtraDamage { extra_damage: 60 },
     );
-    // map.insert("Flip a coin. If heads, this attack does 60 more damage. If tails, this Pokémon also does 20 damage to itself.", todo_implementation);
+    map.insert(
+        "Flip a coin. If heads, this attack does 60 more damage. If tails, this Pokémon also does 20 damage to itself.",
+        Mechanic::CoinFlipExtraDamageOrSelfDamage {
+            extra_damage: 60,
+            self_damage: 20,
+        },
+    );
     map.insert(
         "Flip a coin. If heads, this attack does 70 more damage.",
         Mechanic::CoinFlipExtraDamage { extra_damage: 70 },
@@ -795,11 +844,22 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::OminousClaw,
     );
     // map.insert("Flip a coin. If heads, your opponent shuffles their Active Pokémon into their deck.", todo_implementation);
-    // map.insert("Flip a coin. If heads, your opponent's Active Pokémon is now Burned.", todo_implementation);
+    map.insert(
+        "Flip a coin. If heads, your opponent's Active Pokémon is now Burned.",
+        Mechanic::ChanceStatusAttack {
+            condition: StatusCondition::Burned,
+        },
+    );
     map.insert(
         "Flip a coin. If heads, your opponent's Active Pokémon is now Confused.",
         Mechanic::ChanceStatusAttack {
             condition: StatusCondition::Confused,
+        },
+    );
+    map.insert(
+        "Flip a coin. If heads, your opponent's Active Pokémon is now Confused. If tails, this Pokémon is now Confused.",
+        Mechanic::CoinFlipStatusSelfOrOpponent {
+            status: StatusCondition::Confused,
         },
     );
     map.insert(
@@ -808,10 +868,27 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             condition: StatusCondition::Paralyzed,
         },
     );
-    // map.insert("Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed. If tails, your opponent's Active Pokémon is now Confused.", todo_implementation);
-    // map.insert("Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned and Paralyzed.", todo_implementation);
-    // map.insert("Flip a coin. If heads, your opponent's Active Pokémon's remaining HP is now 10.", todo_implementation);
-    // map.insert("Flip a coin. If tails, discard 2 random Energy from this Pokémon.", todo_implementation);
+    map.insert(
+        "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed. If tails, your opponent's Active Pokémon is now Confused.",
+        Mechanic::CoinFlipStatusOutcome {
+            heads_status: StatusCondition::Paralyzed,
+            tails_status: StatusCondition::Confused,
+        },
+    );
+    map.insert(
+        "Flip a coin. If heads, your opponent's Active Pokémon is now Poisoned and Paralyzed.",
+        Mechanic::ChanceMultipleStatusAttack {
+            conditions: vec![StatusCondition::Poisoned, StatusCondition::Paralyzed],
+        },
+    );
+    map.insert(
+        "Flip a coin. If heads, your opponent's Active Pokémon's remaining HP is now 10.",
+        Mechanic::CoinFlipSetOpponentHpTo { hp: 10 },
+    );
+    map.insert(
+        "Flip a coin. If tails, discard 2 random Energy from this Pokémon.",
+        Mechanic::CoinFlipSelfDiscardRandomEnergy { count: 2 },
+    );
     // map.insert("Flip a coin. If tails, during your next turn, this Pokémon can't attack.", todo_implementation);
     map.insert(
         "Flip a coin. If tails, this Pokémon also does 20 damage to itself.",
@@ -844,7 +921,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Heal 20 damage from this Pokémon.",
         Mechanic::SelfHeal { amount: 20 },
     );
-    // map.insert("Heal 30 damage from each of your Benched Basic Pokémon.", todo_implementation);
+    map.insert(
+        "Heal 30 damage from each of your Benched Basic Pokémon.",
+        Mechanic::HealAllBenchedPokemon {
+            amount: 30,
+            only_basic: true,
+        },
+    );
     map.insert(
         "Heal 30 damage from this Pokémon.",
         Mechanic::SelfHeal { amount: 30 },
@@ -862,7 +945,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Heal 40 damage from this Pokémon.",
         Mechanic::SelfHeal { amount: 40 },
     );
-    // map.insert("Heal 50 damage from 1 of your Benched Pokémon.", todo_implementation);
+    map.insert(
+        "Heal 50 damage from 1 of your Benched Pokémon.",
+        Mechanic::HealOneYourBenchedPokemon { amount: 50 },
+    );
     // map.insert("Heal from this Pokémon the same amount of damage you did to your opponent's Active Pokémon.", todo_implementation);
     map.insert(
         "If 1 of your Pokémon used Sweets Relay during your last turn, this attack does 20 more damage.",
@@ -1960,12 +2046,18 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Flip a coin. If heads, this attack also does 40 damage to 1 of your opponent's Benched Pokémon.",
         Mechanic::CoinFlipAlsoChoiceBenchDamage { opponent: true, damage: 40 },
     );
-    // map.insert("Flip a coin. If heads, this attack does 70 damage to your opponent's Active Pokémon. If tails, heal 30 damage from your opponent's Active Pokémon.", todo_implementation);
+    map.insert(
+        "Flip a coin. If heads, this attack does 70 damage to your opponent's Active Pokémon. If tails, heal 30 damage from your opponent's Active Pokémon.",
+        Mechanic::CoinFlipDamageOrHealOpponent { damage: 70, heal: 30 },
+    );
     map.insert(
         "Flip a coin. If tails, this Pokémon also does 50 damage to itself.",
         Mechanic::CoinFlipSelfDamage { self_damage: 50 },
     );
-    // map.insert("Heal 20 damage from 1 of your Pokémon.", todo_implementation);
+    map.insert(
+        "Heal 20 damage from 1 of your Pokémon.",
+        Mechanic::HealOneYourPokemon { amount: 20 },
+    );
     // map.insert("If Plusle is on your Bench, this attack also does 10 damage to each of your opponent's Benched Pokémon.", todo_implementation);
     // map.insert("If a Stadium is in play, this attack does 40 more damage.", todo_implementation);
     map.insert(
@@ -2074,7 +2166,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Choose a spot from among your opponent's Active Spot and Bench. At the end of your opponent's next turn, do 70 damage to the Pokémon in the spot you chose.",
         Mechanic::DelayedSpotDamage { amount: 70 },
     );
-    // map.insert("Discard 2 [F] Energy from this Pokémon.", todo_implementation);
+    map.insert(
+        "Discard 2 [F] Energy from this Pokémon.",
+        Mechanic::SelfDiscardEnergy {
+            energies: vec![EnergyType::Fighting, EnergyType::Fighting],
+        },
+    );
     map.insert(
         "Discard all [W] Energy from this Pokémon. This attack does 130 damage to 1 of your opponent's Pokémon.",
         Mechanic::SelfDiscardAllTypeEnergyAndDamageAnyOpponentPokemon {
@@ -2238,8 +2335,18 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             conditions: vec![StatusCondition::Poisoned],
         },
     );
-    // map.insert("Discard a [D] Energy from this Pokémon.", todo_implementation);
-    // map.insert("Discard a [R] Energy from your opponent's Active Pokémon.", todo_implementation);
+    map.insert(
+        "Discard a [D] Energy from this Pokémon.",
+        Mechanic::SelfDiscardEnergy {
+            energies: vec![EnergyType::Darkness],
+        },
+    );
+    map.insert(
+        "Discard a [R] Energy from your opponent's Active Pokémon.",
+        Mechanic::DiscardOpponentActiveEnergyOfType {
+            energy_type: EnergyType::Fire,
+        },
+    );
     // map.insert("Discard a [W] Energy from this Pokémon, and this attack also does 40 damage to 1 of your opponent's Benched Pokémon.", todo_implementation);
     map.insert(
         "Discard the top card of your deck.",
@@ -2290,6 +2397,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     map.insert(
         "Heal 10 damage from each of your Pokémon.",
         Mechanic::HealAllYourPokemon { amount: 10 },
+    );
+    map.insert(
+        "Heal 10 damage from each of your Benched Pokémon.",
+        Mechanic::HealAllBenchedPokemon {
+            amount: 10,
+            only_basic: false,
+        },
     );
     // map.insert("Heal 20 damage from each of your [P] Pokémon.", todo_implementation);
     map.insert(

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -8,16 +8,22 @@ mod alcremie_test;
 mod alolan_marowak_test;
 #[path = "pokemon/alolan_sandslash_spike_armor_test.rs"]
 mod alolan_sandslash_spike_armor_test;
+#[path = "pokemon/alomomola_hooh_test.rs"]
+mod alomomola_hooh_test;
 #[path = "pokemon/altaria_dragon_arcana_test.rs"]
 mod altaria_dragon_arcana_test;
 #[path = "pokemon/ambipom_b1_test.rs"]
 mod ambipom_b1_test;
 #[path = "pokemon/applin_share_test.rs"]
 mod applin_share_test;
+#[path = "pokemon/arcanine_test.rs"]
+mod arcanine_test;
 #[path = "pokemon/arceus_ex_test.rs"]
 mod arceus_ex_test;
 #[path = "pokemon/audino_test.rs"]
 mod audino_test;
+#[path = "pokemon/azurill_spritzee_test.rs"]
+mod azurill_spritzee_test;
 #[path = "pokemon/bellossom_a4_test.rs"]
 mod bellossom_a4_test;
 #[path = "pokemon/blastoise_double_splash_test.rs"]
@@ -60,8 +66,14 @@ mod corviknight_line_test;
 mod cradily_stick_and_absorb_test;
 #[path = "pokemon/crawdaunt_unruly_claw_test.rs"]
 mod crawdaunt_unruly_claw_test;
+#[path = "pokemon/croagunk_toxicroak_test.rs"]
+mod croagunk_toxicroak_test;
 #[path = "pokemon/darkrai_ex_test.rs"]
 mod darkrai_ex_test;
+#[path = "pokemon/dedenne_surskit_test.rs"]
+mod dedenne_surskit_test;
+#[path = "pokemon/delibird_test.rs"]
+mod delibird_test;
 #[path = "pokemon/dragonair_dragons_blessing_test.rs"]
 mod dragonair_dragons_blessing_test;
 #[path = "pokemon/drapion_a2_test.rs"]
@@ -80,6 +92,10 @@ mod eelektross_energy_crush_test;
 mod emboar_flare_storm_test;
 #[path = "pokemon/emolga_dedenne_ex_tool_damage_test.rs"]
 mod emolga_dedenne_ex_tool_damage_test;
+#[path = "pokemon/entei_test.rs"]
+mod entei_test;
+#[path = "pokemon/farigiraf_dipplin_test.rs"]
+mod farigiraf_dipplin_test;
 #[path = "pokemon/flutter_mane_ex_test.rs"]
 mod flutter_mane_ex_test;
 #[path = "pokemon/flygon_ex_test.rs"]
@@ -90,6 +106,8 @@ mod gallade_test;
 mod gardevoir_psy_turbo_test;
 #[path = "pokemon/gigalith_ex_megaton_cannon_test.rs"]
 mod gigalith_ex_megaton_cannon_test;
+#[path = "pokemon/giratina_rayquaza_test.rs"]
+mod giratina_rayquaza_test;
 #[path = "pokemon/grovyle_slicing_snipe_test.rs"]
 mod grovyle_slicing_snipe_test;
 #[path = "pokemon/growlithe_puppy_pile_test.rs"]
@@ -136,10 +154,14 @@ mod jolteon_ex_test;
 mod klefki_dismantling_keys_test;
 #[path = "pokemon/kommo_o_clanging_scales_test.rs"]
 mod kommo_o_clanging_scales_test;
+#[path = "pokemon/koraidon_urshifu_test.rs"]
+mod koraidon_urshifu_test;
 #[path = "pokemon/krookodile_a3a_poaching_fangs_test.rs"]
 mod krookodile_a3a_poaching_fangs_test;
 #[path = "pokemon/kubfu_training_test.rs"]
 mod kubfu_training_test;
+#[path = "pokemon/lanturn_ex_test.rs"]
+mod lanturn_ex_test;
 #[path = "pokemon/legacy_ability_logic_test.rs"]
 mod legacy_ability_logic_test;
 #[path = "pokemon/lucario_b3_test.rs"]
@@ -168,6 +190,8 @@ mod maushold_b2a_test;
 mod mega_camerupt_ex_test;
 #[path = "pokemon/mega_diancie_ex_test.rs"]
 mod mega_diancie_ex_test;
+#[path = "pokemon/mega_houndoom_ex_test.rs"]
+mod mega_houndoom_ex_test;
 #[path = "pokemon/mega_kangaskhan_double_punching_family_test.rs"]
 mod mega_kangaskhan_double_punching_family_test;
 #[path = "pokemon/mega_medicham_ex_test.rs"]
@@ -196,6 +220,8 @@ mod miraidon_ex_test;
 mod morpeko_test;
 #[path = "pokemon/ninetales_ember_dance_test.rs"]
 mod ninetales_ember_dance_test;
+#[path = "pokemon/oricorio_yveltal_test.rs"]
+mod oricorio_yveltal_test;
 #[path = "pokemon/passimian_ex_offload_pass_test.rs"]
 mod passimian_ex_offload_pass_test;
 #[path = "pokemon/persian_test.rs"]
@@ -204,6 +230,8 @@ mod persian_test;
 mod pidgeot_twister_test;
 #[path = "pokemon/politoed_raid_test.rs"]
 mod politoed_raid_test;
+#[path = "pokemon/poochyena_test.rs"]
+mod poochyena_test;
 #[path = "pokemon/porygon2_buggy_evolution_test.rs"]
 mod porygon2_buggy_evolution_test;
 #[path = "pokemon/porygonz_buggy_beam_test.rs"]
@@ -212,6 +240,8 @@ mod porygonz_buggy_beam_test;
 mod porygonz_cyberjack_test;
 #[path = "pokemon/primarina_melodious_healing_test.rs"]
 mod primarina_melodious_healing_test;
+#[path = "pokemon/psyduck_b4_test.rs"]
+mod psyduck_b4_test;
 #[path = "pokemon/psyduck_test.rs"]
 mod psyduck_test;
 #[path = "pokemon/purrloin_test.rs"]
@@ -256,6 +286,8 @@ mod sylveon_soothing_ribbon_test;
 mod tandemaus_b2_test;
 #[path = "pokemon/tapu_lele_energy_arrow_test.rs"]
 mod tapu_lele_energy_arrow_test;
+#[path = "pokemon/tentacruel_test.rs"]
+mod tentacruel_test;
 #[path = "pokemon/tepig_stoke_test.rs"]
 mod tepig_stoke_test;
 #[path = "pokemon/terapagos_ex_test.rs"]
@@ -278,8 +310,12 @@ mod vulpix_tail_whip_test;
 mod wailord_ex_wondrous_waves_test;
 #[path = "pokemon/wailord_test.rs"]
 mod wailord_test;
+#[path = "pokemon/whiscash_test.rs"]
+mod whiscash_test;
 #[path = "pokemon/wugtrio_b2a_test.rs"]
 mod wugtrio_b2a_test;
+#[path = "pokemon/xatu_test.rs"]
+mod xatu_test;
 #[path = "pokemon/xerneas_geoburst_test.rs"]
 mod xerneas_geoburst_test;
 #[path = "pokemon/zarude_dark_vengeance_test.rs"]

--- a/tests/pokemon/alomomola_hooh_test.rs
+++ b/tests/pokemon/alomomola_hooh_test.rs
@@ -1,0 +1,85 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+fn damaged_playable(card_id: CardId, damage: u32) -> PlayedCard {
+    PlayedCard::new(get_card_by_enum(card_id), damage, 70, vec![], false, vec![])
+}
+
+#[test]
+fn test_alomomola_heals_each_benched_pokemon() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B4045Alomomola)
+            .with_energy(vec![EnergyType::Water, EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    // Two damaged benched Pokémon (40 remaining each)
+    state.in_play_pokemon[0][1] = Some(damaged_playable(CardId::A1001Bulbasaur, 30));
+    state.in_play_pokemon[0][2] = Some(damaged_playable(CardId::A1002Ivysaur, 30));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4045Alomomola, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // Both healed by 10: 40 -> 50
+    let bench1 = state.in_play_pokemon[0][1].as_ref().unwrap();
+    let bench2 = state.in_play_pokemon[0][2].as_ref().unwrap();
+    assert_eq!(bench1.get_remaining_hp(), 50);
+    assert_eq!(bench2.get_remaining_hp(), 50);
+}
+
+#[test]
+fn test_ho_oh_sacred_fire_heals_only_benched_basic() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1032HoOh).with_energy(vec![
+            EnergyType::Fire,
+            EnergyType::Fire,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+    );
+    // Basic Bulbasaur and evolved Ivysaur, both damaged (40 remaining)
+    state.in_play_pokemon[0][1] = Some(damaged_playable(CardId::A1001Bulbasaur, 30));
+    state.in_play_pokemon[0][2] = Some(damaged_playable(CardId::A1002Ivysaur, 30));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1032HoOh, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // Basic healed by 30: 40 -> 70; evolved NOT healed (stays 40)
+    let basic = state.in_play_pokemon[0][1].as_ref().unwrap();
+    let evolved = state.in_play_pokemon[0][2].as_ref().unwrap();
+    assert_eq!(
+        basic.get_remaining_hp(),
+        70,
+        "Basic benched should be healed"
+    );
+    assert_eq!(
+        evolved.get_remaining_hp(),
+        40,
+        "Evolved benched should NOT be healed"
+    );
+}

--- a/tests/pokemon/arcanine_test.rs
+++ b/tests/pokemon/arcanine_test.rs
@@ -1,0 +1,33 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_arcanine_flame_mane_always_deals_damage_and_heads_burns() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B1029Arcanine)
+                .with_energy(vec![EnergyType::Fire, EnergyType::Fire])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B1029Arcanine, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // 50 damage always
+        assert_eq!(state.get_active(1).get_remaining_hp(), 100, "seed {seed}");
+    }
+}

--- a/tests/pokemon/azurill_spritzee_test.rs
+++ b/tests/pokemon/azurill_spritzee_test.rs
@@ -1,0 +1,66 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+fn damaged_bench_bulbasaur(damage: u32) -> PlayedCard {
+    let bulbasaur = get_card_by_enum(CardId::A1001Bulbasaur);
+    PlayedCard::new(bulbasaur, damage, 70, vec![], false, vec![])
+}
+
+#[test]
+fn test_azurill_splash_heals_50_from_one_benched() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A4a063Azurill)],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    // One damaged benched Pokémon (40 remaining) -> the heal choice is forced
+    state.in_play_pokemon[0][1] = Some(damaged_bench_bulbasaur(30));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A4a063Azurill, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    let benched = state.in_play_pokemon[0][1].as_ref().expect("benched");
+    // 40 + 50 = 90, capped at 70 max HP
+    assert_eq!(benched.get_remaining_hp(), 70);
+}
+
+#[test]
+fn test_spritzee_fairy_wind_heals_20_from_one_pokemon() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1a035Spritzee).with_energy(vec![EnergyType::Psychic])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    // One damaged benched Pokémon (40 remaining) -> the heal choice is forced
+    state.in_play_pokemon[0][1] = Some(damaged_bench_bulbasaur(30));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1a035Spritzee, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    let benched = state.in_play_pokemon[0][1].as_ref().expect("benched");
+    // 40 + 20 = 60
+    assert_eq!(benched.get_remaining_hp(), 60);
+}

--- a/tests/pokemon/croagunk_toxicroak_test.rs
+++ b/tests/pokemon/croagunk_toxicroak_test.rs
@@ -1,0 +1,75 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_croagunk_flips_one_coin_per_pokemon_in_play() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::A2107Croagunk)
+                    .with_energy(vec![EnergyType::Darkness, EnergyType::Darkness]),
+                PlayedCard::from_id(CardId::A1001Bulbasaur),
+                PlayedCard::from_id(CardId::A1002Ivysaur),
+            ],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A2107Croagunk, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let remaining = state.get_active(1).get_remaining_hp();
+        // 3 Pokémon in play -> 3 coins -> damage {0, 20, 40, 60}
+        assert!(
+            [150, 130, 110, 90].contains(&remaining),
+            "seed {seed}: 3 coins of 20, got remaining {remaining}"
+        );
+    }
+}
+
+#[test]
+fn test_toxicroak_flips_one_coin_per_pokemon_in_play() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::A2108Toxicroak)
+                    .with_energy(vec![EnergyType::Darkness, EnergyType::Darkness]),
+                PlayedCard::from_id(CardId::A1001Bulbasaur),
+            ],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A2108Toxicroak, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let remaining = state.get_active(1).get_remaining_hp();
+        // 2 Pokémon in play -> 2 coins -> damage {0, 40, 80}
+        assert!(
+            [150, 110, 70].contains(&remaining),
+            "seed {seed}: 2 coins of 40, got remaining {remaining}"
+        );
+    }
+}

--- a/tests/pokemon/dedenne_surskit_test.rs
+++ b/tests/pokemon/dedenne_surskit_test.rs
@@ -1,0 +1,64 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_dedenne_thunder_wave_discards_lightning_from_opponent() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B1094Dedenne).with_energy(vec![EnergyType::Colorless])],
+        // Opponent with 2 [L] attached
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)
+            .with_energy(vec![EnergyType::Lightning, EnergyType::Lightning])],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1094Dedenne, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 20 damage -> Snorlax 130
+    assert_eq!(state.get_active(1).get_remaining_hp(), 130);
+    // One [L] discarded from opponent's active
+    assert_eq!(state.get_active(1).attached_energy.len(), 1);
+    assert_eq!(state.discard_energies[1].len(), 1);
+    assert_eq!(state.discard_energies[1][0], EnergyType::Lightning);
+}
+
+#[test]
+fn test_surskit_bubble_discards_fire_from_opponent() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B3009Surskit).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)
+            .with_energy(vec![EnergyType::Fire, EnergyType::Fire])],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3009Surskit, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 10 damage -> Snorlax 140
+    assert_eq!(state.get_active(1).get_remaining_hp(), 140);
+    assert_eq!(state.get_active(1).attached_energy.len(), 1);
+    assert_eq!(state.discard_energies[1].len(), 1);
+    assert_eq!(state.discard_energies[1][0], EnergyType::Fire);
+}

--- a/tests/pokemon/delibird_test.rs
+++ b/tests/pokemon/delibird_test.rs
@@ -1,0 +1,37 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_delibird_present_damages_or_heals_opponent() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B2032Delibird)
+                .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B2032Delibird, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let remaining = state.get_active(1).get_remaining_hp();
+        // heads: 70 damage -> 80; tails: heal 30 from full -> stays 150
+        assert!(
+            [80, 150].contains(&remaining),
+            "seed {seed}: heads 70 dmg / tails heal, got {remaining}"
+        );
+    }
+}

--- a/tests/pokemon/entei_test.rs
+++ b/tests/pokemon/entei_test.rs
@@ -1,0 +1,49 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_entei_fire_spin_tails_discards_two_random_energy() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::A4033Entei).with_energy(vec![
+                EnergyType::Fire,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ])],
+            vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A4033Entei, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // 110 damage -> Wailord 140
+        assert_eq!(state.get_active(1).get_remaining_hp(), 140, "seed {seed}");
+        // heads: keeps 4 energies; tails: discards 2 -> keeps 2
+        let remaining = state.get_active(0).attached_energy.len();
+        assert!(
+            [4, 2].contains(&remaining),
+            "seed {seed}: heads keeps 4 / tails discards 2, got {remaining}"
+        );
+        // Conservation: discarded energies landed in discard_energies
+        assert_eq!(
+            state.discard_energies[0].len(),
+            4 - remaining,
+            "seed {seed}"
+        );
+    }
+}

--- a/tests/pokemon/farigiraf_dipplin_test.rs
+++ b/tests/pokemon/farigiraf_dipplin_test.rs
@@ -1,0 +1,66 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_farigiraf_double_hit_flip_two_coins_sixty_per_heads() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B3a058Farigiraf)
+                .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B3a058Farigiraf, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let remaining = state.get_active(1).get_remaining_hp();
+        assert!(
+            [150, 90, 30].contains(&remaining),
+            "seed {seed}: Flip 2 coins, 60 per heads -> 0/60/120 damage, got {remaining}"
+        );
+    }
+}
+
+#[test]
+fn test_dipplin_double_hit_uses_same_effect_text() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B4126Dipplin)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Fire])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B4126Dipplin, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let remaining = state.get_active(1).get_remaining_hp();
+        assert!(
+            [150, 90, 30].contains(&remaining),
+            "seed {seed}: Dipplin shares Double Hit text, got {remaining}"
+        );
+    }
+}

--- a/tests/pokemon/giratina_rayquaza_test.rs
+++ b/tests/pokemon/giratina_rayquaza_test.rs
@@ -1,0 +1,71 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_giratina_shadow_force_discards_two_random_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::A2a061Giratina).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Psychic,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A2a061Giratina, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 120 damage -> Wailord 130
+    assert_eq!(state.get_active(1).get_remaining_hp(), 130);
+    // 2 of the 3 energies discarded
+    assert_eq!(state.get_active(0).attached_energy.len(), 1);
+    assert_eq!(state.discard_energies[0].len(), 2);
+}
+
+#[test]
+fn test_rayquaza_dragon_breath_discards_two_random_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B4119Rayquaza).with_energy(vec![
+            EnergyType::Fire,
+            EnergyType::Lightning,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4119Rayquaza, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 140 damage -> Wailord 110
+    assert_eq!(state.get_active(1).get_remaining_hp(), 110);
+    // 2 of the 4 energies discarded
+    assert_eq!(state.get_active(0).attached_energy.len(), 2);
+    assert_eq!(state.discard_energies[0].len(), 2);
+}

--- a/tests/pokemon/koraidon_urshifu_test.rs
+++ b/tests/pokemon/koraidon_urshifu_test.rs
@@ -1,0 +1,81 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_koraidon_collision_course_discards_two_fighting_energy() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B2a063Koraidon).with_energy(vec![
+                EnergyType::Fighting,
+                EnergyType::Fighting,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        // Wailord ex (Water) is not weak to Fighting
+        vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2a063Koraidon, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 120 damage -> Wailord 130
+    assert_eq!(state.get_active(1).get_remaining_hp(), 130);
+    // The 2 [F] were discarded, leaving only the 2 [C]
+    assert_eq!(state.get_active(0).attached_energy.len(), 2);
+    assert_eq!(state.discard_energies[0].len(), 2);
+    assert!(
+        state.discard_energies[0]
+            .iter()
+            .all(|&e| e == EnergyType::Fighting),
+        "discarded energies must be Fighting"
+    );
+}
+
+#[test]
+fn test_single_strike_urshifu_giga_impact_discards_one_darkness() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B3113SingleStrikeUrshifu).with_energy(vec![
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3113SingleStrikeUrshifu, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 110 damage -> Wailord 250 - 110 = 140
+    assert_eq!(state.get_active(1).get_remaining_hp(), 140);
+    // One [D] discarded: 3 - 1 = 2 remaining
+    assert_eq!(state.get_active(0).attached_energy.len(), 2);
+    assert_eq!(state.discard_energies[0].len(), 1);
+    assert_eq!(state.discard_energies[0][0], EnergyType::Darkness);
+}

--- a/tests/pokemon/lanturn_ex_test.rs
+++ b/tests/pokemon/lanturn_ex_test.rs
@@ -1,0 +1,46 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_lanturn_ex_flash_cannon_paralyzed_or_confused() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::A4065LanturnEx).with_energy(vec![
+                    EnergyType::Lightning,
+                    EnergyType::Colorless,
+                    EnergyType::Colorless,
+                ]),
+            ],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A4065LanturnEx, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        assert_eq!(
+            state.get_active(1).get_remaining_hp(),
+            70,
+            "seed {seed}: 80 damage"
+        );
+        // heads -> Paralyzed, tails -> Confused (always exactly one applies)
+        assert!(
+            state.get_active(1).is_paralyzed() || state.get_active(1).is_confused(),
+            "seed {seed}: opponent must be Paralyzed (heads) or Confused (tails)"
+        );
+    }
+}

--- a/tests/pokemon/mega_houndoom_ex_test.rs
+++ b/tests/pokemon/mega_houndoom_ex_test.rs
@@ -1,0 +1,42 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_mega_houndoom_ex_grimhound_flare_flip_three_coins_eighty_per_heads() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::PB080MegaHoundoomEx).with_energy(vec![
+                    EnergyType::Fire,
+                    EnergyType::Fire,
+                    EnergyType::Colorless,
+                ]),
+            ],
+            // Wailord ex (250 HP) survives the max 240 (3 heads) without a knockout
+            vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::PB080MegaHoundoomEx, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let remaining = state.get_active(1).get_remaining_hp();
+        assert!(
+            [250, 170, 90, 10].contains(&remaining),
+            "seed {seed}: Flip 3 coins, 80 per heads -> 0/80/160/240 damage, got {remaining}"
+        );
+    }
+}

--- a/tests/pokemon/oricorio_yveltal_test.rs
+++ b/tests/pokemon/oricorio_yveltal_test.rs
@@ -1,0 +1,73 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_oricorio_kindle_discards_random_energy_from_both_actives() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A3034Oricorio).with_energy(vec![
+            EnergyType::Fire,
+            EnergyType::Fire,
+            EnergyType::Grass,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)
+            .with_energy(vec![EnergyType::Lightning, EnergyType::Grass])],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3034Oricorio, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 40 damage -> Snorlax 110
+    assert_eq!(state.get_active(1).get_remaining_hp(), 110);
+    // One random energy discarded from EACH active
+    assert_eq!(state.get_active(0).attached_energy.len(), 2);
+    assert_eq!(state.get_active(1).attached_energy.len(), 1);
+    assert_eq!(state.discard_energies[0].len(), 1);
+    assert_eq!(state.discard_energies[1].len(), 1);
+}
+
+#[test]
+fn test_yveltal_evil_crash_discards_random_energy_from_both_actives() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2108Yveltal).with_energy(vec![
+            EnergyType::Darkness,
+            EnergyType::Darkness,
+            EnergyType::Darkness,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)
+            .with_energy(vec![EnergyType::Fire, EnergyType::Water])],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2108Yveltal, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 90 damage -> Snorlax 60
+    assert_eq!(state.get_active(1).get_remaining_hp(), 60);
+    assert_eq!(state.get_active(0).attached_energy.len(), 2);
+    assert_eq!(state.get_active(1).attached_energy.len(), 1);
+    assert_eq!(state.discard_energies[0].len(), 1);
+    assert_eq!(state.discard_energies[1].len(), 1);
+}

--- a/tests/pokemon/poochyena_test.rs
+++ b/tests/pokemon/poochyena_test.rs
@@ -1,0 +1,39 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_poochyena_bite_draws_per_poochyena_in_play() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B4093Poochyena).with_energy(vec![EnergyType::Darkness]),
+            PlayedCard::from_id(CardId::B4171Poochyena),
+            PlayedCard::from_id(CardId::B4171Poochyena),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    let hand_before = state.hands[0].len();
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4093Poochyena, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 3 Poochyena in play -> draw 3
+    assert_eq!(
+        state.hands[0].len(),
+        hand_before + 3,
+        "should draw one card per Poochyena in play"
+    );
+}

--- a/tests/pokemon/psyduck_b4_test.rs
+++ b/tests/pokemon/psyduck_b4_test.rs
@@ -1,0 +1,37 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_psyduck_b4_confusion_wave_confuses_opponent_or_self() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B4030Psyduck).with_energy(vec![EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B4030Psyduck, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // 10 damage always
+        assert_eq!(state.get_active(1).get_remaining_hp(), 140, "seed {seed}");
+        // heads -> opponent Confused, tails -> self Confused (exactly one)
+        assert!(
+            state.get_active(1).is_confused() || state.get_active(0).is_confused(),
+            "seed {seed}: either the opponent (heads) or Psyduck itself (tails) is Confused"
+        );
+    }
+}

--- a/tests/pokemon/tentacruel_test.rs
+++ b/tests/pokemon/tentacruel_test.rs
@@ -1,0 +1,44 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_tentacruel_poisoned_and_paralyzed_together_on_heads() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::A4a016Tentacruel).with_energy(vec![
+                    EnergyType::Water,
+                    EnergyType::Water,
+                    EnergyType::Colorless,
+                ]),
+            ],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A4a016Tentacruel, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // 50 damage always
+        assert_eq!(state.get_active(1).get_remaining_hp(), 100, "seed {seed}");
+        // Poisoned and Paralyzed always come together on heads
+        assert_eq!(
+            state.get_active(1).is_poisoned(),
+            state.get_active(1).is_paralyzed(),
+            "seed {seed}: Poisoned and Paralyzed must be applied together"
+        );
+    }
+}

--- a/tests/pokemon/whiscash_test.rs
+++ b/tests/pokemon/whiscash_test.rs
@@ -1,0 +1,55 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_whiscash_earthquake_extra_damage_or_self_damage() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![
+                PlayedCard::from_id(CardId::A2a017Whiscash).with_energy(vec![
+                    EnergyType::Water,
+                    EnergyType::Water,
+                    EnergyType::Colorless,
+                    EnergyType::Colorless,
+                ]),
+            ],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A2a017Whiscash, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let opponent_remaining = state.get_active(1).get_remaining_hp();
+        // heads: 80 + 60 = 140 -> 10; tails: 80 -> 70
+        assert!(
+            [10, 70].contains(&opponent_remaining),
+            "seed {seed}: heads 140 / tails 80, got {opponent_remaining}"
+        );
+        // heads: Whiscash unharmed (120); tails: takes 20 -> 100
+        let self_remaining = state.get_active(0).get_remaining_hp();
+        assert!(
+            [120, 100].contains(&self_remaining),
+            "seed {seed}: self 120 / 100, got {self_remaining}"
+        );
+        // Heads (140 dmg) must not coincide with self-damage, and vice-versa
+        assert_eq!(
+            opponent_remaining == 10,
+            self_remaining == 120,
+            "seed {seed}: heads heals nothing / tails damages self"
+        );
+    }
+}

--- a/tests/pokemon/xatu_test.rs
+++ b/tests/pokemon/xatu_test.rs
@@ -1,0 +1,37 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_xatu_foresight_heads_sets_opponent_hp_to_ten() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::A4082Xatu)
+                .with_energy(vec![EnergyType::Psychic, EnergyType::Psychic])],
+            vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A4082Xatu, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        // heads: HP set to 10; tails: unchanged (250)
+        let remaining = state.get_active(1).get_remaining_hp();
+        assert!(
+            [10, 250].contains(&remaining),
+            "seed {seed}: heads sets HP to 10 / tails leaves 250, got {remaining}"
+        );
+    }
+}


### PR DESCRIPTION
## What
Implements a broad set of simple/medium attack effects across 25 cards:

- **Coin-flip damage**: Farigiraf (B3a 058), Dipplin (B4 126), Mega Houndoom ex (P-B 080), Croagunk (A2 107, A2 173), Toxicroak (A2 108)
- **Coin-flip status**: Lanturn ex (A4 065/189/204, A4b 142), Arcanine (B1 029), Psyduck (B4 030), Tentacruel (A4a 016), Drapion (B1 153), Amoonguss (B3 108), Xatu (A4 082, A4 174), Delibird (B2 032), Entei (A4 033)
- **Heal**: Azurill (A4a 063, A4a 077), Spritzee (B1a 035), Alomomola (B4 045), Ho-Oh (B1 032)
- **Energy discard**: Koraidon (B2a 063), Single Strike Urshifu (B3 113), Giratina (A2a 061), Rayquaza (B4 119), Dedenne (B1 094), Surskit (B3 009), Oricorio (A3 034), Yveltal (B2 108, B2 175)
- **Draw**: Poochyena (B4 093, B4 171)

## How
New mechanics in `src/actions/attacks/mechanic.rs`:
- `CoinFlipPerPokemonInPlay`, `CoinFlipStatusOutcome`, `ChanceMultipleStatusAttack`, `CoinFlipStatusSelfOrOpponent`, `CoinFlipDamageOrHealOpponent`, `HealAllBenchedPokemon`, `DiscardOpponentActiveEnergyOfType`, `DiscardRandomEnergyBothActive`, `CoinFlipSelfDiscardRandomEnergy`, `CoinFlipSetOpponentHpTo`, `DrawPerPokemonWithName`
- Generalized `SelfDiscardRandomEnergy` from a unit variant to `{ count: usize }` (Giratina/Rayquaza discard 2)

Reused existing mechanics where possible (`ChanceStatusAttack`, `SelfDiscardEnergy`, and the heal helpers), wiring effect texts in `src/actions/effect_mechanic_map.rs`.

## Tests
- TDD at the public `Game` API level: 21 new test files under `tests/pokemon/`
- Seed-loops (`0..50`) assert damage ranges and status/energy invariants (e.g. conservation: discarded energies land in `discard_energies`)
- `cargo test --features test-utils --test pokemon`: 391 passed
- `cargo clippy` and `cargo fmt`: clean (pre-existing unrelated doc-comment lint in `victini_victory_star_test.rs` not touched)
- `cargo run --bin card_test` validated for all cards except B3 113, which has a separate unimplemented Ability (attack itself is wired and tested)