### PR TITLE
Implement B4a ex cards (Toxtricity, Zapdos, Moltres, Slowking, Weezing, Raticate) + Regidrago

### DIFF
--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -242,6 +242,10 @@ pub enum AbilityMechanic {
     /// now Paralyzed." Offered as an optional `UseAbility` when the evolution resolves.
     CoinFlipParalyzeOpponentActiveOnEvolve,
     DiscardRandomEnergyFromOpponentActiveOnEvolve,
+    /// Team Rocket's Weezing ex's Boiler Smog: "Once during your turn, when you play this
+    /// Pokémon from your hand to evolve 1 of your Pokémon, you may make your opponent's Active
+    /// Pokémon Poisoned and Burned."
+    PoisonAndBurnOpponentActiveOnEvolve,
     CanEvolveIntoEeveeEvolution,
     CanEvolveOnFirstTurnIfActive,
     CounterattackDamage {

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -246,6 +246,12 @@ pub enum AbilityMechanic {
     /// Pokémon from your hand to evolve 1 of your Pokémon, you may make your opponent's Active
     /// Pokémon Poisoned and Burned."
     PoisonAndBurnOpponentActiveOnEvolve,
+    /// Team Rocket's Raticate ex's Thieving Incisors: "Once during your turn, when you play this
+    /// Pokémon from your hand to evolve 1 of your Pokémon, you may move a random Energy from your
+    /// opponent's Active Pokémon to this Pokémon." Mirrors the "move the last-attached Energy
+    /// instead of a random one" simplification used elsewhere (e.g.
+    /// `DiscardRandomEnergyFromOpponentActiveOnEvolve`).
+    MoveRandomEnergyFromOpponentActiveToSelfOnEvolve,
     CanEvolveIntoEeveeEvolution,
     CanEvolveOnFirstTurnIfActive,
     CounterattackDamage {

--- a/src/actions/abilities/mechanic.rs
+++ b/src/actions/abilities/mechanic.rs
@@ -160,6 +160,12 @@ pub enum AbilityMechanic {
     PoisonOpponentActive,
     ConfuseOpponentActive,
     BurnOpponentActive,
+    /// Team Rocket's Slowking ex's Evil Inspiration: "Once during your turn, if this Pokémon is
+    /// in the Active Spot, you may draw a card." Unlike `EndTurnDrawCardIfActive`, this is an
+    /// actively-used ability (offered any time during the turn, not just at its end).
+    DrawCardIfActive {
+        amount: u32,
+    },
     /// Dustox's Variety Powder: 1 Special Condition is chosen at random from `options` and
     /// inflicted on the opponent's Active Pokémon. Conditions already affecting that Pokémon are
     /// excluded from the draw, so the ability is unusable once all `options` are applied.

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -204,6 +204,7 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::PoisonOpponentActive => poison_opponent_active(),
         AbilityMechanic::ConfuseOpponentActive => confuse_opponent_active(),
         AbilityMechanic::BurnOpponentActive => burn_opponent_active(),
+        AbilityMechanic::DrawCardIfActive { amount } => draw_card_if_active(*amount),
         AbilityMechanic::RandomStatusConditionToOpponentActive { options } => {
             random_status_condition_to_opponent_active(state, action.actor, options)
         }
@@ -560,6 +561,15 @@ fn poison_opponent_active() -> Outcomes {
     Outcomes::single_fn(|_rng, state, action| {
         let opponent = (action.actor + 1) % 2;
         state.apply_status_condition(opponent, 0, StatusCondition::Poisoned);
+    })
+}
+
+/// Team Rocket's Slowking ex's Evil Inspiration: draw `amount` cards.
+fn draw_card_if_active(amount: u32) -> Outcomes {
+    Outcomes::single_fn(move |_rng, state, action| {
+        for _ in 0..amount {
+            state.maybe_draw_card(action.actor);
+        }
     })
 }
 

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -269,6 +269,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve => {
             panic!("DiscardRandomEnergyFromOpponentActiveOnEvolve is triggered on evolve")
         }
+        AbilityMechanic::PoisonAndBurnOpponentActiveOnEvolve => {
+            panic!("PoisonAndBurnOpponentActiveOnEvolve is triggered on evolve")
+        }
         AbilityMechanic::CanEvolveIntoEeveeEvolution => {
             panic!("CanEvolveIntoEeveeEvolution is a passive ability")
         }

--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -272,6 +272,9 @@ fn forecast_ability_by_mechanic(
         AbilityMechanic::PoisonAndBurnOpponentActiveOnEvolve => {
             panic!("PoisonAndBurnOpponentActiveOnEvolve is triggered on evolve")
         }
+        AbilityMechanic::MoveRandomEnergyFromOpponentActiveToSelfOnEvolve => {
+            panic!("MoveRandomEnergyFromOpponentActiveToSelfOnEvolve is triggered on evolve")
+        }
         AbilityMechanic::CanEvolveIntoEeveeEvolution => {
             panic!("CanEvolveIntoEeveeEvolution is a passive ability")
         }

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -190,7 +190,8 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::DiscardRandomOpponentActiveEnergy
         | SimpleAction::MoveRandomOpponentEnergyToActive { .. }
         | SimpleAction::ApplyStatusToOpponentActive { .. }
-        | SimpleAction::ApplyStatusesToOpponentActive { .. } => forecast_deterministic_action(),
+        | SimpleAction::ApplyStatusesToOpponentActive { .. }
+        | SimpleAction::MoveOpponentActiveEnergyToSelf { .. } => forecast_deterministic_action(),
         // Noop is the "decline" branch of Victini's Victory Star prompt when a coin result is
         // parked; otherwise it is an ordinary no-op ("say no" to an optional effect).
         SimpleAction::Noop => {
@@ -498,6 +499,10 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
                 state.apply_status_condition(opponent, 0, *condition);
             }
         }
+        SimpleAction::MoveOpponentActiveEnergyToSelf { to_in_play_idx } => {
+            let opponent = (action.actor + 1) % 2;
+            apply_move_energy_between_players(state, opponent, 0, action.actor, *to_in_play_idx);
+        }
         SimpleAction::Noop => {}
         _ => panic!("Deterministic Action expected"),
     }
@@ -581,6 +586,31 @@ fn apply_move_energy(
             // Put energies back if destination vanished (should not normally happen)
             from_card.attached_energy.extend(removed_energies);
         }
+    }
+}
+
+/// Like `apply_move_energy`, but moves the last-attached Energy across the two players' boards
+/// (e.g. Team Rocket's Raticate ex's Thieving Incisors, which steals Energy from the opponent's
+/// Active Pokémon). Deterministically moves the *last* attached Energy rather than a random one,
+/// mirroring `DiscardRandomOpponentActiveEnergy` and friends.
+fn apply_move_energy_between_players(
+    state: &mut State,
+    from_player: usize,
+    from_idx: usize,
+    to_player: usize,
+    to_idx: usize,
+) {
+    let energy = state.in_play_pokemon[from_player][from_idx]
+        .as_mut()
+        .and_then(|from_card| from_card.attached_energy.pop());
+    let Some(energy) = energy else {
+        return;
+    };
+    if let Some(to_card) = state.in_play_pokemon[to_player][to_idx].as_mut() {
+        to_card.attached_energy.push(energy);
+    } else if let Some(from_card) = state.in_play_pokemon[from_player][from_idx].as_mut() {
+        // Put the energy back if the destination vanished (should not normally happen).
+        from_card.attached_energy.push(energy);
     }
 }
 

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -189,7 +189,8 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::DiscardActiveStadium
         | SimpleAction::DiscardRandomOpponentActiveEnergy
         | SimpleAction::MoveRandomOpponentEnergyToActive { .. }
-        | SimpleAction::ApplyStatusToOpponentActive { .. } => forecast_deterministic_action(),
+        | SimpleAction::ApplyStatusToOpponentActive { .. }
+        | SimpleAction::ApplyStatusesToOpponentActive { .. } => forecast_deterministic_action(),
         // Noop is the "decline" branch of Victini's Victory Star prompt when a coin result is
         // parked; otherwise it is an ordinary no-op ("say no" to an optional effect).
         SimpleAction::Noop => {
@@ -490,6 +491,12 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
         SimpleAction::ApplyStatusToOpponentActive { condition } => {
             let opponent = (action.actor + 1) % 2;
             state.apply_status_condition(opponent, 0, *condition);
+        }
+        SimpleAction::ApplyStatusesToOpponentActive { conditions } => {
+            let opponent = (action.actor + 1) % 2;
+            for condition in conditions {
+                state.apply_status_condition(opponent, 0, *condition);
+            }
         }
         SimpleAction::Noop => {}
         _ => panic!("Deterministic Action expected"),

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -557,6 +557,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::AlsoBenchDamageIfDamaged { opponent, damage } => {
             also_bench_damage_if_damaged(state, *opponent, attack.fixed_damage, *damage)
         }
+        Mechanic::AlsoChoiceBenchDamageIfDamaged { opponent, damage } => {
+            also_choice_bench_damage_if_damaged(state, *opponent, attack.fixed_damage, *damage)
+        }
         Mechanic::ExtraDamageIfHurt {
             extra_damage,
             opponent,
@@ -1854,6 +1857,44 @@ fn also_choice_bench_damage(
     };
     let choices: Vec<_> = state
         .enumerate_bench_pokemon(bench_target)
+        .map(|(in_play_idx, _)| {
+            let targets = vec![
+                (active_damage, opponent_player, 0),
+                (bench_damage, bench_target, in_play_idx),
+            ];
+            SimpleAction::ApplyDamage {
+                attacking_ref: (state.current_player, 0),
+                targets,
+                is_from_active_attack: true,
+            }
+        })
+        .collect();
+    AttackOutcomes::single_effect(move |_, state, action| {
+        if !choices.is_empty() {
+            state
+                .move_generation_stack
+                .push((action.actor, choices.clone()));
+        }
+    })
+}
+
+/// Team Rocket's Zapdos ex's Thunderclaw: like `also_choice_bench_damage`, but the bench choice
+/// is restricted to `opponent`'s Benched Pokémon that already have damage on them.
+fn also_choice_bench_damage_if_damaged(
+    state: &State,
+    opponent: bool,
+    active_damage: u32,
+    bench_damage: u32,
+) -> AttackOutcomes {
+    let opponent_player = (state.current_player + 1) % 2;
+    let bench_target = if opponent {
+        opponent_player
+    } else {
+        state.current_player
+    };
+    let choices: Vec<_> = state
+        .enumerate_bench_pokemon(bench_target)
+        .filter(|(_, pokemon)| pokemon.is_damaged())
         .map(|(in_play_idx, _)| {
             let targets = vec![
                 (active_damage, opponent_player, 0),

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -571,6 +571,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ExtraDamageIfUndamaged { extra_damage } => {
             extra_damage_if_undamaged(state, attack.fixed_damage, *extra_damage)
         }
+        Mechanic::ReducedDamageIfSelfDamaged { reduction } => {
+            reduced_damage_if_self_damaged(state, attack.fixed_damage, *reduction)
+        }
         Mechanic::OptionalDiscardBenchedBasicForExtraDamage {
             energy_type,
             extra_damage,
@@ -3014,6 +3017,18 @@ fn extra_damage_if_undamaged(state: &State, base: u32, extra: u32) -> AttackOutc
     } else {
         active_damage_doutcome(base + extra)
     }
+}
+
+/// Regidrago's Draconic Slam: `base` is the full (undamaged-self) damage; subtract `reduction`
+/// (floored at 0) when the attacking Pokémon already has damage on it.
+fn reduced_damage_if_self_damaged(state: &State, base: u32, reduction: u32) -> AttackOutcomes {
+    let attacker = state.get_active(state.current_player);
+    let damage = if attacker.is_damaged() {
+        base.saturating_sub(reduction)
+    } else {
+        base
+    };
+    active_damage_doutcome(damage)
 }
 
 /// Vespiquen ex - Chase Order: the attacker may discard 1 of its Benched Basic Pokémon of the

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -270,6 +270,10 @@ fn forecast_effect_attack_by_mechanic(
             mega_kangaskhan_ex_double_punching_family(attack)
         }
         Mechanic::MoltresExInfernoDance => moltres_inferno_dance(),
+        Mechanic::CoinFlipsAttachEnergyToSelf {
+            num_coins,
+            energy_type,
+        } => coin_flips_attach_energy_to_self(*num_coins, *energy_type),
         Mechanic::MagikarpWaterfallEvolution => waterfall_evolution(state),
         Mechanic::MoveAllEnergyTypeToBench { energy_type } => {
             move_all_energy_type_to_bench(state, attack, *energy_type)
@@ -1364,6 +1368,18 @@ fn moltres_inferno_dance() -> AttackOutcomes {
                 state
                     .move_generation_stack
                     .push((action.actor, all_choices));
+            }
+        })
+    })
+}
+
+/// Team Rocket's Moltres ex's Heat Charged: flip `num_coins` coins and attach `energy_type`
+/// Energy from the Energy Zone to the attacking Pokémon itself, once per heads.
+fn coin_flips_attach_energy_to_self(num_coins: usize, energy_type: EnergyType) -> AttackOutcomes {
+    AttackOutcomes::binomial_by_heads(num_coins, move |heads| {
+        active_damage_effect_outcome(0, move |_, state, action| {
+            if heads > 0 {
+                state.attach_energy_from_zone(action.actor, 0, energy_type, heads as u32, false);
             }
         })
     })

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -735,6 +735,9 @@ fn forecast_effect_attack_by_mechanic(
             attack_name,
             damage_per_use,
         } => damage_per_attack_used_this_game(state, attack_name, *damage_per_use),
+        Mechanic::DamagePerOwnHandCard { damage_per_card } => {
+            damage_per_own_hand_card(state, *damage_per_card)
+        }
         Mechanic::ExtraDamageIfMovedFromBench { extra_damage } => {
             extra_damage_if_moved_from_bench_attack(state, attack.fixed_damage, *extra_damage)
         }
@@ -3379,6 +3382,13 @@ fn damage_per_attack_used_this_game(
 ) -> AttackOutcomes {
     let uses = state.count_attack_used_this_game(state.current_player, attack_name);
     active_damage_doutcome(damage_per_use * uses)
+}
+
+/// Team Rocket's Slowking ex's Hand Kinesis: `damage_per_card` damage for each card in the
+/// attacker's own hand (the card used to attack is already out of hand by this point).
+fn damage_per_own_hand_card(state: &State, damage_per_card: u32) -> AttackOutcomes {
+    let hand_size = state.hands[state.current_player].len() as u32;
+    active_damage_doutcome(damage_per_card * hand_size)
 }
 
 fn extra_damage_if_moved_from_bench_attack(

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -554,6 +554,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::AlsoChoiceBenchDamage { opponent, damage } => {
             also_choice_bench_damage(state, *opponent, attack.fixed_damage, *damage)
         }
+        Mechanic::AlsoBenchDamageIfDamaged { opponent, damage } => {
+            also_bench_damage_if_damaged(state, *opponent, attack.fixed_damage, *damage)
+        }
         Mechanic::ExtraDamageIfHurt {
             extra_damage,
             opponent,
@@ -1870,6 +1873,29 @@ fn also_choice_bench_damage(
                 .push((action.actor, choices.clone()));
         }
     })
+}
+
+/// Toxtricity ex's Damaging Spark: like `also_bench_damage`, but applies to EVERY one of
+/// `opponent`'s Benched Pokémon that already has damage on it, rather than every benched Pokémon
+/// (optionally filtered by whether it has Energy attached).
+fn also_bench_damage_if_damaged(
+    state: &State,
+    opponent: bool,
+    active_damage: u32,
+    bench_damage: u32,
+) -> AttackOutcomes {
+    let player = if opponent {
+        (state.current_player + 1) % 2
+    } else {
+        state.current_player
+    };
+    let mut targets: Vec<(u32, bool, usize)> = state
+        .enumerate_bench_pokemon(player)
+        .filter(|(_, pokemon)| pokemon.is_damaged())
+        .map(|(idx, _)| (bench_damage, opponent, idx))
+        .collect();
+    targets.push((active_damage, true, 0)); // Opponent's Active Pokémon is always index 0
+    damage_effect_doutcome(targets, |_, _, _| {})
 }
 
 fn self_charge_active_from_energies(damage: u32, energies: Vec<EnergyType>) -> AttackOutcomes {

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -247,6 +247,13 @@ pub enum Mechanic {
         energy_type: EnergyType,
         count: usize,
     },
+    /// Team Rocket's Moltres ex's Heat Charged: flip `num_coins` coins; for each heads, produce
+    /// an Energy of `energy_type` from the Energy Zone and attach it to the attacking Pokémon
+    /// itself.
+    CoinFlipsAttachEnergyToSelf {
+        num_coins: usize,
+        energy_type: EnergyType,
+    },
     // Fairly unique mechanics
     /// Manaphy's Oceanic Gift / Carbink's Glittering Gift: choose 2 of your Benched Pokémon and
     /// attach an Energy of the given type to each.

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -415,6 +415,13 @@ pub enum Mechanic {
         opponent: bool,
         damage: u32,
     },
+    /// Toxtricity ex's Damaging Spark: deal the attack's fixed damage to the Defending Pokémon,
+    /// then also deal `damage` to EVERY one of `opponent`'s Benched Pokémon that already has
+    /// damage on it.
+    AlsoBenchDamageIfDamaged {
+        opponent: bool,
+        damage: u32,
+    },
     ExtraDamageIfHurt {
         extra_damage: u32,
         opponent: bool,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -480,6 +480,11 @@ pub enum Mechanic {
         attack_name: String,
         damage_per_use: u32,
     },
+    /// Team Rocket's Slowking ex's Hand Kinesis: deal `damage_per_card` damage for each card in
+    /// the attacker's own hand.
+    DamagePerOwnHandCard {
+        damage_per_card: u32,
+    },
     ExtraDamageIfMovedFromBench {
         extra_damage: u32,
     },

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -422,6 +422,13 @@ pub enum Mechanic {
         opponent: bool,
         damage: u32,
     },
+    /// Team Rocket's Zapdos ex's Thunderclaw: deal the attack's fixed damage to the Defending
+    /// Pokémon, then also let the attacker choose 1 of `opponent`'s Benched Pokémon that already
+    /// has damage on it to deal `damage` to.
+    AlsoChoiceBenchDamageIfDamaged {
+        opponent: bool,
+        damage: u32,
+    },
     ExtraDamageIfHurt {
         extra_damage: u32,
         opponent: bool,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -443,6 +443,12 @@ pub enum Mechanic {
     ExtraDamageIfUndamaged {
         extra_damage: u32,
     },
+    /// Regidrago's Draconic Slam: "If this Pokémon has damage on it, this attack does -100
+    /// damage." The attack's `fixed_damage` is the undamaged-self base; `reduction` is subtracted
+    /// (floored at 0) when the attacking Pokémon already has damage on it.
+    ReducedDamageIfSelfDamaged {
+        reduction: u32,
+    },
     /// Vespiquen ex's Chase Order: "You may discard 1 of your Benched Basic [G] Pokémon. If you
     /// do, this attack does 70 more damage." The attacker chooses between the plain damage and
     /// discarding one eligible Benched Basic Pokémon for the boosted damage.

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -237,6 +237,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             AbilityMechanic::PoisonAndBurnOpponentActiveOnEvolve,
         );
         map.insert(
+            "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may move a random Energy from your opponent's Active Pokémon to this Pokémon.",
+            AbilityMechanic::MoveRandomEnergyFromOpponentActiveToSelfOnEvolve,
+        );
+        map.insert(
             "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
             AbilityMechanic::CoinFlipParalyzeOpponentActiveOnEvolve,
         );

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -199,6 +199,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
         // map.insert("Once during your turn, if this Pokémon is in the Active Spot, you may look at a random Supporter card from your opponent's hand. Use the effect of that card as the effect of this Ability.", todo_implementation);
         map.insert("Once during your turn, if this Pokémon is in the Active Spot, you may make your opponent's Active Pokémon Poisoned.", AbilityMechanic::PoisonOpponentActive);
         map.insert(
+            "Once during your turn, if this Pokémon is in the Active Spot, you may draw a card.",
+            AbilityMechanic::DrawCardIfActive { amount: 1 },
+        );
+        map.insert(
             "Once during your turn, if this Pokémon is in the Active Spot, you may switch in 1 of your opponent's Benched Pokémon that has damage on it to the Active Spot.",
             AbilityMechanic::SwitchDamagedOpponentBenchToActive,
         );

--- a/src/actions/effect_ability_mechanic_map.rs
+++ b/src/actions/effect_ability_mechanic_map.rs
@@ -233,6 +233,10 @@ pub static EFFECT_ABILITY_MECHANIC_MAP: LazyLock<HashMap<&'static str, AbilityMe
             AbilityMechanic::DrawCardsOnEvolve { amount: 2 },
         );
         map.insert(
+            "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may make your opponent's Active Pokémon Poisoned and Burned.",
+            AbilityMechanic::PoisonAndBurnOpponentActiveOnEvolve,
+        );
+        map.insert(
             "Once during your turn, when you play this Pokémon from your hand to evolve 1 of your Pokémon, you may flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
             AbilityMechanic::CoinFlipParalyzeOpponentActiveOnEvolve,
         );

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2120,7 +2120,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             count: 3,
         },
     );
-    // map.insert("This attack also does 30 damage to each of your opponent's Benched Pokémon that has damage on it.", todo_implementation);
+    map.insert(
+        "This attack also does 30 damage to each of your opponent's Benched Pokémon that has damage on it.",
+        Mechanic::AlsoBenchDamageIfDamaged {
+            opponent: true,
+            damage: 30,
+        },
+    );
     // Gigalith ex - Megaton Cannon
     map.insert(
         "This attack does 140 damage to 1 of your opponent's Pokémon. During your next turn, this Pokémon can't attack.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1801,6 +1801,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     map.insert(
+        "This attack does 20 damage for each card in your hand.",
+        Mechanic::DamagePerOwnHandCard {
+            damage_per_card: 20,
+        },
+    );
+    map.insert(
         "This attack does 40 damage to 1 of your opponent's Pokémon.",
         Mechanic::DirectDamage {
             damage: 40,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -612,6 +612,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     map.insert("Flip 3 coins. For each heads, a card is chosen at random from your opponent's hand. Your opponent reveals that card and shuffles it into their deck.", Mechanic::CoinFlipsShuffleOpponentHandCards { num_coins: 3 });
     map.insert("Flip 3 coins. Take an amount of [R] Energy from your Energy Zone equal to the number of heads and attach it to your Benched [R] Pokémon in any way you like.", Mechanic::MoltresExInfernoDance);
     map.insert(
+        "Flip 3 coins. For each heads, produce a [R] Energy from your Energy Zone and attach it to this Pokémon.",
+        Mechanic::CoinFlipsAttachEnergyToSelf {
+            num_coins: 3,
+            energy_type: EnergyType::Fire,
+        },
+    );
+    map.insert(
         "Flip 3 coins. This attack does 10 damage for each heads.",
         Mechanic::ExtraDamageForEachHeads {
             include_fixed_damage: false,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1116,6 +1116,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::ExtraDamageIfUndamaged { extra_damage: 40 },
     );
     map.insert(
+        "If this Pokémon has damage on it, this attack does -100 damage.",
+        Mechanic::ReducedDamageIfSelfDamaged { reduction: 100 },
+    );
+    map.insert(
         "If this Pokémon moved from your Bench to the Active Spot this turn, this attack does 50 more damage.",
         Mechanic::ExtraDamageIfMovedFromBench { extra_damage: 50 },
     );

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1814,6 +1814,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     map.insert(
+        "This attack also does 50 damage to 1 of your opponent's Benched Pokémon that has damage on it.",
+        Mechanic::AlsoChoiceBenchDamageIfDamaged {
+            opponent: true,
+            damage: 50,
+        },
+    );
+    map.insert(
         "This attack does 50 damage to 1 of your opponent's Pokémon.",
         Mechanic::DirectDamage {
             damage: 50,

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -173,6 +173,11 @@ pub enum SimpleAction {
     ApplyStatusToOpponentActive {
         condition: StatusCondition,
     },
+    /// Team Rocket's Weezing ex's Boiler Smog: apply ALL of these Special Conditions at once to
+    /// the opponent's Active Pokémon (e.g. Poisoned and Burned together).
+    ApplyStatusesToOpponentActive {
+        conditions: Vec<StatusCondition>,
+    },
     Noop, // No operation, used to have the user say "no" to a question
 }
 
@@ -348,6 +353,9 @@ impl fmt::Display for SimpleAction {
             SimpleAction::UseStadium => write!(f, "UseStadium"),
             SimpleAction::ApplyStatusToOpponentActive { condition } => {
                 write!(f, "ApplyStatusToOpponentActive({condition:?})")
+            }
+            SimpleAction::ApplyStatusesToOpponentActive { conditions } => {
+                write!(f, "ApplyStatusesToOpponentActive({conditions:?})")
             }
             SimpleAction::Noop => write!(f, "Noop"),
         }

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -173,6 +173,11 @@ pub enum SimpleAction {
     ApplyStatusToOpponentActive {
         condition: StatusCondition,
     },
+    /// Team Rocket's Raticate ex's Thieving Incisors: move the last-attached Energy from the
+    /// opponent's Active Pokémon to `to_in_play_idx` on the actor's own board.
+    MoveOpponentActiveEnergyToSelf {
+        to_in_play_idx: usize,
+    },
     /// Team Rocket's Weezing ex's Boiler Smog: apply ALL of these Special Conditions at once to
     /// the opponent's Active Pokémon (e.g. Poisoned and Burned together).
     ApplyStatusesToOpponentActive {
@@ -356,6 +361,9 @@ impl fmt::Display for SimpleAction {
             }
             SimpleAction::ApplyStatusesToOpponentActive { conditions } => {
                 write!(f, "ApplyStatusesToOpponentActive({conditions:?})")
+            }
+            SimpleAction::MoveOpponentActiveEnergyToSelf { to_in_play_idx } => {
+                write!(f, "MoveOpponentActiveEnergyToSelf({to_in_play_idx})")
             }
             SimpleAction::Noop => write!(f, "Noop"),
         }

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -10,7 +10,9 @@ use crate::{
     },
     card_ids::CardId,
     effects::{CardEffect, TurnEffect},
-    models::{Card, EnergyType, PlayedCard, TrainerCard, TrainerType, BASIC_STAGE},
+    models::{
+        Card, EnergyType, PlayedCard, StatusCondition, TrainerCard, TrainerType, BASIC_STAGE,
+    },
     stadiums::{
         get_arena_of_antiquity_damage_bonus, get_training_area_damage_bonus,
         is_bounded_field_active, is_hiking_trail_active, is_soothing_shore_active,
@@ -201,6 +203,17 @@ pub(crate) fn on_evolve(
                     ],
                 ));
             }
+        }
+        Some(AbilityMechanic::PoisonAndBurnOpponentActiveOnEvolve) => {
+            state.move_generation_stack.push((
+                actor,
+                vec![
+                    SimpleAction::ApplyStatusesToOpponentActive {
+                        conditions: vec![StatusCondition::Poisoned, StatusCondition::Burned],
+                    },
+                    SimpleAction::Noop,
+                ],
+            ));
         }
         _ => {}
     }

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -215,6 +215,23 @@ pub(crate) fn on_evolve(
                 ],
             ));
         }
+        Some(AbilityMechanic::MoveRandomEnergyFromOpponentActiveToSelfOnEvolve) => {
+            let opponent = (actor + 1) % 2;
+            let has_energy = state
+                .maybe_get_active(opponent)
+                .is_some_and(|active| !active.attached_energy.is_empty());
+            if has_energy {
+                state.move_generation_stack.push((
+                    actor,
+                    vec![
+                        SimpleAction::MoveOpponentActiveEnergyToSelf {
+                            to_in_play_idx: in_play_idx,
+                        },
+                        SimpleAction::Noop,
+                    ],
+                ));
+            }
+        }
         _ => {}
     }
 }

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -141,6 +141,7 @@ fn can_use_ability_by_mechanic(
             !card.ability_used && card.attached_energy.contains(discard_energy)
         }
         AbilityMechanic::PoisonOpponentActive => _in_play_index == 0 && !card.ability_used,
