### PR TITLE
Implement B4a Trainer cards

### DIFF
--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -234,6 +234,9 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
             forecast_discard_opponent_supporter(action.actor, supporter_card)
         }
         SimpleAction::DiscardOwnCards { cards } => forecast_discard_own_cards(action.actor, cards),
+        SimpleAction::BenchOpponentPokemonFromHand { cards } => {
+            forecast_bench_opponent_pokemon_from_hand(action.actor, cards)
+        }
         SimpleAction::AttachFromDiscard {
             in_play_idx,
             num_random_energies,
@@ -948,6 +951,29 @@ fn forecast_discard_own_cards(acting_player: usize, cards: &[Card]) -> Outcomes 
             state.discard_card_from_hand(acting_player, card);
         }
         debug!("Discarded {:?} from hand", cards_clone);
+    })
+}
+
+/// Team Rocket's Boss: put the chosen Basic Pokémon found in the opponent's hand onto the
+/// opponent's Bench.
+fn forecast_bench_opponent_pokemon_from_hand(acting_player: usize, cards: &[Card]) -> Outcomes {
+    let cards_clone = cards.to_vec();
+    Outcomes::single_fn(move |_rng, state, _action| {
+        let opponent = (acting_player + 1) % 2;
+        for card in &cards_clone {
+            let Some(bench_idx) = state.in_play_pokemon[opponent]
+                .iter()
+                .position(|slot| slot.is_none())
+            else {
+                debug!("No bench space available, skipping remaining Pokemon");
+                break;
+            };
+            apply_place_card(state, opponent, card, bench_idx, false);
+        }
+        debug!(
+            "Team Rocket's Boss: Put {:?} from opponent's hand onto their Bench",
+            cards_clone
+        );
     })
 }
 

--- a/src/actions/apply_stadium_action.rs
+++ b/src/actions/apply_stadium_action.rs
@@ -7,8 +7,8 @@ use crate::{
     },
     models::{Card, EnergyType, TrainerType},
     stadiums::{
-        is_area_zero_active, is_fragrant_forest_active, is_kids_room_active, is_mesagoza_active,
-        is_rainbow_cave_active,
+        is_arcade_active, is_area_zero_active, is_fragrant_forest_active, is_kids_room_active,
+        is_mesagoza_active, is_rainbow_cave_active,
     },
     State,
 };
@@ -36,6 +36,9 @@ pub(crate) fn forecast_use_stadium(state: &State, acting_player: usize) -> Outco
     }
     if is_rainbow_cave_active(state) {
         return forecast_rainbow_cave_effect();
+    }
+    if is_arcade_active(state) {
+        return forecast_arcade_effect();
     }
     Outcomes::single_fn(|_, _, _| {})
 }
@@ -133,6 +136,25 @@ fn forecast_kids_room_effect(state: &State, acting_player: usize) -> Outcomes {
                 .move_generation_stack
                 .push((action.actor, choices.clone()));
         }
+    })
+}
+
+/// Arcade: once during each player's turn, that player may flip 3 coins. If all of them are
+/// heads, that player draws cards until they have 7 cards in their hand.
+fn forecast_arcade_effect() -> Outcomes {
+    Outcomes::binomial_by_heads(3, |heads| {
+        Box::new(move |_, state, action| {
+            state.has_used_stadium[action.actor] = true;
+            if heads == 3 {
+                while state.hands[action.actor].len() < 7 {
+                    let hand_size_before = state.hands[action.actor].len();
+                    state.maybe_draw_card(action.actor);
+                    if state.hands[action.actor].len() == hand_size_before {
+                        break; // Deck is empty, nothing left to draw
+                    }
+                }
+            }
+        })
     })
 }
 

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -223,6 +223,9 @@ pub fn forecast_trainer_action(
         CardId::B4153Wally | CardId::B4193Wally => Outcomes::single_fn(wally_effect),
         CardId::B4150Psychic | CardId::B4190Psychic => Outcomes::single_fn(psychic_effect),
         CardId::B4151Drayden | CardId::B4191Drayden => Outcomes::single_fn(drayden_effect),
+        CardId::B4a070TeamRocketsMasterPlan
+        | CardId::B4a086TeamRocketsMasterPlan
+        | CardId::B4a094TeamRocketsMasterPlan => team_rockets_master_plan_outcomes(),
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1289,6 +1292,21 @@ fn drayden_effect(_: &mut StdRng, state: &mut State, _: &Action) {
         },
         0,
     );
