### PR TITLE
Defer knockout checks in end-of-turn effects to allow abilities to save Pokémon

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -182,6 +182,12 @@ pub enum AbilityMechanic {
     EndTurnHealSelfIfActive {
         amount: u32,
     },
+    /// Garganacl's Blessed Salt: "During Pokémon Checkup, heal `amount` damage from each of your
+    /// Pokémon." Passive and unconditional — applies every Pokémon Checkup regardless of whether
+    /// this Pokémon is Active or Benched, as long as it's in play.
+    HealAllYourPokemonDuringCheckup {
+        amount: u32,
+    },
     CoinFlipSleepOpponentActive,
     DiscardFromHandToDrawCard,
     ImmuneToStatusConditions,

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -314,6 +314,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::QuickGrowth => {
             panic!("QuickGrowth is triggered at the end of the opponent's turn")
         }
+        AbilityMechanic::HealAllYourPokemonDuringCheckup { .. } => {
+            panic!("HealAllYourPokemonDuringCheckup is a passive ability triggered during Pokemon Checkup")
+        }
         AbilityMechanic::VictoryStarReflip => victory_star_reflip(),
     }
 }

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -110,6 +110,12 @@ fn forecast_pokemon_checkup(state: &State) -> (Probabilities, Mutations) {
                 finish_turn_after_checkup(state, rng);
 
                 start_mutation(rng, state, action);
+
+                // Some end-of-turn damage (e.g. Deceptive Needle) defers its knockout check so
+                // that abilities triggered in this same window (e.g. Caterpie's Quick Growth,
+                // applied by `start_mutation` above) get a chance to evolve — and thus save —
+                // the target before it is finally checked for being Knocked Out.
+                handle_knockouts(state, (action.actor, 0), false);
             }));
         }
     }

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -233,12 +233,16 @@ fn apply_pokemon_checkup(
         let attacking_ref = (player, in_play_idx); // present it as self-damage
         let poison_damage = get_poison_damage(mutated_state, player, in_play_idx);
 
-        handle_damage(
+        // Knockout checks are deferred to the end of the whole end-of-turn/checkup sequence (see
+        // `handle_knockouts` call in `forecast_pokemon_checkup`), so that other checkup effects
+        // (e.g. Garganacl's Blessed Salt heal, below) get a chance to apply before a Pokémon that
+        // took lethal damage here is actually removed from play.
+        handle_damage_only(
             mutated_state,
             attacking_ref,
             &[(poison_damage, player, in_play_idx)],
             false,
-            None,
+            DamageModifierContext::default(),
         );
     }
 
@@ -249,12 +253,13 @@ fn apply_pokemon_checkup(
         }
 
         let attacking_ref = (player, in_play_idx); // present it as self-damage
-        handle_damage(
+                                                   // Deferred knockout check — see comment above the poison damage call.
+        handle_damage_only(
             mutated_state,
             attacking_ref,
             &[(20, player, in_play_idx)],
             false,
-            None,
+            DamageModifierContext::default(),
         );
 
         let heals_from_burn = outcome[num_sleeps + i];
@@ -293,6 +298,8 @@ fn apply_pokemon_checkup(
         debug!("{player}'s Pokemon {in_play_idx} is un-paralyzed");
     }
 
+    apply_checkup_healing_abilities(mutated_state);
+
     apply_snowy_terrain_checkup_damage(mutated_state);
 
     // Shift the per-turn KO flag. Turn advancement (including energy rotation) is performed
@@ -306,6 +313,37 @@ fn apply_pokemon_checkup(
 
 fn finish_turn_after_checkup(state: &mut State, rng: &mut StdRng) {
     state.advance_turn(rng);
+}
+
+/// Garganacl's Blessed Salt: "During Pokémon Checkup, heal `amount` damage from each of your
+/// Pokémon." Applies once per in-play Pokémon with this ability (so it stacks if a player somehow
+/// has more than one in play), healing every one of that ability's owner's in-play Pokémon
+/// (Active and Benched).
+fn apply_checkup_healing_abilities(state: &mut State) {
+    let healers: Vec<(usize, u32)> = (0..2)
+        .flat_map(|player| {
+            state
+                .enumerate_in_play_pokemon(player)
+                .filter_map(
+                    move |(_, pokemon)| match get_ability_mechanic(&pokemon.card) {
+                        Some(AbilityMechanic::HealAllYourPokemonDuringCheckup { amount }) => {
+                            Some((player, *amount))
+                        }
+                        _ => None,
+                    },
+                )
+        })
+        .collect();
+
+    for (player, amount) in healers {
+        debug!(
+            "Blessed Salt: Healing {} damage from each of player {}'s Pokémon",
+            amount, player
+        );
+        for pokemon in state.in_play_pokemon[player].iter_mut().flatten() {
+            pokemon.heal(amount);
+        }
+    }
 }
 
 fn apply_snowy_terrain_checkup_damage(state: &mut State) {
@@ -337,12 +375,12 @@ fn apply_snowy_terrain_checkup_damage(state: &mut State) {
                 "Snowy Terrain: Player {} active Pokémon deals {} checkup damage to opponent active",
                 source_player, checkup_damage
             );
-            handle_damage(
+            handle_damage_only(
                 state,
                 (source_player, 0),
                 &[(checkup_damage, target_player, 0)],
                 false,
-                None,
+                DamageModifierContext::default(),
             );
         }
     }
@@ -358,7 +396,13 @@ fn apply_snowy_terrain_checkup_damage(state: &mut State) {
                 "Sand Slammer: Player {} active Pokémon deals {} checkup damage to all opponent Pokémon",
                 source_player, checkup_damage
             );
-            handle_damage(state, (source_player, 0), &targets, false, None);
+            handle_damage_only(
+                state,
+                (source_player, 0),
+                &targets,
+                false,
+                DamageModifierContext::default(),
+            );
         }
     }
 }

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -564,6 +564,12 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             "At the end of your opponent's turn, if this Pokémon is in the Active Spot, put a random card from your deck that evolves from this Pokémon onto this Pokémon to evolve it.",
             AbilityMechanic::QuickGrowth,
         );
