### PR TITLE
Implement Lana trainer card and fix a pre-existing clippy failure

### DIFF
--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -102,6 +102,7 @@ pub fn forecast_trainer_action(
         CardId::A2150Cyrus | CardId::A2190Cyrus | CardId::A4b326Cyrus | CardId::A4b327Cyrus => {
             Outcomes::single_fn(cyrus_effect)
         }
+        CardId::A3152Lana | CardId::A3194Lana => Outcomes::single_fn(lana_effect),
         CardId::A2155Mars | CardId::A2195Mars | CardId::A4b344Mars | CardId::A4b345Mars => {
             Outcomes::single_fn(mars_effect)
         }
@@ -658,6 +659,21 @@ fn cyrus_effect(_: &mut StdRng, state: &mut State, action: &Action) {
     let possible_moves = state
         .enumerate_bench_pokemon(opponent_player)
         .filter(|(_, x)| x.is_damaged())
+        .map(|(in_play_idx, _)| SimpleAction::Activate {
+            player: opponent_player,
+            in_play_idx,
+        })
+        .collect::<Vec<_>>();
+    state
+        .move_generation_stack
+        .push((action.actor, possible_moves));
+}
+
+fn lana_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    // Switch in 1 of your opponent's Benched Pokemon to the Active Spot.
+    let opponent_player = (action.actor + 1) % 2;
+    let possible_moves = state
+        .enumerate_bench_pokemon(opponent_player)
         .map(|(in_play_idx, _)| SimpleAction::Activate {
             player: opponent_player,
             in_play_idx,

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -576,16 +576,10 @@ pub fn get_ability_mechanic(card: &Card) -> Option<&'static AbilityMechanic> {
         return None;
     };
 
-    if let Some(ability) = &pokemon.ability {
-        let mechanic = ability_mechanic_from_effect(&ability.effect);
-        if let Some(mechanic) = mechanic {
-            Some(mechanic)
-        } else {
-            None
-        }
-    } else {
-        None
-    }
+    pokemon
+        .ability
+        .as_ref()
+        .and_then(|ability| ability_mechanic_from_effect(&ability.effect))
 }
 
 pub fn has_ability_mechanic(card: &Card, mechanic: &AbilityMechanic) -> bool {

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -108,6 +108,7 @@ pub fn trainer_move_generation_implementation(
         CardId::A2150Cyrus | CardId::A2190Cyrus | CardId::A4b326Cyrus | CardId::A4b327Cyrus => {
             can_play_cyrus(state, trainer_card)
         }
+        CardId::A3152Lana | CardId::A3194Lana => can_play_lana(state, trainer_card),
         CardId::A2155Mars | CardId::A2195Mars | CardId::A4b344Mars | CardId::A4b345Mars => {
             can_play_trainer(state, trainer_card)
         }
@@ -505,6 +506,20 @@ fn can_play_cyrus(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simpl
         .filter(|(_, x)| x.is_damaged())
         .count();
     if damaged_bench_count > 0 {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
+}
+
+/// Check if Lana can be played (requires Araquanid in play and opponent to have a benched pokemon)
+fn can_play_lana(state: &State, trainer_card: &TrainerCard) -> Option<Vec<SimpleAction>> {
+    let has_araquanid = state
+        .enumerate_in_play_pokemon(state.current_player)
+        .any(|(_, pokemon)| pokemon.get_name() == "Araquanid");
+    let opponent = (state.current_player + 1) % 2;
+    let opponent_has_bench = state.enumerate_bench_pokemon(opponent).count() > 0;
+    if has_araquanid && opponent_has_bench {
         can_play_trainer(state, trainer_card)
     } else {
         cannot_play_trainer()

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -18,6 +18,8 @@ mod jasmine_test;
 mod juliana_test;
 #[path = "trainers/korrina_cabbie_parasol_lady_test.rs"]
 mod korrina_cabbie_parasol_lady_test;
+#[path = "trainers/lana_test.rs"]
+mod lana_test;
 #[path = "trainers/mallow_test.rs"]
 mod mallow_test;
 #[path = "trainers/marlon_test.rs"]

--- a/tests/trainers/lana_test.rs
+++ b/tests/trainers/lana_test.rs
@@ -1,0 +1,95 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn lana_card() -> deckgym::models::TrainerCard {
+    match get_card_by_enum(CardId::A3152Lana) {
+        Card::Trainer(trainer_card) => trainer_card,
+        _ => panic!("Lana should be a Trainer card"),
+    }
+}
+
+/// Lana: "You can use this card only if you have Araquanid in play. Switch in 1 of your
+/// opponent's Benched Pokémon to the Active Spot."
+#[test]
+fn test_cannot_play_lana_without_araquanid() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![
+            PlayedCard::from_id(CardId::A1033Charmander),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+    state.hands[0].clear();
+    state.hands[0].push(Card::Trainer(lana_card()));
+    game.set_state(state);
+
+    let (_, actions) = game.get_state_clone().generate_possible_actions();
+    let can_play = actions
+        .iter()
+        .any(|a| matches!(&a.action, SimpleAction::Play { .. }));
+    assert!(
+        !can_play,
+        "Should not be able to play Lana without Araquanid in play, actions: {actions:?}"
+    );
+}
+
+/// Playing Lana with Araquanid in play lets the player switch in any of the opponent's
+/// Benched Pokémon (even undamaged ones) to the Active Spot.
+#[test]
+fn test_lana_switches_in_opponents_undamaged_benched_pokemon() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.set_board(
+        vec![
+            PlayedCard::from_id(CardId::B4047Araquanid),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1033Charmander),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+    state.hands[0].clear();
+    state.hands[0].push(Card::Trainer(lana_card()));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: lana_card(),
+        },
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(
+        choices.len(),
+        1,
+        "Opponent has 1 undamaged Benched Pokémon, should still be a valid Lana target"
+    );
+    assert!(matches!(
+        choices[0].action,
+        SimpleAction::Activate {
+            player: 1,
+            in_play_idx: 1
+        }
+    ));
+    game.apply_action(&choices[0]);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).card.get_name(),
+        "Bulbasaur",
+        "Opponent's Bulbasaur should now be Active"
+    );
+}


### PR DESCRIPTION
## Summary
- Implement the Lana Supporter card (`A3 152`, `A3 194`): "You can use this card only if you have Araquanid in play. Switch in 1 of your opponent's Benched Pokémon to the Active Spot."
  - Move generation gates play on having Araquanid in play and the opponent having at least one Benched Pokémon.
  - Apply-action logic mirrors Cyrus's switch-in pattern, but offers every Benched Pokémon (not just damaged ones) as a choice via `SimpleAction::Activate`.
- Fix a pre-existing `clippy::needless_match` failure in `get_ability_mechanic` (`src/actions/effect_ability_mechanic_map.rs`), unrelated to the Lana card, that a newer `stable` toolchain started flagging on `main` itself (verified failing identically on `main`'s own CI: https://github.com/bcollazo/deckgym-core/actions/runs/32543173129/job/96956896759). Kept as its own commit since it's an unrelated cleanup.

## Test plan
- [x] Added `tests/trainers/lana_test.rs` (Game public-API level, TDD-first): cannot play without Araquanid; switches in an undamaged opponent Benched Pokémon when Araquanid is in play.
- [x] `cargo test --features test-utils --test trainers` — all 63 trainer tests pass.
- [x] `cargo test --features "tui test-utils"` — full suite passes.
- [x] `cargo run --bin card_test -- "A3 152"` — 10,000 games across `example_decks/` complete without errors.
- [x] `cargo run --bin card_status` — both Lana printings now show `✓ Complete`.
- [x] `cargo fmt -- --check` and `cargo clippy --features "tui test-utils" -- -D warnings` (matching CI's exact command and toolchain) both pass clean.