+}
+
+/// Team Rocket's Master Plan: opponent's Active Pokémon is now Confused. Flip a coin. If tails,
+/// your Active Pokémon is now also Confused.
+fn team_rockets_master_plan_outcomes() -> Outcomes {
+    let heads_mutation = Box::new(|_: &mut StdRng, state: &mut State, action: &Action| {
+        let opponent = (action.actor + 1) % 2;
+        state.apply_status_condition(opponent, 0, StatusCondition::Confused);
+    });
+    let tails_mutation = Box::new(|_: &mut StdRng, state: &mut State, action: &Action| {
+        let opponent = (action.actor + 1) % 2;
+        state.apply_status_condition(opponent, 0, StatusCondition::Confused);
+        state.apply_status_condition(action.actor, 0, StatusCondition::Confused);
+    });
+    Outcomes::binary_coin(heads_mutation, tails_mutation)
 }
 
 fn psychic_effect(_: &mut StdRng, state: &mut State, action: &Action) {

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -232,6 +232,9 @@ pub fn forecast_trainer_action(
         CardId::B4a068TeamRocketsGoozooka | CardId::B4a110TeamRocketsGoozooka => {
             Outcomes::single_fn(team_rockets_goozooka_effect)
         }
+        CardId::B4a069TeamRocketsResearcher | CardId::B4a085TeamRocketsResearcher => {
+            team_rockets_researcher_outcomes()
+        }
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1569,6 +1572,33 @@ fn team_rockets_goozooka_effect(_: &mut StdRng, state: &mut State, action: &Acti
     state
         .get_active_mut(opponent)
         .add_effect(CardEffect::IncreasedRetreatCost { amount: 1 }, 1);
+}
+
+/// Team Rocket's Researcher: flip a coin until you get tails. For each heads, put a random
+/// Pokémon that has "Team Rocket" in its name from your deck into your hand.
+fn team_rockets_researcher_outcomes() -> Outcomes {
+    // Flip coins until tails - capped at 5 heads for practicality (mirrors Vaporeon's Hyper
+    // Whirlpool). Which specific matching card is pulled for each heads is picked deterministically
+    // (instead of branching over every combination) to avoid exploding the game tree; the deck is
+    // reshuffled afterwards so this doesn't leak deck order.
+    Outcomes::geometric_until_tails(5, move |heads| {
+        Box::new(move |rng, state, action| {
+            let player = action.actor;
+            let mut eligible: Vec<Card> = state.decks[player]
+                .cards
+                .iter()
+                .filter(|card| card.get_name().contains("Team Rocket"))
+                .cloned()
+                .collect();
+            for _ in 0..heads {
+                let Some(card) = eligible.pop() else {
+                    break;
+                };
+                state.transfer_card_from_deck_to_hand(player, &card);
+            }
+            state.decks[player].shuffle(false, rng);
+        })
+    })
 }
 
 fn nemona_effect(_: &mut StdRng, state: &mut State, _: &Action) {

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -18,7 +18,7 @@ use crate::{
         psychic_energy_sources, quick_grow_extract_candidates, wallace_candidates,
     },
     combinatorics::generate_combinations,
-    effects::TurnEffect,
+    effects::{CardEffect, TurnEffect},
     hooks::{get_stage, is_ancient_pokemon, is_future_pokemon, is_ultra_beast},
     models::{Card, EnergyType, StatusCondition, TrainerCard, TrainerType},
     tools::{enumerate_tool_choices, is_tool_effect_implemented},
@@ -228,6 +228,9 @@ pub fn forecast_trainer_action(
         | CardId::B4a094TeamRocketsMasterPlan => team_rockets_master_plan_outcomes(),
         CardId::B4a067TeamRocketsThievingMachine => {
             team_rockets_thieving_machine_effect(acting_player, state)
+        }
+        CardId::B4a068TeamRocketsGoozooka | CardId::B4a110TeamRocketsGoozooka => {
+            Outcomes::single_fn(team_rockets_goozooka_effect)
         }
         _ => panic!("Unsupported Trainer Card"),
     }
@@ -1557,6 +1560,15 @@ fn team_rockets_thieving_machine_effect(acting_player: usize, state: &State) -> 
     }
 
     Outcomes::from_parts(probabilities, outcomes)
+}
+
+/// Team Rocket's Goo-zooka: until the end of your opponent's next turn, your opponent's Active
+/// Pokémon's Retreat Cost is 1 more.
+fn team_rockets_goozooka_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    let opponent = (action.actor + 1) % 2;
+    state
+        .get_active_mut(opponent)
+        .add_effect(CardEffect::IncreasedRetreatCost { amount: 1 }, 1);
 }
 
 fn nemona_effect(_: &mut StdRng, state: &mut State, _: &Action) {

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -226,6 +226,9 @@ pub fn forecast_trainer_action(
         CardId::B4a070TeamRocketsMasterPlan
         | CardId::B4a086TeamRocketsMasterPlan
         | CardId::B4a094TeamRocketsMasterPlan => team_rockets_master_plan_outcomes(),
+        CardId::B4a067TeamRocketsThievingMachine => {
+            team_rockets_thieving_machine_effect(acting_player, state)
+        }
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1512,6 +1515,43 @@ fn celestic_town_elder_effect(acting_player: usize, state: &State) -> Outcomes {
             {
                 state.discard_piles[action.actor].remove(idx);
                 state.hands[action.actor].push(pokemon.clone());
+            }
+        }));
+    }
+
+    Outcomes::from_parts(probabilities, outcomes)
+}
+
+/// Team Rocket's Thieving Machine: put a random Item card, except any Team Rocket's Thieving
+/// Machine, from your opponent's discard pile into your hand.
+fn team_rockets_thieving_machine_effect(acting_player: usize, state: &State) -> Outcomes {
+    let opponent = (acting_player + 1) % 2;
+    let eligible_items: Vec<Card> = state.discard_piles[opponent]
+        .iter()
+        .filter(|card| {
+            matches!(card, Card::Trainer(t) if t.trainer_card_type == TrainerType::Item && t.name != "Team Rocket's Thieving Machine")
+        })
+        .cloned()
+        .collect();
+
+    if eligible_items.is_empty() {
+        // No eligible Item in the opponent's discard pile, nothing to do
+        return Outcomes::single_fn(|_, _, _| {});
+    }
+
+    let num_outcomes = eligible_items.len();
+    let probabilities = vec![1.0 / (num_outcomes as f64); num_outcomes];
+    let mut outcomes: Mutations = vec![];
+
+    for item in eligible_items {
+        outcomes.push(Box::new(move |_, state, action| {
+            let opponent = (action.actor + 1) % 2;
+            if let Some(idx) = state.discard_piles[opponent]
+                .iter()
+                .position(|card| card == &item)
+            {
+                state.discard_piles[opponent].remove(idx);
+                state.hands[action.actor].push(item.clone());
             }
         }));
     }

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -235,6 +235,9 @@ pub fn forecast_trainer_action(
         CardId::B4a069TeamRocketsResearcher | CardId::B4a085TeamRocketsResearcher => {
             team_rockets_researcher_outcomes()
         }
+        CardId::B4a071TeamRocketsBoss | CardId::B4a087TeamRocketsBoss => {
+            Outcomes::single_fn(team_rockets_boss_effect)
+        }
         _ => panic!("Unsupported Trainer Card"),
     }
 }