+        AbilityMechanic::DrawCardIfActive { .. } => _in_play_index == 0 && !card.ability_used,
         AbilityMechanic::ConfuseOpponentActive => _in_play_index == 0 && !card.ability_used,
         AbilityMechanic::BurnOpponentActive => !card.ability_used,
         AbilityMechanic::RandomStatusConditionToOpponentActive { options } => {

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -185,6 +185,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::CoinFlipParalyzeOpponentActiveOnEvolve => false,
         AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve => false,
         AbilityMechanic::PoisonAndBurnOpponentActiveOnEvolve => false,
+        AbilityMechanic::MoveRandomEnergyFromOpponentActiveToSelfOnEvolve => false,
         AbilityMechanic::CanEvolveIntoEeveeEvolution => false,
         AbilityMechanic::CanEvolveOnFirstTurnIfActive => false,
         AbilityMechanic::CounterattackDamage { .. } => false,

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -184,6 +184,7 @@ fn can_use_ability_by_mechanic(
         AbilityMechanic::DamageOpponentActiveOnEvolve { .. } => false,
         AbilityMechanic::CoinFlipParalyzeOpponentActiveOnEvolve => false,
         AbilityMechanic::DiscardRandomEnergyFromOpponentActiveOnEvolve => false,
+        AbilityMechanic::PoisonAndBurnOpponentActiveOnEvolve => false,
         AbilityMechanic::CanEvolveIntoEeveeEvolution => false,
         AbilityMechanic::CanEvolveOnFirstTurnIfActive => false,
         AbilityMechanic::CounterattackDamage { .. } => false,

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -78,6 +78,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::DiscardRandomOpponentActiveEnergy => 10,
         SimpleAction::MoveRandomOpponentEnergyToActive { .. } => 10,
         SimpleAction::ApplyStatusToOpponentActive { .. } => 10,
+        SimpleAction::ApplyStatusesToOpponentActive { .. } => 10,
         SimpleAction::UseStadium => 5, // Stadium abilities like Mesagoza
         SimpleAction::Noop => 0,       // No operation has no weight
     }

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -79,6 +79,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::MoveRandomOpponentEnergyToActive { .. } => 10,
         SimpleAction::ApplyStatusToOpponentActive { .. } => 10,
         SimpleAction::ApplyStatusesToOpponentActive { .. } => 10,
+        SimpleAction::MoveOpponentActiveEnergyToSelf { .. } => 10,
         SimpleAction::UseStadium => 5, // Stadium abilities like Mesagoza
         SimpleAction::Noop => 0,       // No operation has no weight
     }

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -290,6 +290,8 @@ mod sylveon_soothing_ribbon_test;
 mod tandemaus_b2_test;
 #[path = "pokemon/tapu_lele_energy_arrow_test.rs"]
 mod tapu_lele_energy_arrow_test;
