### PR TITLE
Implement Drampa's Berserk and Dragon Breath attacks

### DIFF
--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -539,6 +539,9 @@ fn forecast_effect_attack_by_mechanic(
         }
         Mechanic::CoinFlipSetOpponentHpTo { hp } => coin_flip_set_opponent_hp(*hp),
         Mechanic::SelfDiscardAllEnergy => damage_and_discard_all_energy(attack.fixed_damage),
+        Mechanic::SelfDiscardAllEnergyAndKnockOutOpponentActive => {
+            self_discard_all_energy_and_knock_out_opponent_active()
+        }
         Mechanic::SelfDiscardAllTypeEnergy { energy_type } => {
             discard_all_energy_of_type_attack(attack.fixed_damage, *energy_type)
         }
@@ -2747,6 +2750,19 @@ fn damage_and_discard_all_energy(damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(damage, move |_, state, action| {
         let active = state.get_active_mut(action.actor);
         active.attached_energy.clear(); // Discard all energy
+    })
+}
+
+/// Raging Bolt's Baneful Boom: discard all Energy from the attacking Pokémon, then Knock Out
+/// the opponent's Active Pokémon outright.
+fn self_discard_all_energy_and_knock_out_opponent_active() -> AttackOutcomes {
+    active_damage_effect_doutcome(0, move |_, state, action| {
+        state.get_active_mut(action.actor).attached_energy.clear();
+
+        let opponent = (action.actor + 1) % 2;
+        let opponent_active = state.get_active_mut(opponent);
+        let remaining_hp = opponent_active.get_remaining_hp();
+        opponent_active.apply_damage(remaining_hp);
     })
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -327,6 +327,9 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::ChanceStatusAttack { condition } => {
             damage_chance_status_attack(attack.fixed_damage, *condition)
         }
+        Mechanic::CoinFlipNoDamageOrStatusAttack { status } => {
+            coin_flip_no_damage_or_status_attack(attack.fixed_damage, *status)
+        }
         Mechanic::CoinFlipStatusOutcome {
             heads_status,
             tails_status,
@@ -595,6 +598,9 @@ fn forecast_effect_attack_by_mechanic(
             pokemon_name,
             *extra_damage,
         ),
+        Mechanic::ExtraDamageIfAnyBenchedDamaged { extra_damage } => {
+            extra_damage_if_any_benched_damaged(state, attack.fixed_damage, *extra_damage)
+        }
         Mechanic::ExtraDamagePerPokemonWithNameOnBench {
             pokemon_name,
             damage_per,
@@ -1734,6 +1740,15 @@ fn damage_chance_status_attack(damage: u32, status: StatusCondition) -> AttackOu
     AttackOutcomes::binary_coin(
         active_damage_effect_outcome(damage, build_status_effect(status)),
         active_damage_outcome(damage),
+    )
+}
+
+/// Drampa's Dragon Breath: on tails this attack does nothing (no damage at all); on heads deal
+/// the attack's fixed damage and inflict `status` on the opponent's Active.
+fn coin_flip_no_damage_or_status_attack(damage: u32, status: StatusCondition) -> AttackOutcomes {
+    AttackOutcomes::binary_coin(
+        active_damage_effect_outcome(damage, build_status_effect(status)),
+        active_damage_outcome(0),
     )
 }
 
@@ -3098,6 +3113,19 @@ fn extra_damage_if_pokemon_on_bench(
         .enumerate_bench_pokemon(state.current_player)
         .any(|(_, p)| p.get_name() == pokemon_name);
     if has_pokemon_on_bench {
+        active_damage_doutcome(base + extra)
+    } else {
+        active_damage_doutcome(base)
+    }
+}
+
+/// Drampa's Berserk: extra damage if any of the attacker's own Benched Pokémon already have
+/// damage on them.
+fn extra_damage_if_any_benched_damaged(state: &State, base: u32, extra: u32) -> AttackOutcomes {
+    let any_benched_damaged = state
+        .enumerate_bench_pokemon(state.current_player)
+        .any(|(_, p)| p.is_damaged());
+    if any_benched_damaged {
         active_damage_doutcome(base + extra)
     } else {
         active_damage_doutcome(base)

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 
 use super::{
-    attack_outcome::{AttackOutcome, AttackOutcomes},
+    attack_outcome::{AttackOutcome, AttackOutcomes, DamageTarget},
     mutations::{
         active_damage_doutcome, active_damage_effect_doutcome, active_damage_effect_outcome,
         active_damage_outcome, build_status_effect, damage_effect_doutcome,
@@ -567,6 +567,17 @@ fn forecast_effect_attack_by_mechanic(
             attack.fixed_damage,
             *damage,
             *must_have_energy,
+        ),
+        Mechanic::SelfDiscardRandomEnergyAndBenchDamage {
+            count,
+            opponent,
+            bench_damage,
+        } => self_discard_random_energy_and_bench_damage(
+            state,
+            attack.fixed_damage,
+            *count,
+            *opponent,
+            *bench_damage,
         ),
         Mechanic::AlsoChoiceBenchDamage { opponent, damage } => {
             also_choice_bench_damage(state, *opponent, attack.fixed_damage, *damage)
@@ -2984,6 +2995,42 @@ fn also_bench_damage(
         .collect();
     targets.push((active_damage, true, 0)); // Opponent's Active Pokémon is always index 0
     damage_effect_doutcome(targets, |_, _, _| {})
+}
+
+/// Walking Wake's Sweeping Billow: discard `count` random Energy from the attacking Pokémon,
+/// and this attack also does `bench_damage` to each of the chosen player's Benched Pokémon.
+fn self_discard_random_energy_and_bench_damage(
+    state: &State,
+    active_damage: u32,
+    count: usize,
+    opponent: bool,
+    bench_damage: u32,
+) -> AttackOutcomes {
+    let player = if opponent {
+        (state.current_player + 1) % 2
+    } else {
+        state.current_player
+    };
+    let mut targets: Vec<DamageTarget> = state
+        .enumerate_bench_pokemon(player)
+        .map(|(idx, _)| (bench_damage, opponent, idx))
+        .collect();
+    targets.push((active_damage, true, 0)); // Opponent's Active Pokémon is always index 0
+    damage_effect_doutcome(targets, move |rng, state, action| {
+        let active = state.get_active(action.actor);
+        let mut to_discard = Vec::new();
+        let mut remaining = active.attached_energy.clone();
+        for _ in 0..count {
+            if remaining.is_empty() {
+                break;
+            }
+            let idx = rng.gen_range(0..remaining.len());
+            to_discard.push(remaining.swap_remove(idx));
+        }
+        if !to_discard.is_empty() {
+            state.discard_from_active(action.actor, &to_discard);
+        }
+    })
 }
 
 /// Deals the same damage to all of opponent's Pokémon (active and bench) - like Spiritomb/Clawitzer

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -461,6 +461,16 @@ fn forecast_effect_attack_by_mechanic(
             effect.clone(),
             *duration,
         ),
+        Mechanic::SelfDiscardRandomEnergyAndCardEffect {
+            count,
+            effect,
+            duration,
+        } => self_discard_random_energy_and_card_effect(
+            attack.fixed_damage,
+            *count,
+            effect.clone(),
+            *duration,
+        ),
         Mechanic::ExtraDamageIfExtraEnergy {
             required_extra_energy,
             extra_damage,
@@ -2176,6 +2186,34 @@ fn self_discard_energy_and_card_effect(
 ) -> AttackOutcomes {
     active_damage_effect_doutcome(fixed_damage, move |_, state, action| {
         discard_requested_energy_from_active_best_effort(state, action.actor, &to_discard);
+        state
+            .get_active_mut(action.actor)
+            .add_effect(effect.clone(), duration);
+    })
+}
+
+/// Gouging Fire's Scorching Interruption: discard `count` random Energy from the attacking
+/// Pokémon, then leave a `CardEffect` on it.
+fn self_discard_random_energy_and_card_effect(
+    fixed_damage: u32,
+    count: usize,
+    effect: CardEffect,
+    duration: u8,
+) -> AttackOutcomes {
+    active_damage_effect_doutcome(fixed_damage, move |rng, state, action| {
+        let active = state.get_active(action.actor);
+        let mut to_discard = Vec::new();
+        let mut remaining = active.attached_energy.clone();
+        for _ in 0..count {
+            if remaining.is_empty() {
+                break;
+            }
+            let idx = rng.gen_range(0..remaining.len());
+            to_discard.push(remaining.swap_remove(idx));
+        }
+        if !to_discard.is_empty() {
+            state.discard_from_active(action.actor, &to_discard);
+        }
         state
             .get_active_mut(action.actor)
             .add_effect(effect.clone(), duration);

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -408,6 +408,9 @@ pub enum Mechanic {
         hp: u32,
     },
     SelfDiscardAllEnergy,
+    /// Raging Bolt's Baneful Boom: discard all Energy from the attacking Pokémon, then Knock Out
+    /// the opponent's Active Pokémon outright (no damage calculation involved).
+    SelfDiscardAllEnergyAndKnockOutOpponentActive,
     SelfDiscardAllTypeEnergy {
         energy_type: EnergyType,
     },

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -430,6 +430,14 @@ pub enum Mechanic {
         damage: u32,
         must_have_energy: bool,
     },
+    /// Walking Wake's Sweeping Billow: discard `count` random Energy from the attacking
+    /// Pokémon, and this attack also does `bench_damage` to each of the chosen player's
+    /// Benched Pokémon (opponent = true → opponent's bench).
+    SelfDiscardRandomEnergyAndBenchDamage {
+        count: usize,
+        opponent: bool,
+        bench_damage: u32,
+    },
     AlsoChoiceBenchDamage {
         opponent: bool,
         damage: u32,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -80,6 +80,11 @@ pub enum Mechanic {
     ChanceStatusAttack {
         condition: StatusCondition,
     },
+    /// Drampa's Dragon Breath: flip a coin; on tails this attack does nothing (no damage either).
+    /// On heads, deal the attack's fixed damage and inflict `status` on the opponent's Active.
+    CoinFlipNoDamageOrStatusAttack {
+        status: StatusCondition,
+    },
     /// Flip a coin; heads inflicts `heads_status`, tails inflicts `tails_status`, both on the
     /// opponent's Active (e.g. Lanturn ex).
     CoinFlipStatusOutcome {
@@ -461,6 +466,11 @@ pub enum Mechanic {
     },
     ExtraDamageIfPokemonOnBench {
         pokemon_name: String,
+        extra_damage: u32,
+    },
+    /// Drampa's Berserk: extra damage if any of the attacker's own Benched Pokémon already
+    /// have damage on them.
+    ExtraDamageIfAnyBenchedDamaged {
         extra_damage: u32,
     },
     /// Nidoqueen - Lovestrike: +'damage_per' for EACH benched Pokémon named 'pokemon_name'

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -199,6 +199,13 @@ pub enum Mechanic {
         effect: CardEffect,
         duration: u8,
     },
+    /// Gouging Fire's Scorching Interruption: discard `count` random Energy from the attacking
+    /// Pokémon, then leave a `CardEffect` on it (e.g. reduced damage taken next turn).
+    SelfDiscardRandomEnergyAndCardEffect {
+        count: usize,
+        effect: CardEffect,
+        duration: u8,
+    },
     ExtraDamageIfExtraEnergy {
         required_extra_energy: Vec<EnergyType>,
         extra_damage: u32,

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -914,7 +914,12 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         effect: CardEffect::PreventAllDamageAndEffects,
         duration: 1,
     });
-    // map.insert("Flip a coin. If tails, this attack does nothing. If heads, your opponent's Active Pokémon is now Paralyzed.", todo_implementation);
+    map.insert(
+        "Flip a coin. If tails, this attack does nothing. If heads, your opponent's Active Pokémon is now Paralyzed.",
+        Mechanic::CoinFlipNoDamageOrStatusAttack {
+            status: StatusCondition::Paralyzed,
+        },
+    );
     // map.insert("Halve your opponent's Active Pokémon's remaining HP, rounded down.", todo_implementation);
     map.insert(
         "Heal 10 damage from this Pokémon.",
@@ -999,7 +1004,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             extra_damage: 40,
         },
     );
-    // map.insert("If any of your Benched Pokémon have damage on them, this attack does 50 more damage.", todo_implementation);
+    map.insert(
+        "If any of your Benched Pokémon have damage on them, this attack does 50 more damage.",
+        Mechanic::ExtraDamageIfAnyBenchedDamaged { extra_damage: 50 },
+    );
     map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 60 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { energy_type: None, extra_damage: 60 });
     map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 40 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { energy_type: None, extra_damage: 40 });
     map.insert("If any of your Pokémon were Knocked Out by damage from an attack during your opponent's last turn, this attack does 50 more damage.", Mechanic::ExtraDamageIfKnockedOutLastTurn { energy_type: None, extra_damage: 50 });

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2595,6 +2595,11 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             duration: 1,
         },
     );
+    // Raging Bolt - Baneful Boom
+    map.insert(
+        "Discard all Energy from this Pokémon. Knock Out your opponent's Active Pokémon.",
+        Mechanic::SelfDiscardAllEnergyAndKnockOutOpponentActive,
+    );
 
     // B4 Mechanics
     // Vespiquen ex - Chase Order

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2577,6 +2577,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             extra_damage_by_heads: vec![0, 20, 50, 120],
         },
     );
+    // Walking Wake - Sweeping Billow
+    map.insert(
+        "Discard an Energy from this Pokémon, and this attack also does 20 damage to each of your opponent's Benched Pokémon.",
+        Mechanic::SelfDiscardRandomEnergyAndBenchDamage {
+            count: 1,
+            opponent: true,
+            bench_damage: 20,
+        },
+    );
     // Gouging Fire - Scorching Interruption
     map.insert(
         "Discard 2 Energy from this Pokémon. During your opponent's next turn, this Pokémon takes -30 damage from attacks.",

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2577,6 +2577,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             extra_damage_by_heads: vec![0, 20, 50, 120],
         },
     );
+    // Gouging Fire - Scorching Interruption
+    map.insert(
+        "Discard 2 Energy from this Pokémon. During your opponent's next turn, this Pokémon takes -30 damage from attacks.",
+        Mechanic::SelfDiscardRandomEnergyAndCardEffect {
+            count: 2,
+            effect: CardEffect::ReducedDamage { amount: 30 },
+            duration: 1,
+        },
+    );
 
     // B4 Mechanics
     // Vespiquen ex - Chase Order

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -76,6 +76,8 @@ mod dedenne_surskit_test;
 mod delibird_test;
 #[path = "pokemon/dragonair_dragons_blessing_test.rs"]
 mod dragonair_dragons_blessing_test;
+#[path = "pokemon/drampa_test.rs"]
+mod drampa_test;
 #[path = "pokemon/drapion_a2_test.rs"]
 mod drapion_a2_test;
 #[path = "pokemon/durant_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -256,6 +256,8 @@ mod psyduck_b4_test;
 mod psyduck_test;
 #[path = "pokemon/purrloin_test.rs"]
 mod purrloin_test;
+#[path = "pokemon/raging_bolt_test.rs"]
+mod raging_bolt_test;
 #[path = "pokemon/raichu_evoshock_test.rs"]
 mod raichu_evoshock_test;
 #[path = "pokemon/rampardos_head_smash_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -110,6 +110,8 @@ mod gardevoir_psy_turbo_test;
 mod gigalith_ex_megaton_cannon_test;
 #[path = "pokemon/giratina_rayquaza_test.rs"]
 mod giratina_rayquaza_test;
+#[path = "pokemon/gouging_fire_test.rs"]
+mod gouging_fire_test;
 #[path = "pokemon/grovyle_slicing_snipe_test.rs"]
 mod grovyle_slicing_snipe_test;
 #[path = "pokemon/growlithe_puppy_pile_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -336,6 +336,8 @@ mod vulpix_tail_whip_test;
 mod wailord_ex_wondrous_waves_test;
 #[path = "pokemon/wailord_test.rs"]
 mod wailord_test;
+#[path = "pokemon/walking_wake_test.rs"]
+mod walking_wake_test;
 #[path = "pokemon/whiscash_test.rs"]
 mod whiscash_test;
 #[path = "pokemon/wugtrio_b2a_test.rs"]

--- a/tests/pokemon/drampa_test.rs
+++ b/tests/pokemon/drampa_test.rs
@@ -1,0 +1,90 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_initialized_game, get_test_game_with_board},
+};
+
+#[test]
+fn test_drampa_berserk_extra_damage_when_bench_damaged() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A3124Drampa)
+                .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(10),
+        ],
+        vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3124Drampa, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // Berserk: 20 base + 50 extra since the Bulbasaur on the bench has damage on it.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 250 - 70);
+}
+
+#[test]
+fn test_drampa_berserk_no_extra_damage_when_bench_undamaged() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A3124Drampa)
+                .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3124Drampa, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // No Benched Pokémon has damage, so only the base 20 damage applies.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 250 - 20);
+}
+
+#[test]
+fn test_drampa_dragon_breath_heads_paralyzes_tails_does_nothing() {
+    for seed in 0..50 {
+        let mut game = get_initialized_game(seed);
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        state.turn_count = 1;
+        state.set_board(
+            vec![PlayedCard::from_id(CardId::A3b054Drampa)
+                .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+            vec![PlayedCard::from_id(CardId::B4197WailordEx)],
+        );
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A3b054Drampa, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        let state = game.get_state_clone();
+        let remaining = state.get_active(1).get_remaining_hp();
+        let paralyzed = state.get_active(1).is_paralyzed();
+
+        if paralyzed {
+            assert_eq!(
+                remaining,
+                250 - 70,
+                "seed {seed}: heads should deal 70 damage and paralyze"
+            );
+        } else {
+            assert_eq!(
+                remaining, 250,
+                "seed {seed}: tails should do nothing at all"
+            );
+        }
+    }
+}

--- a/tests/pokemon/gouging_fire_test.rs
+++ b/tests/pokemon/gouging_fire_test.rs
@@ -1,0 +1,66 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    database::get_card_by_enum,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+fn played_card_with_base_hp(card_id: CardId, base_hp: u32) -> PlayedCard {
+    let card = get_card_by_enum(card_id);
+    PlayedCard::new(card, 0, base_hp, vec![], false, vec![])
+}
+
+/// Test Gouging Fire B3a 054 - Scorching Interruption: discard 2 Energy from itself, then take
+/// -30 damage from attacks during the opponent's next turn.
+#[test]
+fn test_gouging_fire_scorching_interruption() {
+    // Give the opposing Charmander extra HP so it survives Scorching Interruption's 100 damage.
+    let charmander =
+        played_card_with_base_hp(CardId::A1033Charmander, 150).with_energy(vec![EnergyType::Fire]);
+
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a054GougingFire).with_energy(vec![
+                EnergyType::Fire,
+                EnergyType::Lightning,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![charmander],
+    );
+
+    // Player 0: Gouging Fire attacks with Scorching Interruption.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3a054GougingFire, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // 100 fixed damage to the opponent's Active.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 150 - 100);
+    // 2 of the 3 attached Energy were discarded.
+    assert_eq!(state.get_active(0).attached_energy.len(), 1);
+
+    // End turn so it becomes the opponent's next turn.
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    let gouging_fire_hp_before = game.get_state_clone().get_active(0).get_remaining_hp();
+
+    // Player 1: Charmander attacks Gouging Fire with Ember (30 damage, no weakness vs [N]).
+    game.apply_action(&Action {
+        actor: 1,
+        action: attack_action(CardId::A1033Charmander, 0),
+        is_stack: false,
+    });
+
+    let gouging_fire_hp_after = game.get_state_clone().get_active(0).get_remaining_hp();
+
+    // -30 damage reduction should fully negate Ember's 30 damage.
+    assert_eq!(gouging_fire_hp_after, gouging_fire_hp_before);
+}

--- a/tests/pokemon/raging_bolt_test.rs
+++ b/tests/pokemon/raging_bolt_test.rs
@@ -1,0 +1,50 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Test Raging Bolt B3a 055 - Baneful Boom: discard all Energy from itself, then Knock Out the
+/// opponent's Active Pokémon outright.
+#[test]
+fn test_raging_bolt_baneful_boom_knocks_out_opponent_active() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3a055RagingBolt).with_energy(vec![
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Lightning,
+                EnergyType::Lightning,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::B4197WailordEx),
+            PlayedCard::from_id(CardId::A1033Charmander),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3a055RagingBolt, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // All Energy was discarded from Raging Bolt.
+    assert!(state.get_active(0).attached_energy.is_empty());
+    // The opponent's Wailord ex was Knocked Out outright, leaving an empty Active spot.
+    assert!(state.in_play_pokemon[1][0].is_none());
+
+    // Player 1 must now choose a new Active Pokémon from the bench.
+    let (actor, choices) = state.generate_possible_actions();
+    assert_eq!(actor, 1);
+    assert!(choices.iter().all(|choice| matches!(
+        choice.action,
+        SimpleAction::Activate {
+            player: 1,
+            in_play_idx: _
+        }
+    )));
+}