+
+        // b3a mechanics
+        map.insert(
+            "During Pokémon Checkup, heal 10 damage from each of your Pokémon.",
+            AbilityMechanic::HealAllYourPokemonDuringCheckup { amount: 10 },
+        );
         map
     });
 

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -22,7 +22,6 @@ pub(crate) use apply_action::apply_evolve;
 pub(crate) use apply_action::apply_place_card;
 pub(crate) use apply_action::forecast_action;
 pub(crate) use apply_action::resolve_pending_coin_reflip;
-pub(crate) use apply_action_helpers::handle_damage;
 pub(crate) use apply_action_helpers::handle_damage_only;
 pub(crate) use apply_action_helpers::handle_knockouts;
 pub use apply_trainer_action::may_effect;

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -431,6 +431,14 @@ fn apply_leftovers_healing(player_ending_turn: usize, state: &mut State) {
 
 /// Deceptive Needle: At the end of your turn, if the [D] Pokémon this card is attached to is in
 /// the Active Spot, do 10 damage to your opponent's Active Pokémon.
+///
+/// The knockout check for this damage is deliberately deferred (see
+/// `crate::actions::handle_damage_only` vs. `handle_damage`): the opponent's Active Pokémon may
+/// have an ability like Caterpie's Quick Growth that also triggers "at the end of your
+/// opponent's turn" and evolves it before the between-turns knockout check runs. If the
+/// evolution raises its max HP above the damage already taken, it survives — even if the damage
+/// dealt here would otherwise have been lethal. The caller is responsible for running the
+/// deferred knockout check (`crate::actions::handle_knockouts`) after such abilities resolve.
 fn apply_deceptive_needle_damage(player_ending_turn: usize, state: &mut State) {
     let Some(active) = state.maybe_get_active(player_ending_turn) else {
         return;
@@ -445,12 +453,12 @@ fn apply_deceptive_needle_damage(player_ending_turn: usize, state: &mut State) {
         return;
     }
     debug!("Deceptive Needle: Doing 10 damage to opponent's Active Pokémon");
-    crate::actions::handle_damage(
+    crate::actions::handle_damage_only(
         state,
         (player_ending_turn, 0),
         &[(10, opponent, 0)],
         false,
-        None,
+        DamageModifierContext::default(),
     );
 }
 

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -297,12 +297,13 @@ pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
         );
         // The opponent is the source of the delayed damage (they used the attack that caused it)
         let opponent = (player_ending_turn + 1) % 2;
-        crate::actions::handle_damage(
+        // Deferred knockout check — see the comment on `apply_deceptive_needle_damage` below.
+        crate::actions::handle_damage_only(
             state,
             (opponent, 0), // Opponent's active Pokemon as the source
             &[(total_delayed_damage, player_ending_turn, 0)], // Target is current player's active
             false,         // Not from an active attack (it's a delayed effect)
-            None,          // No attack name
+            DamageModifierContext::default(),
         );
     }
 
@@ -333,12 +334,13 @@ pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
             "Delayed spot damage: Applying {} damage to player {} slot {}",
             amount, target_player, target_in_play_idx
         );
-        crate::actions::handle_damage(
+        // Deferred knockout check — see the comment on `apply_deceptive_needle_damage` below.
+        crate::actions::handle_damage_only(
             state,
             (source_player, 0),
             &[(amount, target_player, target_in_play_idx)],
             false,
-            None,
+            DamageModifierContext::default(),
         );
     }
 
@@ -515,12 +517,13 @@ fn apply_bad_dreams_damage(state: &mut State) {
             "Bad Dreams: Player {}'s Darkrai deals {} damage to opponent's Asleep active",
             darkrai_owner, amount
         );
-        crate::actions::handle_damage(
+        // Deferred knockout check — see the comment on `apply_deceptive_needle_damage` below.
+        crate::actions::handle_damage_only(
             state,
             (darkrai_owner, darkrai_idx),
             &[(amount, opponent, 0)],
             false,
-            None,
+            DamageModifierContext::default(),
         );
     }
 }

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -205,6 +205,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::FutureSystem => false, // passive ability
         AbilityMechanic::TimeRecall => false,  // passive ability (consumed in attack generation)
         AbilityMechanic::QuickGrowth => false, // triggered at end of opponent's turn