+#[path = "pokemon/team_rockets_moltres_ex_heat_charged_test.rs"]
+mod team_rockets_moltres_ex_heat_charged_test;
 #[path = "pokemon/team_rockets_zapdos_ex_thunderclaw_test.rs"]
 mod team_rockets_zapdos_ex_thunderclaw_test;
 #[path = "pokemon/tentacruel_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -292,6 +292,8 @@ mod tandemaus_b2_test;
 mod tapu_lele_energy_arrow_test;
 #[path = "pokemon/team_rockets_moltres_ex_heat_charged_test.rs"]
 mod team_rockets_moltres_ex_heat_charged_test;
+#[path = "pokemon/team_rockets_raticate_ex_test.rs"]
+mod team_rockets_raticate_ex_test;
 #[path = "pokemon/team_rockets_slowking_ex_test.rs"]
 mod team_rockets_slowking_ex_test;
 #[path = "pokemon/team_rockets_weezing_ex_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -254,6 +254,8 @@ mod purrloin_test;
 mod raichu_evoshock_test;
 #[path = "pokemon/rampardos_head_smash_test.rs"]
 mod rampardos_head_smash_test;
+#[path = "pokemon/regidrago_draconic_slam_test.rs"]
+mod regidrago_draconic_slam_test;
 #[path = "pokemon/rhyperior_test.rs"]
 mod rhyperior_test;
 #[path = "pokemon/roaring_moon_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -294,6 +294,8 @@ mod tapu_lele_energy_arrow_test;
 mod team_rockets_moltres_ex_heat_charged_test;
 #[path = "pokemon/team_rockets_slowking_ex_test.rs"]
 mod team_rockets_slowking_ex_test;
