### PR TITLE
Implement Oricorio (Fantastical Parade) and Happiny next-turn damage boost mechanic

### DIFF
--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2020,7 +2020,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
     );
     // map.insert("Discard Water2 [W] Energy from this Pokémon. Your opponent's Active Pokémon is now Paralyzed.", todo_implementation);
     // map.insert("Discard a Stadium in play.", todo_implementation);
-    // map.insert("During your next turn, attacks used by your Pokémon do +20 damage to your opponent's Active Pokémon.", todo_implementation);
+    map.insert(
+        "During your next turn, attacks used by your Pokémon do +20 damage to your opponent's Active Pokémon.",
+        Mechanic::DamageAndTurnEffect {
+            effect: TurnEffect::IncreasedDamage { amount: 20 },
+            duration: 1,
+        },
+    );
     map.insert(
         "During your opponent's next turn, if this Pokémon is damaged by an attack, do 80 damage to the Attacking Pokémon.",
         Mechanic::DamageAndCardEffect {

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -224,6 +224,8 @@ mod morpeko_test;
 mod nidoqueen_test;
 #[path = "pokemon/ninetales_ember_dance_test.rs"]
 mod ninetales_ember_dance_test;
+#[path = "pokemon/oricorio_happiny_damage_boost_test.rs"]
+mod oricorio_happiny_damage_boost_test;
 #[path = "pokemon/oricorio_yveltal_test.rs"]
 mod oricorio_yveltal_test;
 #[path = "pokemon/passimian_ex_offload_pass_test.rs"]

--- a/tests/pokemon/oricorio_happiny_damage_boost_test.rs
+++ b/tests/pokemon/oricorio_happiny_damage_boost_test.rs
@@ -1,0 +1,111 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game},
+};
+
+#[test]
+fn test_oricorio_inspiring_dance_increases_damage_on_next_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B2022Oricorio).with_energy(vec![EnergyType::Fire])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![EnergyType::Grass])],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2022Oricorio, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let mut next_turn_state = game.get_state_clone();
+    next_turn_state.turn_count = 2;
+    next_turn_state.current_player = 0;
+    game.set_state(next_turn_state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2022Oricorio, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 110);
+}
+
+#[test]
+fn test_happiny_chubby_cheer_b4a063_increases_damage_on_next_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B4a063Happiny)],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![EnergyType::Grass])],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a063Happiny, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let mut next_turn_state = game.get_state_clone();
+    next_turn_state.turn_count = 2;
+    next_turn_state.current_player = 0;
+    game.set_state(next_turn_state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a063Happiny, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 110);
+}
+
+#[test]
+fn test_happiny_chubby_cheer_b4a077_increases_damage_on_next_turn() {
+    let mut game = get_initialized_game(0);
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.turn_count = 1;
+    state.set_board(
+        vec![PlayedCard::from_id(CardId::B4a077Happiny)],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![EnergyType::Grass])],
+    );
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a077Happiny, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let mut next_turn_state = game.get_state_clone();
+    next_turn_state.turn_count = 2;
+    next_turn_state.current_player = 0;
+    game.set_state(next_turn_state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a077Happiny, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 110);
+}


### PR DESCRIPTION
## Summary

- Implements the missing next-turn +20 damage boost mechanic for:
  - Oricorio (B2 022, B2 161) — Inspiring Dance
  - Happiny (B4a 063, B4a 077) — Chubby Cheer
- These cards use the effect: “During your next turn, attacks used by your Pokémon do +20 damage to your opponent’s Active Pokémon.”
- Adds the required `DamageAndTurnEffect` mapping and validates it via public Game API tests.

I hope the code is correct. It's been a while since I implemented some cards, and I wanted to get Happiny into the optimizer. :)