+        AbilityMechanic::HealAllYourPokemonDuringCheckup { .. } => false, // passive, during Pokemon Checkup
         // Reactive: only offered via the move-generation stack right after an eligible [R]
         // coin-flip attack, never as a freely-selectable ability.
         AbilityMechanic::VictoryStarReflip => false,

--- a/tests/mechanics.rs
+++ b/tests/mechanics.rs
@@ -4,5 +4,7 @@ mod ability_effects_test;
 mod attack_effects_test;
 #[path = "mechanics/confusion_test.rs"]
 mod confusion_test;
+#[path = "mechanics/hoopa_ex_deceptive_needle_quick_growth_test.rs"]
+mod hoopa_ex_deceptive_needle_quick_growth_test;
 #[path = "mechanics/retreat_test.rs"]
 mod retreat_test;

--- a/tests/mechanics.rs
+++ b/tests/mechanics.rs
@@ -2,6 +2,8 @@
 mod ability_effects_test;
 #[path = "mechanics/attack_effects_test.rs"]
 mod attack_effects_test;
+#[path = "mechanics/basic_knockout_happy_paths_test.rs"]
+mod basic_knockout_happy_paths_test;
 #[path = "mechanics/confusion_test.rs"]
 mod confusion_test;
 #[path = "mechanics/end_of_turn_knockout_ordering_test.rs"]

--- a/tests/mechanics.rs
+++ b/tests/mechanics.rs
@@ -4,6 +4,8 @@ mod ability_effects_test;
 mod attack_effects_test;
 #[path = "mechanics/confusion_test.rs"]
 mod confusion_test;
+#[path = "mechanics/end_of_turn_knockout_ordering_test.rs"]
+mod end_of_turn_knockout_ordering_test;
 #[path = "mechanics/hoopa_ex_deceptive_needle_quick_growth_test.rs"]
 mod hoopa_ex_deceptive_needle_quick_growth_test;
 #[path = "mechanics/retreat_test.rs"]

--- a/tests/mechanics/basic_knockout_happy_paths_test.rs
+++ b/tests/mechanics/basic_knockout_happy_paths_test.rs
@@ -158,6 +158,8 @@ fn test_deceptive_needle_kos_plain_40_hp_pokemon_after_hoopa_ex_attack() {
         "Shadow Bullet should leave Rattata (40 HP) at 10 remaining HP"
     );
 
+    // TODO: attacking should really auto-sequence into ending the turn — the player shouldn't
+    // have to separately decide to end turn after there's nothing left to do but that.
     end_turn(&mut game, 0);
 
     let state = game.get_state_clone();