+#[path = "pokemon/team_rockets_weezing_ex_test.rs"]
+mod team_rockets_weezing_ex_test;
 #[path = "pokemon/team_rockets_zapdos_ex_thunderclaw_test.rs"]
 mod team_rockets_zapdos_ex_thunderclaw_test;
 #[path = "pokemon/tentacruel_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -292,6 +292,8 @@ mod tandemaus_b2_test;
 mod tapu_lele_energy_arrow_test;
 #[path = "pokemon/team_rockets_moltres_ex_heat_charged_test.rs"]
 mod team_rockets_moltres_ex_heat_charged_test;
+#[path = "pokemon/team_rockets_slowking_ex_test.rs"]
+mod team_rockets_slowking_ex_test;
 #[path = "pokemon/team_rockets_zapdos_ex_thunderclaw_test.rs"]
 mod team_rockets_zapdos_ex_thunderclaw_test;
 #[path = "pokemon/tentacruel_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -296,6 +296,8 @@ mod tentacruel_test;
 mod tepig_stoke_test;
 #[path = "pokemon/terapagos_ex_test.rs"]
 mod terapagos_ex_test;
+#[path = "pokemon/toxtricity_ex_damaging_spark_test.rs"]
+mod toxtricity_ex_damaging_spark_test;
 #[path = "pokemon/typhlosion_fire_breath_test.rs"]
 mod typhlosion_fire_breath_test;
 #[path = "pokemon/ursaluna_guts_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -290,6 +290,8 @@ mod sylveon_soothing_ribbon_test;
 mod tandemaus_b2_test;
 #[path = "pokemon/tapu_lele_energy_arrow_test.rs"]
 mod tapu_lele_energy_arrow_test;