@@ -1572,6 +1575,33 @@ fn team_rockets_goozooka_effect(_: &mut StdRng, state: &mut State, action: &Acti
     state
         .get_active_mut(opponent)
         .add_effect(CardEffect::IncreasedRetreatCost { amount: 1 }, 1);
+}
+
+/// Team Rocket's Boss: look at your opponent's hand and put any number of Basic Pokémon you find
+/// there onto your opponent's Bench.
+fn team_rockets_boss_effect(_: &mut StdRng, state: &mut State, action: &Action) {
+    let player = action.actor;
+    let opponent = (player + 1) % 2;
+    let eligible: Vec<Card> = state.hands[opponent]
+        .iter()
+        .filter(|card| card.is_basic())
+        .cloned()
+        .collect();
+    let free_bench_slots = state.in_play_pokemon[opponent]
+        .iter()
+        .filter(|slot| slot.is_none())
+        .count();
+    let max_to_bench = min(eligible.len(), free_bench_slots);
+
+    if max_to_bench == 0 {
+        return;
+    }
+
+    let choices: Vec<SimpleAction> = (0..=max_to_bench)
+        .flat_map(|k| generate_combinations(&eligible, k))
+        .map(|cards| SimpleAction::BenchOpponentPokemonFromHand { cards })
+        .collect();
+    state.move_generation_stack.push((player, choices));
 }
 
 /// Team Rocket's Researcher: flip a coin until you get tails. For each heads, put a random

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -114,6 +114,11 @@ pub enum SimpleAction {
     DiscardOwnCards {
         cards: Vec<Card>,
     },
+    /// Team Rocket's Boss: put a chosen subset of Basic Pokémon found in the opponent's hand
+    /// onto the opponent's Bench
+    BenchOpponentPokemonFromHand {
+        cards: Vec<Card>,
+    },
     /// Lusamine: attach energies from discard to a Pokemon
     AttachFromDiscard {
         in_play_idx: usize,
@@ -292,6 +297,9 @@ impl fmt::Display for SimpleAction {
             }
             SimpleAction::DiscardOwnCards { cards } => {
                 write!(f, "DiscardOwnCards({:?})", cards)
+            }
+            SimpleAction::BenchOpponentPokemonFromHand { cards } => {
+                write!(f, "BenchOpponentPokemonFromHand({:?})", cards)
             }
             SimpleAction::AttachFromDiscard {
                 in_play_idx,

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -15,6 +15,10 @@ pub enum CardEffect {
     IncreasedAttackCost {
         amount: u8,
     },
+    /// This Pokémon's Retreat Cost is `amount` more (e.g. Team Rocket's Goo-zooka).
+    IncreasedRetreatCost {
+        amount: u8,
+    },
     CannotAttack,
     CannotUseAttack(String),
     IncreasedDamageForAttack {

--- a/src/hooks/retreat.rs
+++ b/src/hooks/retreat.rs
@@ -30,6 +30,17 @@ pub(crate) fn get_retreat_cost(state: &State, card: &PlayedCard) -> Vec<EnergyTy
             return vec![];
         }
         let mut normal_cost = pokemon_card.retreat_cost.clone();
+        let retreat_cost_increase: u8 = card
+            .get_effective_card_effects()
+            .iter()
+            .map(|effect| match effect {
+                CardEffect::IncreasedRetreatCost { amount } => *amount,
+                _ => 0,
+            })
+            .sum();
+        for _ in 0..retreat_cost_increase {
+            normal_cost.push(EnergyType::Colorless);
+        }
         if has_tool(card, CardId::A4a067InflatableBoat)
             && card.get_energy_type() == Some(EnergyType::Water)
         {

--- a/src/move_generation/mod.rs
+++ b/src/move_generation/mod.rs
@@ -6,8 +6,8 @@ use crate::actions::{abilities::AbilityMechanic, get_ability_mechanic, Action, S
 use crate::hooks::{can_evolve_into, can_retreat, contains_energy, get_retreat_cost};
 use crate::models::Card;
 use crate::stadiums::{
-    can_use_area_zero, can_use_fragrant_forest, can_use_kids_room, can_use_mesagoza,
-    can_use_rainbow_cave,
+    can_use_arcade, can_use_area_zero, can_use_fragrant_forest, can_use_kids_room,
+    can_use_mesagoza, can_use_rainbow_cave,
 };
 use crate::state::State;
 
@@ -118,6 +118,7 @@ pub fn generate_possible_actions(state: &State) -> (usize, Vec<Action>) {
         || can_use_area_zero(state, current_player)
         || can_use_kids_room(state, current_player)
         || can_use_rainbow_cave(state, current_player)
+        || can_use_arcade(state, current_player)
     {
         actions.push(SimpleAction::UseStadium);
     }

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -265,6 +265,9 @@ pub fn trainer_move_generation_implementation(
         CardId::B4a068TeamRocketsGoozooka | CardId::B4a110TeamRocketsGoozooka => {
             can_play_trainer(state, trainer_card)
         }
+        CardId::B4a069TeamRocketsResearcher | CardId::B4a085TeamRocketsResearcher => {
+            can_play_trainer(state, trainer_card)
+        }
         _ => None,
     }
 }

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -256,6 +256,9 @@ pub fn trainer_move_generation_implementation(
         CardId::B4153Wally | CardId::B4193Wally => can_play_wally(state, trainer_card),
         CardId::B4150Psychic | CardId::B4190Psychic => can_play_psychic(state, trainer_card),
         CardId::B4151Drayden | CardId::B4191Drayden => can_play_trainer(state, trainer_card),
+        CardId::B4a070TeamRocketsMasterPlan
+        | CardId::B4a086TeamRocketsMasterPlan
+        | CardId::B4a094TeamRocketsMasterPlan => can_play_trainer(state, trainer_card),
         _ => None,
     }
 }

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -259,6 +259,9 @@ pub fn trainer_move_generation_implementation(
         CardId::B4a070TeamRocketsMasterPlan
         | CardId::B4a086TeamRocketsMasterPlan
         | CardId::B4a094TeamRocketsMasterPlan => can_play_trainer(state, trainer_card),
+        CardId::B4a067TeamRocketsThievingMachine => {
+            can_play_team_rockets_thieving_machine(state, trainer_card)
+        }
         _ => None,
     }
 }
@@ -834,6 +837,27 @@ fn can_play_diantha(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Sim
     } else {
         cannot_play_trainer()
     }
+}
+
+/// Check if Team Rocket's Thieving Machine can be played (requires an Item card, other than
+/// itself, in the opponent's discard pile)
+fn can_play_team_rockets_thieving_machine(
+    state: &State,
+    trainer_card: &TrainerCard,
+) -> Option<Vec<SimpleAction>> {
+    let opponent = (state.current_player + 1) % 2;
+    let has_target = state.discard_piles[opponent]
+        .iter()
+        .any(is_thieving_machine_eligible_item);
+    if has_target {
+        can_play_trainer(state, trainer_card)
+    } else {
+        cannot_play_trainer()
+    }
+}
+
+fn is_thieving_machine_eligible_item(card: &Card) -> bool {
+    matches!(card, Card::Trainer(t) if t.trainer_card_type == TrainerType::Item && t.name != "Team Rocket's Thieving Machine")
 }
 
 /// Check if Celestic Town Elder can be played (requires at least 1 Basic Pokemon in discard pile)

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -262,6 +262,9 @@ pub fn trainer_move_generation_implementation(
         CardId::B4a067TeamRocketsThievingMachine => {
             can_play_team_rockets_thieving_machine(state, trainer_card)
         }
+        CardId::B4a068TeamRocketsGoozooka | CardId::B4a110TeamRocketsGoozooka => {
+            can_play_trainer(state, trainer_card)
+        }
         _ => None,
     }
 }

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -268,6 +268,9 @@ pub fn trainer_move_generation_implementation(
         CardId::B4a069TeamRocketsResearcher | CardId::B4a085TeamRocketsResearcher => {
             can_play_trainer(state, trainer_card)
         }
+        CardId::B4a071TeamRocketsBoss | CardId::B4a087TeamRocketsBoss => {
+            can_play_trainer(state, trainer_card)
+        }
         _ => None,
     }
 }

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -63,6 +63,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::ShuffleOpponentSupporter { .. } => 5,
         SimpleAction::DiscardOpponentSupporter { .. } => 5,
         SimpleAction::DiscardOwnCards { .. } => 5,
+        SimpleAction::BenchOpponentPokemonFromHand { .. } => 5,
         SimpleAction::AttachFromDiscard { .. } => 10,
         SimpleAction::AttachTypedFromDiscard { .. } => 10,
         SimpleAction::SadaAttach { .. } => 10,

--- a/src/stadiums.rs
+++ b/src/stadiums.rs
@@ -54,6 +54,8 @@ static SOOTHING_SHORE_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B4154SoothingShore));
 static RAINBOW_CAVE_EFFECT: LazyLock<String> =
     LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B4155RainbowCave));