--- a/tests/mechanics/basic_knockout_happy_paths_test.rs
+++ b/tests/mechanics/basic_knockout_happy_paths_test.rs
@@ -1,0 +1,266 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard, StatusCondition},
+    state::GameOutcome,
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+fn end_turn(game: &mut deckgym::Game<'static>, actor: usize) {
+    game.apply_action(&Action {
+        actor,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+}
+
+/// Baseline happy path: a plain attack that knocks out the opponent's Active Pokémon should
+/// promote their Bench Pokémon and award points, leaving the new Active at full, undamaged HP.
+#[test]
+fn test_basic_attack_kos_active_and_promotes_bench() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+        vec![
+            PlayedCard::from_id(CardId::A1033Charmander).with_remaining_hp(30),
+            PlayedCard::from_id(CardId::A1189Rattata),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1001Bulbasaur, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_name(),
+        "Rattata",
+        "Rattata should have been promoted after Charmander (30 HP remaining) was KO'd by Vine Whip"
+    );
+    assert_eq!(
+        state.get_remaining_hp(1, 0),
+        40,
+        "The promoted Rattata should be at full, undamaged HP"
+    );
+    assert_eq!(
+        state.points[0], 1,
+        "A regular knockout should award 1 point"
+    );
+    assert_eq!(state.winner, None, "The game should still be ongoing");
+}
+
+/// An attack whose own damage is lethal AND which also inflicts a status condition on the same
+/// hit should still result in a clean knockout (the status-application code path shouldn't
+/// interfere with, or short-circuit, the knockout check for the same attack).
+#[test]
+fn test_lethal_attack_that_also_inflicts_status_still_results_in_knockout() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B1036MegaBlazikenEx)
+            .with_energy(vec![EnergyType::Fire, EnergyType::Fire])],
+        vec![
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1189Rattata),
+        ],
+    );
+
+    // Mega Burning: 120 damage (well past Bulbasaur's 70 HP) and burns the target — the target
+    // dies from the attack's own damage, the Burned status is just along for the ride.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1036MegaBlazikenEx, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_name(),
+        "Rattata",
+        "Rattata should have been promoted after Bulbasaur was KO'd by the lethal, burn-inflicting attack"
+    );
+    assert_eq!(
+        state.get_remaining_hp(1, 0),
+        40,
+        "The promoted Rattata should be untouched by the attack that KO'd Bulbasaur"
+    );
+    assert_eq!(
+        state.points[0], 1,
+        "A regular knockout should award 1 point"
+    );
+    assert_eq!(state.winner, None, "The game should still be ongoing");
+}
+
+/// Rocky Helmet's counterattack damage can knock out the attacker itself. If the attacker has no
+/// Bench Pokémon left, that immediately ends the game for the defending player — this exercises
+/// the *immediate* (non-deferred) knockout path used during attack resolution, which this PR's
+/// end-of-turn/checkup changes should not have touched.
+#[test]
+fn test_rocky_helmet_counterattack_kos_attacker_and_ends_game() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])
+            .with_remaining_hp(20)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_tool(get_card_by_enum(CardId::A2148RockyHelmet))],
+    );
+
+    // Vine Whip deals 40 to the Rocky Helmet holder (30 HP remaining, survives), but Rocky
+    // Helmet's 20 counterattack damage knocks out the attacker (20 HP remaining) in return.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1001Bulbasaur, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.winner,
+        Some(GameOutcome::Win(1)),
+        "Player 0's only Pokemon was KO'd by Rocky Helmet with no Bench to promote, ending the game"
+    );
+    assert_eq!(
+        state.points[1], 1,
+        "Player 1 should have scored a knockout point from the counterattack KO"
+    );
+}
+
+/// Hoopa ex's Shadow Bullet (30 damage) followed by Deceptive Needle's end-of-turn 10 damage
+/// should cleanly knock out a plain 40 HP Pokémon with no relevant abilities — the simplest case
+/// the deferred end-of-turn knockout check needs to still get right.
+#[test]
+fn test_deceptive_needle_kos_plain_40_hp_pokemon_after_hoopa_ex_attack() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4103HoopaEx)
+            .with_energy(vec![EnergyType::Darkness])
+            .with_tool(get_card_by_enum(CardId::B4148DeceptiveNeedle))],
+        vec![
+            PlayedCard::from_id(CardId::A1189Rattata),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4103HoopaEx, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    assert_eq!(
+        game.get_state_clone().get_remaining_hp(1, 0),
+        10,
+        "Shadow Bullet should leave Rattata (40 HP) at 10 remaining HP"
+    );
+
+    end_turn(&mut game, 0);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_name(),
+        "Bulbasaur",
+        "Bulbasaur should have been promoted after Deceptive Needle's 10 damage knocked out Rattata"
+    );
+    assert_eq!(
+        state.points[0], 1,
+        "A regular knockout should award 1 point"
+    );
+    assert_eq!(state.winner, None, "The game should still be ongoing");
+}
+
+/// Sanity check in the other direction: a non-lethal attack should leave the defender as the
+/// Active Pokémon, undamaged beyond the attack itself — nothing should get knocked out early.
+#[test]
+fn test_non_lethal_attack_does_not_knock_out_defender() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1001Bulbasaur, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_name(),
+        "Charmander",
+        "Charmander should survive a non-lethal Vine Whip and remain Active"
+    );
+    assert_eq!(
+        state.get_remaining_hp(1, 0),
+        20,
+        "60 HP - 40 damage = 20 HP remaining"
+    );
+    assert_eq!(state.points[0], 0, "No knockout should have occurred");
+    assert_eq!(state.winner, None);
+}
+
+/// Plain Burn damage during Pokémon Checkup, with no healing ability in play to save it, should
+/// still cleanly knock out the Pokémon and promote the Bench — the basic case the deferred
+/// checkup-knockout check needs to get right on its own, without any other effect involved.
+#[test]
+fn test_plain_burn_checkup_kos_without_any_saving_ability() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![
+            PlayedCard::from_id(CardId::A1033Charmander).with_remaining_hp(20),
+            PlayedCard::from_id(CardId::A1189Rattata),
+        ],
+    );
+    let mut state = game.get_state_clone();
+    state.apply_status_condition(1, 0, StatusCondition::Burned);
+    game.set_state(state);
+
+    end_turn(&mut game, 0);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_name(),
+        "Rattata",
+        "Rattata should have been promoted after Burn (20 damage) knocked out Charmander (20 HP remaining)"
+    );
+    assert_eq!(
+        state.points[0], 1,
+        "The opponent scores the point even though the knockout was from Burn, not an attack"
+    );
+    assert_eq!(state.winner, None);
+}
+
+/// Same as the Burn case above, but for Poison — the other checkup-damage status condition.
+#[test]
+fn test_plain_poison_checkup_kos_without_any_saving_ability() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![
+            PlayedCard::from_id(CardId::A1033Charmander).with_remaining_hp(10),
+            PlayedCard::from_id(CardId::A1189Rattata),
+        ],
+    );
+    let mut state = game.get_state_clone();
+    state.apply_status_condition(1, 0, StatusCondition::Poisoned);
+    game.set_state(state);
+
+    end_turn(&mut game, 0);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_name(),
+        "Rattata",
+        "Rattata should have been promoted after Poison (10 damage) knocked out Charmander (10 HP remaining)"
+    );
+    assert_eq!(
+        state.points[0], 1,
+        "The opponent scores the point even though the knockout was from Poison, not an attack"
+    );
+    assert_eq!(state.winner, None);
+}