+#[path = "pokemon/team_rockets_zapdos_ex_thunderclaw_test.rs"]
+mod team_rockets_zapdos_ex_thunderclaw_test;
 #[path = "pokemon/tentacruel_test.rs"]
 mod tentacruel_test;
 #[path = "pokemon/tepig_stoke_test.rs"]

--- a/tests/pokemon/regidrago_draconic_slam_test.rs
+++ b/tests/pokemon/regidrago_draconic_slam_test.rs
@@ -1,0 +1,62 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+const VENUSAUR_EX_MAX_HP: u32 = 190;
+
+/// Regidrago's Draconic Slam: 140 damage normally, but only 40 damage ("-100 damage") if
+/// Regidrago itself already has damage on it.
+#[test]
+fn test_regidrago_draconic_slam_full_damage_when_undamaged() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4a057Regidrago).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Fire,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a057Regidrago, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 140
+    );
+}
+
+#[test]
+fn test_regidrago_draconic_slam_reduced_damage_when_self_damaged() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4a057Regidrago)
+            .with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Fire,
+                EnergyType::Colorless,
+            ])
+            .with_damage(10)],
+        vec![PlayedCard::from_id(CardId::A1004VenusaurEx)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a057Regidrago, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 40
+    );
+}

--- a/tests/pokemon/team_rockets_moltres_ex_heat_charged_test.rs
+++ b/tests/pokemon/team_rockets_moltres_ex_heat_charged_test.rs
@@ -1,0 +1,57 @@
+use std::collections::HashSet;
+
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::EnergyType,
+    models::PlayedCard,
+    test_support::{attack_action, get_initialized_game},
+};
+
+/// Team Rocket's Moltres ex's Heat Charged: flip 3 coins, and for each heads attach a [R] Energy
+/// from the Energy Zone to Moltres itself. Across many seeds the resulting energy count should
+/// always land within the binomial range of the coin flips (starting energy + 0..=3 heads), and
+/// more than one outcome should actually occur (i.e. the mechanic isn't a no-op).
+#[test]
+fn test_moltres_ex_heat_charged_attaches_energy_per_heads() {
+    let mut seen_energy_counts = HashSet::new();
+    for seed in 0..30 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 3;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::B4a007TeamRocketsMoltresEx)
+                .with_energy(vec![EnergyType::Fire])],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B4a007TeamRocketsMoltresEx, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let energy_count = state.get_active(0).attached_energy.len();
+        assert!(
+            (1..=4).contains(&energy_count),
+            "seed {seed}: expected 1 starting + 0..=3 heads of Fire energy, got {energy_count}"
+        );
+        assert!(
+            state
+                .get_active(0)
+                .attached_energy
+                .iter()
+                .all(|e| *e == EnergyType::Fire),
+            "seed {seed}: all attached energy should be Fire"
+        );
+        seen_energy_counts.insert(energy_count);
+    }
+    assert!(
+        seen_energy_counts.len() > 1,
+        "expected varying numbers of heads across seeds, got only {seen_energy_counts:?}"
+    );
+}