--- a/tests/pokemon/walking_wake_test.rs
+++ b/tests/pokemon/walking_wake_test.rs
@@ -1,0 +1,37 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Test Walking Wake B3a 053 - Sweeping Billow: discard an Energy from itself, and this
+/// attack also does 20 damage to each of the opponent's Benched Pokémon.
+#[test]
+fn test_walking_wake_sweeping_billow() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3a053WalkingWake)
+            .with_energy(vec![EnergyType::Fire, EnergyType::Water])],
+        vec![
+            PlayedCard::from_id(CardId::B4197WailordEx),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3a053WalkingWake, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    // 60 fixed damage to the opponent's Active.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 250 - 60);
+    // 20 damage to the opponent's Benched Bulbasaur.
+    let benched_bulbasaur = state.in_play_pokemon[1][1]
+        .as_ref()
+        .expect("Bulbasaur should still be on the bench");
+    assert_eq!(benched_bulbasaur.get_remaining_hp(), 70 - 20);
+    // Exactly 1 of the 2 attached Energy was discarded.
+    assert_eq!(state.get_active(0).attached_energy.len(), 1);
+}


### PR DESCRIPTION
Berserk (A3 124 / A3 176) deals 50 extra damage when any of the
attacker's Benched Pokémon already has damage on it. Dragon Breath
(A3b 054) flips a coin: on tails the attack does nothing at all, on
heads it deals its damage and Paralyzes the opponent's Active Pokémon.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WBxhFXMWafPLvQsaHfhALY