+static ARCADE_EFFECT: LazyLock<String> =
+    LazyLock::new(|| stadium_effect_text_from_card_id(CardId::B4a072Arcade));
 
 pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
     ensure_stadium_trainer(trainer_card);
@@ -72,6 +74,7 @@ pub fn is_stadium_effect_implemented(trainer_card: &TrainerCard) -> bool {
             || e == KIDS_ROOM_EFFECT.as_str()
             || e == SOOTHING_SHORE_EFFECT.as_str()
             || e == RAINBOW_CAVE_EFFECT.as_str()
+            || e == ARCADE_EFFECT.as_str()
     )
 }
 
@@ -226,4 +229,14 @@ pub fn can_use_kids_room(state: &State, player: usize) -> bool {
         .cards
         .iter()
         .any(|card| matches!(card, Card::Trainer(t) if t.trainer_card_type == TrainerType::Tool))
+}
+
+pub fn is_arcade_active(state: &State) -> bool {
+    has_stadium(state, CardId::B4a072Arcade)
+}
+
+/// Returns true if the player can use Arcade's effect (stadium is active, not used this turn,
+/// and the player has room in hand to benefit from drawing up to 7 cards).
+pub fn can_use_arcade(state: &State, player: usize) -> bool {
+    is_arcade_active(state) && !state.has_used_stadium[player] && state.hands[player].len() < 7
 }