--- a/tests/pokemon/team_rockets_raticate_ex_test.rs
+++ b/tests/pokemon/team_rockets_raticate_ex_test.rs
@@ -1,0 +1,122 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::get_initialized_game_with_board,
+    Game,
+};
+
+/// Team Rocket's Raticate ex's Thieving Incisors: "Once during your turn, when you play this
+/// Pokémon from your hand to evolve 1 of your Pokémon, you may move a random Energy from your
+/// opponent's Active Pokémon to this Pokémon."
+fn evolve_rattata_into_raticate_ex(seed: u64) -> Game<'static> {
+    let mut game = get_initialized_game_with_board(
+        seed,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B4a058TeamRocketsRattata)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Grass])],
+    );
+
+    let mut state = game.get_state_clone();
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::B4a059TeamRocketsRaticateEx));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Evolve {
+            evolution: get_card_by_enum(CardId::B4a059TeamRocketsRaticateEx),
+            in_play_idx: 0,
+            from_deck: false,
+        },
+        is_stack: false,
+    });
+
+    game
+}
+
+#[test]
+fn test_thieving_incisors_is_optional_and_steals_energy_on_evolve() {
+    let mut game = evolve_rattata_into_raticate_ex(0);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(choices.len(), 2, "Thieving Incisors should be optional");
+    assert!(choices.iter().any(|c| matches!(
+        c.action,
+        SimpleAction::MoveOpponentActiveEnergyToSelf { .. }
+    )));
+    assert!(choices
+        .iter()
+        .any(|c| matches!(c.action, SimpleAction::Noop)));
+
+    let steal_choice = choices
+        .into_iter()
+        .find(|c| {
+            matches!(
+                c.action,
+                SimpleAction::MoveOpponentActiveEnergyToSelf { .. }
+            )
+        })
+        .expect("Thieving Incisors choice should be present");
+    game.apply_action(&steal_choice);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(0).attached_energy.len(), 1);
+    assert_eq!(state.get_active(0).attached_energy[0], EnergyType::Grass);
+    assert_eq!(state.get_active(1).attached_energy.len(), 1);
+}
+
+#[test]
+fn test_thieving_incisors_declined_leaves_energy_unmoved() {
+    let mut game = evolve_rattata_into_raticate_ex(0);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Noop,
+        is_stack: true,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(0).attached_energy.len(), 0);
+    assert_eq!(state.get_active(1).attached_energy.len(), 2);
+}
+
+#[test]
+fn test_thieving_incisors_not_offered_when_opponent_active_has_no_energy() {
+    let mut game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B4a058TeamRocketsRattata)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::B4a059TeamRocketsRaticateEx));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Evolve {
+            evolution: get_card_by_enum(CardId::B4a059TeamRocketsRaticateEx),
+            in_play_idx: 0,
+            from_deck: false,
+        },
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(
+        !choices.iter().any(|c| matches!(
+            c.action,
+            SimpleAction::MoveOpponentActiveEnergyToSelf { .. }
+        )),
+        "Thieving Incisors shouldn't be offered when the opponent's Active has no Energy"
+    );
+}