--- a/tests/mechanics/end_of_turn_knockout_ordering_test.rs
+++ b/tests/mechanics/end_of_turn_knockout_ordering_test.rs
@@ -1,0 +1,123 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{Card, EnergyType, PlayedCard},
+    state::GameOutcome,
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Mega Blaziken ex's Mega Burning does 120 damage and burns the opponent's Active Pokémon.
+/// Between turns, burn deals another 20 damage during Pokémon Checkup, and (if the burned
+/// Pokémon's owner has a Garganacl in play) Garganacl's Blessed Salt heals 10 damage from each of
+/// its owner's Pokémon during that same checkup. The knockout check must not run until *all* of
+/// these checkup effects have applied, not immediately after burn's damage alone — otherwise a
+/// Pokémon that would have survived the net damage (attack + burn - Blessed Salt heal) gets
+/// discarded prematurely, before Garganacl's heal ever gets a chance to apply.
+///
+/// This test: a Mega Lucario ex (190 HP) that took the full net damage (120 + 20 - 10 = 130)
+/// still ends up exactly at 0 HP and knocked out — the point being that the KO is only decided
+/// after Garganacl's heal has been applied, not right after burn.
+#[test]
+fn test_burn_ko_is_decided_only_after_garganacl_heal_applies() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B1036MegaBlazikenEx)
+            .with_energy(vec![EnergyType::Fire, EnergyType::Fire])],
+        vec![
+            PlayedCard::from_id(CardId::B3081MegaLucarioEx).with_remaining_hp(130),
+            PlayedCard::from_id(CardId::B3a033Garganacl),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1036MegaBlazikenEx, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_remaining_hp(1, 0),
+        10,
+        "Mega Burning should leave Mega Lucario ex (130 HP remaining) at 10 HP and Burned"
+    );
+
+    // End Mega Blaziken ex's turn: burn (20) then Garganacl's heal (10) both apply during the
+    // between-turns Pokémon Checkup. Net: 130 HP remaining - 20 + 10 = 0 -> knocked out.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.points[0], 3,
+        "Knocking out a Mega ex Pokémon should award 3 points"
+    );
+    // Mega Lucario ex is worth 3 points on its own, so this KO immediately wins the game for
+    // player 0 (short-circuiting the promotion logic that would otherwise bring Garganacl up).
+    assert_eq!(
+        state.winner,
+        Some(GameOutcome::Win(0)),
+        "Knocking out Mega Lucario ex should immediately win the game for player 0"
+    );
+}
+
+/// Same interaction as above, but with a smaller net burn that Garganacl's heal actually saves:
+/// a Koraidon ex (150 HP) at 140 HP remaining takes 120 (Mega Burning) + 20 (burn) damage during
+/// the same turn/checkup sequence, which alone would be lethal (140 - 120 - 20 = -20). But
+/// Koraidon ex's owner also has a Garganacl in play, whose Blessed Salt heals 10 damage from each
+/// of their Pokémon during that same Pokémon Checkup — applied before the knockout check, this
+/// leaves Koraidon ex alive at 10 HP (140 - 120 - 20 + 10 = 10) instead of knocked out.
+#[test]
+fn test_garganacl_heal_saves_koraidon_ex_from_otherwise_lethal_burn() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B1036MegaBlazikenEx)
+            .with_energy(vec![EnergyType::Fire, EnergyType::Fire])],
+        vec![
+            PlayedCard::from_id(CardId::B3a036KoraidonEx).with_remaining_hp(140),
+            PlayedCard::from_id(CardId::B3a033Garganacl),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1036MegaBlazikenEx, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_remaining_hp(1, 0),
+        20,
+        "Mega Burning should leave Koraidon ex (140 HP remaining) at 20 HP and Burned"
+    );
+
+    // End Mega Blaziken ex's turn: burn (20) would be lethal on its own (20 - 20 == 0), but
+    // Garganacl's heal (10) applies in the same checkup before the knockout is decided.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_remaining_hp(1, 0),
+        10,
+        "Garganacl's Blessed Salt heal should save Koraidon ex from otherwise-lethal burn \
+         damage, leaving it at 10 HP (140 - 120 - 20 + 10)"
+    );
+    assert!(
+        matches!(&state.get_active(1).card, Card::Pokemon(p) if p.name == "Koraidon ex"),
+        "Koraidon ex should still be the Active Pokemon"
+    );
+    assert_eq!(
+        state.points[0], 0,
+        "Player 0 should not have scored any knockout points"
+    );
+}