--- a/tests/stadiums.rs
+++ b/tests/stadiums.rs
@@ -1,3 +1,5 @@
+#[path = "stadiums/arcade_test.rs"]
+mod arcade_test;
 #[path = "stadiums/area_zero_test.rs"]
 mod area_zero_test;
 #[path = "stadiums/arena_of_antiquity_test.rs"]

--- a/tests/stadiums/arcade_test.rs
+++ b/tests/stadiums/arcade_test.rs
@@ -1,0 +1,115 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+fn game_with_arcade(deck_cards: Vec<Card>, hand_cards: Vec<Card>) -> deckgym::Game<'static> {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.active_stadium = Some(get_card_by_enum(CardId::B4a072Arcade));
+    state.decks[0].cards = deck_cards;
+    state.hands[0] = hand_cards;
+    game.set_state(state);
+    game
+}
+
+fn use_stadium(game: &mut deckgym::Game<'static>, actor: usize) {
+    game.apply_action(&Action {
+        actor,
+        action: SimpleAction::UseStadium,
+        is_stack: false,
+    });
+}
+
+fn has_use_stadium(game: &deckgym::Game<'static>) -> bool {
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    actions
+        .iter()
+        .any(|action| matches!(action.action, SimpleAction::UseStadium))
+}
+
+/// Arcade: "Once during each player's turn, that player may flip 3 coins. If all of them are
+/// heads, that player draws cards until they have 7 cards in their hand."
+#[test]
+fn test_arcade_draws_to_seven_cards_on_all_heads_and_can_only_be_used_once() {
+    let deck_cards: Vec<Card> = (0..10)
+        .map(|_| get_card_by_enum(CardId::A1001Bulbasaur))
+        .collect();
+    let hand_cards: Vec<Card> = (0..3)
+        .map(|_| get_card_by_enum(CardId::A1033Charmander))
+        .collect();
+
+    assert!(has_use_stadium(&game_with_arcade(
+        deck_cards.clone(),
+        hand_cards.clone()
+    )));
+
+    // Try many seeds until we observe both an all-heads (drew to 7) and a not-all-heads
+    // (hand size unchanged) outcome.
+    let mut saw_draw = false;
+    let mut saw_no_draw = false;
+    for seed in 0..30 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+            vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        );
+        state.current_player = 0;
+        state.turn_count = 3;
+        state.active_stadium = Some(get_card_by_enum(CardId::B4a072Arcade));
+        state.decks[0].cards = deck_cards.clone();
+        state.hands[0] = hand_cards.clone();
+        game.set_state(state);
+
+        use_stadium(&mut game, 0);
+        let state = game.get_state_clone();
+
+        assert!(
+            state.has_used_stadium[0],
+            "Seed {seed}: Arcade is a once-per-turn stadium effect"
+        );
+        assert!(
+            !has_use_stadium(&game),
+            "Seed {seed}: player should not be able to use Arcade twice in one turn"
+        );
+
+        match state.hands[0].len() {
+            7 => saw_draw = true,
+            3 => saw_no_draw = true,
+            other => panic!("Seed {seed}: unexpected hand size {other}"),
+        }
+    }
+
+    assert!(saw_draw, "Arcade should draw to 7 cards for some seed");
+    assert!(
+        saw_no_draw,
+        "Arcade should leave the hand untouched for some seed"
+    );
+}
+
+#[test]
+fn test_arcade_unavailable_when_hand_already_has_seven_cards() {
+    let deck_cards: Vec<Card> = (0..10)
+        .map(|_| get_card_by_enum(CardId::A1001Bulbasaur))
+        .collect();
+    let hand_cards: Vec<Card> = (0..7)
+        .map(|_| get_card_by_enum(CardId::A1033Charmander))
+        .collect();
+
+    let game = game_with_arcade(deck_cards, hand_cards);
+    assert!(
+        !has_use_stadium(&game),
+        "UseStadium should not be offered when the hand already has 7+ cards"
+    );
+}

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -40,6 +40,8 @@ mod skyla_test;
 mod team_rockets_goozooka_test;
 #[path = "trainers/team_rockets_master_plan_test.rs"]
 mod team_rockets_master_plan_test;
+#[path = "trainers/team_rockets_researcher_test.rs"]
+mod team_rockets_researcher_test;
 #[path = "trainers/team_rockets_thieving_machine_test.rs"]
 mod team_rockets_thieving_machine_test;
 #[path = "trainers/volkner_test.rs"]

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -38,6 +38,8 @@ mod puppy_loving_girl_test;
 mod skyla_test;
 #[path = "trainers/team_rockets_master_plan_test.rs"]
 mod team_rockets_master_plan_test;
+#[path = "trainers/team_rockets_thieving_machine_test.rs"]
+mod team_rockets_thieving_machine_test;
 #[path = "trainers/volkner_test.rs"]
 mod volkner_test;
 #[path = "trainers/wallace_test.rs"]

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -36,6 +36,8 @@ mod psychic_test;
 mod puppy_loving_girl_test;
 #[path = "trainers/skyla_test.rs"]
 mod skyla_test;
+#[path = "trainers/team_rockets_goozooka_test.rs"]
+mod team_rockets_goozooka_test;
 #[path = "trainers/team_rockets_master_plan_test.rs"]
 mod team_rockets_master_plan_test;
 #[path = "trainers/team_rockets_thieving_machine_test.rs"]

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -36,6 +36,8 @@ mod psychic_test;
 mod puppy_loving_girl_test;
 #[path = "trainers/skyla_test.rs"]
 mod skyla_test;