--- a/tests/pokemon/team_rockets_slowking_ex_test.rs
+++ b/tests/pokemon/team_rockets_slowking_ex_test.rs
@@ -1,0 +1,60 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Team Rocket's Slowking ex's Evil Inspiration: "Once during your turn, if this Pokémon is in
+/// the Active Spot, you may draw a card." Using it once draws a card and can't be used again
+/// this turn.
+#[test]
+fn test_slowking_ex_evil_inspiration_draws_once_per_turn() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4a026TeamRocketsSlowkingEx)],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let hand_size_before = game.get_state_clone().hands[0].len();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::UseAbility { in_play_idx: 0 },
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.hands[0].len(), hand_size_before + 1);
+
+    // The ability can't be used again this turn.
+    let (actor, choices) = state.generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(!choices
+        .iter()
+        .any(|choice| matches!(choice.action, SimpleAction::UseAbility { in_play_idx: 0 })));
+}
+
+/// Team Rocket's Slowking ex's Hand Kinesis: 20 damage for each card in the attacker's hand.
+#[test]
+fn test_slowking_ex_hand_kinesis_damage_scales_with_hand_size() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4a026TeamRocketsSlowkingEx)
+            .with_energy(vec![EnergyType::Psychic, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let hand_size = game.get_state_clone().hands[0].len() as u32;
+    let opponent_max_hp = game.get_state_clone().get_active(1).get_remaining_hp();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a026TeamRocketsSlowkingEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        opponent_max_hp - 20 * hand_size
+    );
+}

--- a/tests/pokemon/team_rockets_weezing_ex_test.rs
+++ b/tests/pokemon/team_rockets_weezing_ex_test.rs
@@ -1,0 +1,101 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game_with_board},
+    Game,
+};
+
+/// Team Rocket's Weezing ex's Boiler Smog: "Once during your turn, when you play this Pokémon
+/// from your hand to evolve 1 of your Pokémon, you may make your opponent's Active Pokémon
+/// Poisoned and Burned."
+fn evolve_koffing_into_weezing_ex(seed: u64) -> Game<'static> {
+    let mut game = get_initialized_game_with_board(
+        seed,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B4a042TeamRocketsKoffing)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.hands[0].clear();
+    state.hands[0].push(get_card_by_enum(CardId::B4a043TeamRocketsWeezingEx));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Evolve {
+            evolution: get_card_by_enum(CardId::B4a043TeamRocketsWeezingEx),
+            in_play_idx: 0,
+            from_deck: false,
+        },
+        is_stack: false,
+    });
+
+    game
+}
+
+#[test]
+fn test_boiler_smog_is_optional_on_evolve_and_applies_both_statuses() {
+    let mut game = evolve_koffing_into_weezing_ex(0);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(choices.len(), 2, "Boiler Smog should be optional");
+    assert!(choices
+        .iter()
+        .any(|c| matches!(c.action, SimpleAction::ApplyStatusesToOpponentActive { .. })));
+    assert!(choices
+        .iter()
+        .any(|c| matches!(c.action, SimpleAction::Noop)));
+
+    let apply_choice = choices
+        .into_iter()
+        .find(|c| matches!(c.action, SimpleAction::ApplyStatusesToOpponentActive { .. }))
+        .expect("Boiler Smog choice should be present");
+    game.apply_action(&apply_choice);
+
+    let state = game.get_state_clone();
+    assert!(state.get_active(1).is_poisoned());
+    assert!(state.get_active(1).is_burned());
+}
+
+#[test]
+fn test_boiler_smog_declined_leaves_opponent_unaffected() {
+    let mut game = evolve_koffing_into_weezing_ex(0);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Noop,
+        is_stack: true,
+    });
+
+    let state = game.get_state_clone();
+    assert!(!state.get_active(1).is_poisoned());
+    assert!(!state.get_active(1).is_burned());
+}
+
+/// Team Rocket's Weezing ex's Confusion Gas: 60 damage, and the Defending Pokémon is now
+/// Confused.
+#[test]
+fn test_weezing_ex_confusion_gas_confuses_defender() {
+    let mut game = get_initialized_game_with_board(
+        0,
+        0,
+        3,
+        vec![PlayedCard::from_id(CardId::B4a043TeamRocketsWeezingEx)
+            .with_energy(vec![EnergyType::Darkness, EnergyType::Darkness])],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a043TeamRocketsWeezingEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(state.get_active(1).is_confused());
+}

--- a/tests/pokemon/team_rockets_zapdos_ex_thunderclaw_test.rs
+++ b/tests/pokemon/team_rockets_zapdos_ex_thunderclaw_test.rs
@@ -1,0 +1,72 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+const VENUSAUR_EX_MAX_HP: u32 = 190;
+const BULBASAUR_MAX_HP: u32 = 70;
+
+/// Team Rocket's Zapdos ex's Thunderclaw: 90 damage to the Defending Pokémon, plus the attacker
+/// may choose 1 of the opponent's Benched Pokémon that already has damage on it to deal 50 more
+/// damage to. Undamaged Benched Pokémon aren't offered as targets.
+#[test]
+fn test_zapdos_ex_thunderclaw_only_offers_damaged_bench_as_target() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4a021TeamRocketsZapdosEx).with_energy(vec![
+                EnergyType::Lightning,
+                EnergyType::Lightning,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1004VenusaurEx),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_remaining_hp(BULBASAUR_MAX_HP - 10),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a021TeamRocketsZapdosEx, 1),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(!choices.is_empty());
+    for choice in &choices {
+        let SimpleAction::ApplyDamage { targets, .. } = &choice.action else {
+            panic!("Expected ApplyDamage choices");
+        };
+        assert!(
+            targets.iter().all(|(_, _, in_play_idx)| *in_play_idx != 2),
+            "Undamaged benched Bulbasaur (idx 2) should never be offered as a target"
+        );
+    }
+
+    let choice = choices[0].clone();
+    game.apply_action(&choice);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 90
+    );
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("Damaged benched Bulbasaur should still be in play")
+            .get_remaining_hp(),
+        BULBASAUR_MAX_HP - 10 - 50
+    );
+    assert_eq!(
+        state.in_play_pokemon[1][2]
+            .as_ref()
+            .expect("Undamaged benched Bulbasaur should still be in play")
+            .get_remaining_hp(),
+        BULBASAUR_MAX_HP
+    );
+}