--- a/tests/mechanics/hoopa_ex_deceptive_needle_quick_growth_test.rs
+++ b/tests/mechanics/hoopa_ex_deceptive_needle_quick_growth_test.rs
@@ -1,0 +1,71 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Interaction: Hoopa ex (holding Deceptive Needle) attacks a Caterpie (B3b 001) with Quick
+/// Growth for 30 damage via Shadow Bullet. Caterpie has 40 HP, so it survives at 10 remaining.
+/// At the end of Hoopa ex's turn, Deceptive Needle does an additional 10 damage to Caterpie,
+/// exactly enough to knock it out (30 + 10 == 40). However, Quick Growth also triggers "at the
+/// end of the opponent's turn" and evolves Caterpie into Metapod before the knockout is final,
+/// so Caterpie should survive as a Metapod (80 max HP) carrying the 40 damage over, i.e. left
+/// with 40 remaining HP, instead of being knocked out.
+#[test]
+fn test_deceptive_needle_lethal_damage_does_not_prevent_quick_growth_evolution() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4103HoopaEx)
+            .with_energy(vec![EnergyType::Darkness])
+            .with_tool(get_card_by_enum(CardId::B4148DeceptiveNeedle))],
+        vec![
+            PlayedCard::from_id(CardId::B3b001Caterpie),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+    let mut state = game.get_state_clone();
+    // Put exactly one Metapod (evolves from Caterpie) in player 1's deck.
+    state.decks[1].cards = vec![get_card_by_enum(CardId::B3b002Metapod)];
+    game.set_state(state);
+
+    // Hoopa ex attacks with Shadow Bullet (30 damage to active, 20 to a Benched Pokemon).
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4103HoopaEx, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let caterpie_hp_after_attack = game.get_state_clone().get_remaining_hp(1, 0);
+    assert_eq!(
+        caterpie_hp_after_attack, 10,
+        "Shadow Bullet should leave Caterpie (40 HP) at 10 remaining HP"
+    );
+
+    // End Hoopa ex's turn: Deceptive Needle does 10 more damage (30 + 10 == 40, lethal), but
+    // Quick Growth should evolve Caterpie into Metapod before the knockout is finalized.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    let active = state.get_active(1);
+    assert!(
+        matches!(&active.card, Card::Pokemon(p) if p.name == "Metapod"),
+        "Caterpie should have evolved into Metapod via Quick Growth despite lethal damage; got {:?}",
+        active.card.get_name()
+    );
+    assert_eq!(
+        active.get_remaining_hp(),
+        40,
+        "Metapod (80 HP) should carry over the 40 damage already dealt to Caterpie, leaving 40 HP"
+    );
+    assert!(
+        state.decks[1].cards.is_empty(),
+        "Metapod should have been removed from the deck"
+    );
+}