+#[path = "trainers/team_rockets_boss_test.rs"]
+mod team_rockets_boss_test;
 #[path = "trainers/team_rockets_goozooka_test.rs"]
 mod team_rockets_goozooka_test;
 #[path = "trainers/team_rockets_master_plan_test.rs"]

--- a/tests/trainers.rs
+++ b/tests/trainers.rs
@@ -36,6 +36,8 @@ mod psychic_test;
 mod puppy_loving_girl_test;
 #[path = "trainers/skyla_test.rs"]
 mod skyla_test;
+#[path = "trainers/team_rockets_master_plan_test.rs"]
+mod team_rockets_master_plan_test;
 #[path = "trainers/volkner_test.rs"]
 mod volkner_test;
 #[path = "trainers/wallace_test.rs"]

--- a/tests/trainers/team_rockets_boss_test.rs
+++ b/tests/trainers/team_rockets_boss_test.rs
@@ -1,0 +1,125 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard, TrainerCard},
+    test_support::get_initialized_game,
+};
+
+fn make_boss_trainer_card() -> TrainerCard {
+    get_card_by_enum(CardId::B4a071TeamRocketsBoss).as_trainer()
+}
+
+fn play_boss(game: &mut deckgym::Game) {
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: make_boss_trainer_card(),
+        },
+        is_stack: false,
+    });
+}
+
+/// Team Rocket's Boss: "Look at your opponent's hand and put any number of Basic Pokémon you
+/// find there onto your opponent's Bench."
+#[test]
+fn test_boss_offers_every_subset_of_opponents_basics_up_to_bench_space() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    state.hands[0] = vec![Card::Trainer(make_boss_trainer_card())];
+    state.hands[1] = vec![
+        get_card_by_enum(CardId::A1001Bulbasaur),
+        get_card_by_enum(CardId::A1033Charmander),
+    ];
+    game.set_state(state);
+
+    play_boss(&mut game);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    // With 2 Basics in hand and 2 free Bench slots: choose 0, either 1 of 2, or both -> 4 choices.
+    assert_eq!(
+        choices.len(),
+        4,
+        "Should offer every subset (including none) of the opponent's 2 Basics; got {choices:?}"
+    );
+
+    let put_both = choices
+        .iter()
+        .find(|a| matches!(&a.action, SimpleAction::BenchOpponentPokemonFromHand { cards } if cards.len() == 2))
+        .expect("Should have a choice putting both Basics onto the Bench")
+        .clone();
+    game.apply_action(&put_both);
+
+    let state = game.get_state_clone();
+    assert!(
+        state.hands[1].is_empty(),
+        "Both Basics should have left the opponent's hand"
+    );
+    assert!(
+        state.in_play_pokemon[1][1].is_some() && state.in_play_pokemon[1][2].is_some(),
+        "Both Basics should now be on the opponent's Bench"
+    );
+}
+
+#[test]
+fn test_boss_can_choose_to_bench_none() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    state.hands[0] = vec![Card::Trainer(make_boss_trainer_card())];
+    state.hands[1] = vec![get_card_by_enum(CardId::A1001Bulbasaur)];
+    game.set_state(state);
+
+    play_boss(&mut game);
+
+    let (_actor, choices) = game.get_state_clone().generate_possible_actions();
+    let put_none = choices
+        .iter()
+        .find(|a| matches!(&a.action, SimpleAction::BenchOpponentPokemonFromHand { cards } if cards.is_empty()))
+        .expect("Should have a choice putting nothing onto the Bench")
+        .clone();
+    game.apply_action(&put_none);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.hands[1].len(),
+        1,
+        "Declining should leave the opponent's hand untouched"
+    );
+    assert!(
+        state.in_play_pokemon[1][1].is_none(),
+        "Declining should leave the opponent's Bench untouched"
+    );
+}
+
+#[test]
+fn test_boss_is_playable_even_without_eligible_basics() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    state.hands[0] = vec![Card::Trainer(make_boss_trainer_card())];
+    state.hands[1] = vec![];
+    game.set_state(state);
+
+    let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        actions
+            .iter()
+            .any(|a| matches!(&a.action, SimpleAction::Play { .. })),
+        "Team Rocket's Boss should always be playable, even with nothing to bench"
+    );
+}

--- a/tests/trainers/team_rockets_goozooka_test.rs
+++ b/tests/trainers/team_rockets_goozooka_test.rs
@@ -1,0 +1,86 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, EnergyType, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Resolves automatic single-choice actions (like the forced start-of-turn draw) until a real
+/// decision point is reached.
+fn advance_to_menu(game: &mut deckgym::Game) {
+    loop {
+        let (_actor, actions) = game.get_state_clone().generate_possible_actions();
+        if let [only_action] = actions.as_slice() {
+            if matches!(only_action.action, SimpleAction::DrawCard { .. }) {
+                game.apply_action(only_action);
+                continue;
+            }
+        }
+        break;
+    }
+}
+
+fn can_retreat(game: &deckgym::Game, player: usize) -> bool {
+    let (actor, actions) = game.get_state_clone().generate_possible_actions();
+    actor == player
+        && actions
+            .iter()
+            .any(|a| matches!(a.action, SimpleAction::Retreat(_)))
+}
+
+fn end_turn(game: &mut deckgym::Game, actor: usize) {
+    game.apply_action(&Action {
+        actor,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    advance_to_menu(game);
+}
+
+/// Team Rocket's Goo-zooka: "Until the end of your opponent's next turn, your opponent's Active
+/// Pokémon's Retreat Cost is 1 more."
+#[test]
+fn test_goozooka_blocks_retreat_during_opponents_next_turn_then_expires() {
+    let goozooka = get_card_by_enum(CardId::B4a068TeamRocketsGoozooka).as_trainer();
+
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    // Blastoise's Retreat Cost is 3 Colorless; give the opponent exactly that much energy so a
+    // 1-more increase is the difference between being able to retreat or not.
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![
+            PlayedCard::from_id(CardId::A1055Blastoise).with_energy(vec![EnergyType::Colorless; 3]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0] = vec![Card::Trainer(goozooka.clone())];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: goozooka,
+        },
+        is_stack: false,
+    });
+
+    // Player 0 ends their turn -> becomes the opponent's (player 1) next turn.
+    end_turn(&mut game, 0);
+    assert!(
+        !can_retreat(&game, 1),
+        "Opponent should not be able to retreat with only 3 energy while Retreat Cost is +1"
+    );
+
+    // Opponent ends their turn without retreating -> back to player 0.
+    end_turn(&mut game, 1);
+    // Player 0 ends their turn -> the opponent's *second* next turn, where the effect expired.
+    end_turn(&mut game, 0);
+    assert!(
+        can_retreat(&game, 1),
+        "Retreat Cost increase should have expired after the opponent's next turn ended"
+    );
+}