--- a/tests/pokemon/toxtricity_ex_damaging_spark_test.rs
+++ b/tests/pokemon/toxtricity_ex_damaging_spark_test.rs
@@ -1,0 +1,56 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+const VENUSAUR_EX_MAX_HP: u32 = 190;
+const BULBASAUR_MAX_HP: u32 = 70;
+
+/// Toxtricity ex's Damaging Spark: 90 damage to the Defending Pokémon, plus 30 damage to EACH of
+/// the opponent's Benched Pokémon that already has damage on it. Undamaged Benched Pokémon are
+/// untouched.
+#[test]
+fn test_toxtricity_ex_damaging_spark_hits_only_damaged_bench() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4a106ToxtricityEx).with_energy(vec![
+                EnergyType::Lightning,
+                EnergyType::Lightning,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1004VenusaurEx),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_remaining_hp(BULBASAUR_MAX_HP - 10),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a106ToxtricityEx, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.get_active(1).get_remaining_hp(),
+        VENUSAUR_EX_MAX_HP - 90
+    );
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("Damaged benched Bulbasaur should still be in play")
+            .get_remaining_hp(),
+        BULBASAUR_MAX_HP - 10 - 30
+    );
+    assert_eq!(
+        state.in_play_pokemon[1][2]
+            .as_ref()
+            .expect("Undamaged benched Bulbasaur should still be in play")
+            .get_remaining_hp(),
+        BULBASAUR_MAX_HP
+    );
+}


### PR DESCRIPTION
Implements the B4a ("Team Rocket's Ambition") `ex` Pokémon that weren't already complete, plus one additional meta-relevant pick, each as a separate commit for review.

## What's implemented

- **Toxtricity ex** (B4a 106) — Damaging Spark. Adds the `AlsoBenchDamageIfDamaged` mechanic (damage to the Defending Pokémon plus bonus damage to every Benched Pokémon that already has damage on it). As a side effect, this also completes the previously-unimplemented B2 Toxtricity ex prints, which share the same effect text.
- **Team Rocket's Zapdos ex** (B4a 021) — Thunderclaw. Adds `AlsoChoiceBenchDamageIfDamaged`: bonus damage to a Benched Pokémon the attacker chooses, restricted to ones that already have damage.
- **Team Rocket's Moltres ex** (B4a 007) — Heat Charged. Adds `CoinFlipsAttachEnergyToSelf`: flip N coins, attach an Energy to the attacker itself per heads. Netherwing (its other attack) already resolved via the existing `SelfDiscardEnergy` mechanic.
- **Team Rocket's Slowking ex** (B4a 026) — Evil Inspiration ability (`DrawCardIfActive`: once per turn while Active, draw a card) + Hand Kinesis attack (`DamagePerOwnHandCard`: damage scales with the attacker's hand size).
- **Team Rocket's Weezing ex** (B4a 043) — Boiler Smog ability (`PoisonAndBurnOpponentActiveOnEvolve`: optionally inflict both Poisoned and Burned when played from hand to evolve), backed by a new `SimpleAction::ApplyStatusesToOpponentActive` that applies multiple conditions atomically. Confusion Gas (its attack) already resolved via the existing `InflictStatusConditions` mechanic.
- **Team Rocket's Raticate ex** (B4a 059) — Thieving Incisors ability (`MoveRandomEnergyFromOpponentActiveToSelfOnEvolve`: optionally steal an Energy from the opponent's Active onto itself when played from hand to evolve).
- **Regidrago** (B4a 057) — Draconic Slam, added as an extra meta-relevant pick. Adds `ReducedDamageIfSelfDamaged`: full damage normally, reduced (floored at 0) if the attacker already has damage on it.

## Not in this PR

- **Garchomp** — already fully implemented on `main` before this branch (all `ex` prints across A2a/A4a/A4b), so there was nothing to do.
- **Mega Charizard Y ex, Mimikyu ex, Mega Mawile ex** — the other B4a `ex` cards were already complete on `main`.
- B4a Trainer cards (Boss, Master Plan, Researcher, Thieving Machine, Goo-zooka, Arcade) and remaining non-`ex` Pokémon are left for a follow-up — out of scope per this PR's "Pokémon only" request.
- Gholdengo's "Luxury Coin" ability (reroll Trainer-card coin flips) was considered as a meta pick but skipped: it needs a distinct reflip pathway from the existing attack-only coin reflip mechanism and felt like scope creep here.

## Test plan

- [x] TDD: 1-2 focused `Game`-API-level tests per card, added before implementation
- [x] `cargo fmt`
- [x] `cargo test --features "tui test-utils"` — full suite passes, 0 failures
- [x] `cargo run --bin card_status` — all targeted cards now show `✓ Complete`
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — pre-existing, unrelated failure on `main` (`clippy::doc_lazy_continuation` in `tests/pokemon/victini_victory_star_test.rs`), not introduced by this branch

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013syLfcqwMyX512qVmereZf