### PR DESCRIPTION
## Summary
This PR fixes a critical ordering bug where Pokémon were being knocked out immediately after taking end-of-turn damage, before other end-of-turn abilities had a chance to evolve or heal them. The fix defers knockout checks until after all end-of-turn effects have resolved.

## Key Changes

- **Deferred knockout checks in end-of-turn damage**: Modified `handle_damage` calls to use `handle_damage_only` (which skips knockout checks) in:
  - Poison damage during Pokémon Checkup
  - Burn damage during Pokémon Checkup
  - Deceptive Needle damage at end of turn
  - Bad Dreams damage at end of turn
  - Snowy Terrain checkup damage
  - Delayed spot damage effects

- **Added `apply_checkup_healing_abilities` function**: Implements Garganacl's Blessed Salt ability, which heals 10 damage from each of the player's Pokémon during Pokémon Checkup. This healing now applies before the deferred knockout check.

- **Added `HealAllYourPokemonDuringCheckup` ability mechanic**: New ability type for passive healing effects that trigger during Pokémon Checkup, mapped to Garganacl's Blessed Salt effect text.

- **Centralized deferred knockout check**: Added a single `handle_knockouts` call in `forecast_pokemon_checkup` after `start_mutation` completes, ensuring all end-of-turn abilities (like Quick Growth evolution) resolve before any Pokémon are removed from play.

## Notable Implementation Details

- The knockout check is now deferred to occur after `start_mutation` in the forecast flow, allowing abilities like Caterpie's Quick Growth to evolve the Pokémon before the knockout is finalized.
- If an evolution occurs and raises max HP above the damage taken, the Pokémon survives with the damage carried over to its new form.
- Healing abilities like Garganacl's Blessed Salt now apply before the knockout check, allowing them to save Pokémon that would otherwise be knocked out by the net damage (attack + burn - heal).

## Tests Added

- `test_burn_ko_is_decided_only_after_garganacl_heal_applies`: Verifies that Garganacl's heal applies before knockout is decided, resulting in a KO at exactly 0 HP.
- `test_garganacl_heal_saves_koraidon_ex_from_otherwise_lethal_burn`: Confirms that Garganacl's heal can save a Pokémon from otherwise lethal burn damage.
- `test_deceptive_needle_lethal_damage_does_not_prevent_quick_growth_evolution`: Ensures Quick Growth evolution occurs before Deceptive Needle damage results in a knockout.

https://claude.ai/code/session_01UG6K2yHinyemr7TsfGE3VQ