--- a/tests/trainers/team_rockets_master_plan_test.rs
+++ b/tests/trainers/team_rockets_master_plan_test.rs
@@ -1,0 +1,68 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Sets up a board with Team Rocket's Master Plan in hand and plays it.
+fn play_master_plan(seed: u64) -> deckgym::State {
+    let master_plan = get_card_by_enum(CardId::B4a070TeamRocketsMasterPlan).as_trainer();
+
+    let mut game = get_initialized_game(seed);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0] = vec![Card::Trainer(master_plan.clone())];
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: master_plan,
+        },
+        is_stack: false,
+    });
+
+    game.get_state_clone()
+}
+
+#[test]
+fn test_master_plan_always_confuses_opponent_active() {
+    for seed in 0..30 {
+        let state = play_master_plan(seed);
+        assert!(
+            state.get_active(1).is_confused(),
+            "Seed {seed}: opponent's Active Pokémon should always be Confused"
+        );
+    }
+}
+
+#[test]
+fn test_master_plan_sometimes_confuses_own_active_on_tails() {
+    let mut own_confused_seen = 0;
+    let mut own_not_confused_seen = 0;
+
+    for seed in 0..30 {
+        let state = play_master_plan(seed);
+        if state.get_active(0).is_confused() {
+            own_confused_seen += 1;
+        } else {
+            own_not_confused_seen += 1;
+        }
+    }
+
+    assert!(
+        own_confused_seen > 0,
+        "Master Plan should confuse own Active on tails for some seed"
+    );
+    assert!(
+        own_not_confused_seen > 0,
+        "Master Plan should not confuse own Active on heads for some seed"
+    );
+}

--- a/tests/trainers/team_rockets_researcher_test.rs
+++ b/tests/trainers/team_rockets_researcher_test.rs
@@ -1,0 +1,88 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Sets up a board with Team Rocket's Researcher in hand and `deck_cards` as the whole deck,
+/// then plays it.
+fn play_researcher(seed: u64, deck_cards: Vec<Card>) -> deckgym::State {
+    let researcher = get_card_by_enum(CardId::B4a069TeamRocketsResearcher).as_trainer();
+
+    let mut game = get_initialized_game(seed);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0] = vec![Card::Trainer(researcher.clone())];
+    state.decks[0].cards = deck_cards;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: researcher,
+        },
+        is_stack: false,
+    });
+
+    game.get_state_clone()
+}
+
+#[test]
+fn test_researcher_never_pulls_non_team_rocket_pokemon() {
+    // Deck only has non-"Team Rocket" cards, so no heads-count should ever pull anything.
+    let bulbasaur = get_card_by_enum(CardId::A1001Bulbasaur);
+    let cynthia = get_card_by_enum(CardId::A2152Cynthia);
+    let deck_cards = vec![bulbasaur, cynthia];
+
+    for seed in 0..15 {
+        let state = play_researcher(seed, deck_cards.clone());
+        assert_eq!(
+            state.decks[0].cards.len(),
+            deck_cards.len(),
+            "Seed {seed}: no card should leave the deck without a Team Rocket Pokemon"
+        );
+        assert!(
+            state.hands[0].is_empty(),
+            "Seed {seed}: hand should stay empty when no Team Rocket Pokemon exists in deck"
+        );
+    }
+}
+
+#[test]
+fn test_researcher_can_pull_multiple_team_rocket_pokemon_on_heads_streak() {
+    let grunt_mon_a = get_card_by_enum(CardId::B4a038TeamRocketsEkans);
+    let grunt_mon_b = get_card_by_enum(CardId::B4a040TeamRocketsGrimer);
+    let deck_cards = vec![grunt_mon_a.clone(), grunt_mon_b.clone()];
+
+    let mut max_pulled = 0;
+    for seed in 0..60 {
+        let state = play_researcher(seed, deck_cards.clone());
+        let pulled = state.hands[0].len();
+        // Every card actually placed in hand must be one of the eligible Team Rocket Pokemon.
+        for card in &state.hands[0] {
+            assert!(
+                deck_cards.contains(card),
+                "Seed {seed}: only Team Rocket Pokemon from the deck should be pulled"
+            );
+        }
+        assert_eq!(
+            state.decks[0].cards.len() + pulled,
+            deck_cards.len(),
+            "Seed {seed}: pulled cards should have left the deck"
+        );
+        max_pulled = max_pulled.max(pulled);
+    }
+
+    assert_eq!(
+        max_pulled,
+        deck_cards.len(),
+        "Researcher should be able to pull every eligible Team Rocket Pokemon on a heads streak"
+    );
+}

--- a/tests/trainers/team_rockets_thieving_machine_test.rs
+++ b/tests/trainers/team_rockets_thieving_machine_test.rs
@@ -1,0 +1,101 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{Card, PlayedCard},
+    test_support::get_initialized_game,
+};
+
+/// Sets up a board where player 0 holds Team Rocket's Thieving Machine and their opponent's
+/// discard pile only contains `discard_cards`, then plays the Item.
+fn play_thieving_machine(seed: u64, discard_cards: Vec<Card>) -> deckgym::State {
+    let thieving_machine = get_card_by_enum(CardId::B4a067TeamRocketsThievingMachine).as_trainer();
+
+    let mut game = get_initialized_game(seed);
+    let mut state = game.get_state_clone();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0] = vec![Card::Trainer(thieving_machine.clone())];
+    state.discard_piles[1] = discard_cards;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::Play {
+            trainer_card: thieving_machine,
+        },
+        is_stack: false,
+    });
+
+    game.get_state_clone()
+}
+
+#[test]
+fn test_thieving_machine_pulls_item_from_opponent_discard() {
+    let potion = get_card_by_enum(CardId::PA001Potion);
+    let state = play_thieving_machine(0, vec![potion.clone()]);
+
+    assert!(
+        state.hands[0].contains(&potion),
+        "Thieving Machine should pull the only Item from the opponent's discard pile"
+    );
+    assert!(
+        !state.discard_piles[1].contains(&potion),
+        "The pulled Item should leave the opponent's discard pile"
+    );
+}
+
+#[test]
+fn test_thieving_machine_never_pulls_itself_or_non_items() {
+    let another_thieving_machine = get_card_by_enum(CardId::B4a067TeamRocketsThievingMachine);
+    let cynthia = get_card_by_enum(CardId::A2152Cynthia);
+    let charmander = get_card_by_enum(CardId::A1033Charmander);
+    let discard_cards = vec![
+        another_thieving_machine.clone(),
+        cynthia.clone(),
+        charmander.clone(),
+    ];
+
+    for seed in 0..15 {
+        let state = play_thieving_machine(seed, discard_cards.clone());
+        assert_eq!(
+            state.discard_piles[1].len(),
+            discard_cards.len(),
+            "Seed {seed}: nothing eligible should have left the opponent's discard pile"
+        );
+        assert!(
+            state.hands[0].is_empty(),
+            "Seed {seed}: hand should stay empty when no eligible Item exists"
+        );
+    }
+}
+
+#[test]
+fn test_thieving_machine_not_playable_without_eligible_target() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    let thieving_machine = get_card_by_enum(CardId::B4a067TeamRocketsThievingMachine).as_trainer();
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::A1001Bulbasaur)],
+        vec![PlayedCard::from_id(CardId::A1033Charmander)],
+    );
+    state.current_player = 0;
+    state.turn_count = 3;
+    state.hands[0] = vec![Card::Trainer(thieving_machine.clone())];
+    state.discard_piles[1] = vec![];
+    game.set_state(state);
+
+    let state = game.get_state_clone();
+    let (_actor, actions) = state.generate_possible_actions();
+    assert!(
+        !actions.iter().any(|action| matches!(
+            &action.action,
+            SimpleAction::Play { trainer_card } if trainer_card.name == thieving_machine.name
+        )),
+        "Thieving Machine should not be playable when the opponent's discard has no eligible Item"
+    );
+}


### PR DESCRIPTION
## Summary
- Implements all 6 Trainer cards from the new B4a "Team Rocket's Ambition" set, one card per commit:
  - **Team Rocket's Master Plan** (B4a 070, 086, 094) — confuses opponent's Active, coin flip to also confuse your own Active.
  - **Team Rocket's Thieving Machine** (B4a 067) — pulls a random Item (excluding another copy of itself) from the opponent's discard pile into hand.
  - **Team Rocket's Goo-zooka** (B4a 068, 110) — +1 Retreat Cost on the opponent's Active until the end of their next turn; adds a new `CardEffect::IncreasedRetreatCost`.
  - **Team Rocket's Researcher** (B4a 069, 085) — flips a coin until tails, pulling a "Team Rocket ..." named Pokémon from deck to hand for each heads (mirrors Vaporeon's Hyper Whirlpool simplification of picking the specific card deterministically instead of branching over every combination).
  - **Team Rocket's Boss** (B4a 071, 087) — reveals the opponent's hand and lets the player choose any subset of Basic Pokémon (up to available Bench space) to place on the opponent's Bench; adds a new `SimpleAction::BenchOpponentPokemonFromHand`.
  - **Arcade** (B4a 072, Stadium) — once per turn, a player may flip 3 coins and draw up to 7 cards in hand on an all-heads result, following the existing `UseStadium` once-per-turn pattern (Mesagoza, Rainbow Cave, etc).

## Test plan
- [x] Added focused `Game` public-API level tests for each card under `tests/trainers/` and `tests/stadiums/`
- [x] `cargo test --features "tui test-utils"` passes (0 failures across all test binaries)
- [x] `cargo fmt` and `cargo clippy --lib --all-features -- -D warnings` clean
- [x] `cargo run --bin card_status` confirms all 6 B4a Trainer cards now show `✓ Complete`


---
_Generated by [Claude Code](https://claude.ai/code/session_01GSkqT9iKfLjyc52twoA31c)_