### PR TITLE
Record the winner of each game in exported simulation data

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,20 +68,26 @@ exported_data/
 ├── <game_id_1>/
 │   ├── ply_0000.json
 │   ├── ply_0001.json
-│   └── ...
+│   ├── ...
+│   └── outcome.json
 ├── <game_id_2>/
 │   ├── ply_0000.json
-│   └── ...
+│   ├── ...
+│   └── outcome.json
 └── ...
 ```
 
-Each JSON file contains:
+Each `ply_*.json` file contains:
 - `game_id`: UUID of the game
 - `ply`: Sequential decision point number
 - `actor`: Which player (0 or 1) made the decision
 - `state`: Complete game state (hands, decks, in-play Pokemon, etc.)
 - `playable_actions`: All available actions at this decision point
 - `chosen_action`: The action that was actually taken
+
+Ply states are captured before each action, so none of them hold the final result. `outcome.json` records it once per game:
+- `game_id`: UUID of the game
+- `result`: `{"Win": 0}`, `{"Win": 1}`, `"Tie"`, or `null` if the game did not finish
 
 ### Processing the Data
 

--- a/examples/load_exported_data.py
+++ b/examples/load_exported_data.py
@@ -9,7 +9,34 @@ Usage:
 import json
 import sys
 from pathlib import Path
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Optional
+
+
+def load_game_outcome(game_folder: Path) -> Optional[Dict[str, Any]]:
+    """
+    Load the terminal result of a game, written once by the exporter when the
+    game ends. Ply files only contain pre-action states, so this is the only
+    place the winner is recorded.
+
+    The `result` field is the serde encoding of `Option<GameOutcome>`:
+    {"Win": 0}, {"Win": 1}, "Tie", or null when the game was cut short.
+    """
+    outcome_file = game_folder / "outcome.json"
+    if not outcome_file.exists():
+        return None
+    with open(outcome_file, 'r') as f:
+        return json.load(f)
+
+
+def describe_outcome(outcome: Optional[Dict[str, Any]]) -> str:
+    if outcome is None:
+        return "unknown (no outcome.json)"
+    result = outcome.get('result')
+    if result is None:
+        return "unfinished"
+    if result == "Tie":
+        return "tie"
+    return f"player {result['Win']} wins"
 
 
 def load_game_data(game_folder: Path) -> List[Dict[str, Any]]:
@@ -50,8 +77,9 @@ def extract_features(state: Dict[str, Any]) -> Dict[str, Any]:
         'player_0_pokemon_count': sum(1 for p in state['in_play_pokemon'][0] if p is not None),
         'player_1_pokemon_count': sum(1 for p in state['in_play_pokemon'][1] if p is not None),
 
-        # Current energy available
-        'current_energy': state['current_energy'],
+        # Energy zone: the energy available this turn and the one queued next
+        'player_0_current_energy': state['energy_zone'][0]['current'],
+        'player_1_current_energy': state['energy_zone'][1]['current'],
 
         # Turn flags
         'has_played_support': state['has_played_support'],
@@ -83,13 +111,18 @@ def process_exported_data(data_folder: Path):
     print()
 
     total_plys = 0
+    outcome_counts: Dict[str, int] = {}
 
     for game_folder in game_folders:
         game_id = game_folder.name
         game_data = load_game_data(game_folder)
+        outcome = load_game_outcome(game_folder)
+        outcome_label = describe_outcome(outcome)
+        outcome_counts[outcome_label] = outcome_counts.get(outcome_label, 0) + 1
 
         print(f"Game {game_id}:")
         print(f"  Total plys: {len(game_data)}")
+        print(f"  Outcome: {outcome_label}")
 
         total_plys += len(game_data)
 
@@ -106,6 +139,8 @@ def process_exported_data(data_folder: Path):
         print()
 
     print(f"Total plys across all games: {total_plys}")
+    for label, count in sorted(outcome_counts.items()):
+        print(f"  {label}: {count}")
     print()
     print("You can now use this data to:")
     print("  1. Build feature vectors from the state")

--- a/src/data_exporter.rs
+++ b/src/data_exporter.rs
@@ -18,6 +18,13 @@ pub struct ExportedDataPoint {
     pub chosen_action: Action,
 }
 
+/// Struct to hold the terminal outcome of a game
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExportedGameOutcome {
+    pub game_id: String,
+    pub result: Option<GameOutcome>,
+}
+
 /// Event handler that exports (state, action) pairs to JSON files
 pub struct DataExporter {
     output_folder: PathBuf,
@@ -86,7 +93,31 @@ impl SimulationEventHandler for DataExporter {
         self.ply_counter += 1;
     }
 
-    fn on_game_end(&mut self, _game_id: Uuid, _state: State, _result: Option<GameOutcome>) {
+    fn on_game_end(&mut self, game_id: Uuid, _state: State, result: Option<GameOutcome>) {
+        // The exported plies only contain pre-action states, so the terminal outcome
+        // is never recoverable from them. Persist it alongside the plies.
+        let game_folder = self.output_folder.join(game_id.to_string());
+        if let Err(e) = fs::create_dir_all(&game_folder) {
+            warn!("Failed to create game folder {:?}: {}", game_folder, e);
+        }
+
+        let outcome = ExportedGameOutcome {
+            game_id: game_id.to_string(),
+            result,
+        };
+
+        let file_path = game_folder.join("outcome.json");
+        match serde_json::to_string_pretty(&outcome) {
+            Ok(json) => {
+                if let Err(e) = fs::write(&file_path, json) {
+                    warn!("Failed to write outcome file {:?}: {}", file_path, e);
+                }
+            }
+            Err(e) => {
+                warn!("Failed to serialize outcome for game {}: {}", game_id, e);
+            }
+        }
+
         // Reset for next game
         self.ply_counter = 0;
         self.current_game_id = None;

--- a/tests/engine.rs
+++ b/tests/engine.rs
@@ -1,5 +1,7 @@
 #[path = "engine/apply_actions_test.rs"]
 mod apply_actions_test;
+#[path = "engine/data_exporter_test.rs"]
+mod data_exporter_test;
 #[path = "engine/deck_test.rs"]
 mod deck_test;
 #[path = "engine/game_api_test.rs"]

--- a/tests/engine/data_exporter_test.rs
+++ b/tests/engine/data_exporter_test.rs
@@ -1,0 +1,90 @@
+use deckgym::{
+    data_exporter::{DataExporter, ExportedDataPoint, ExportedGameOutcome},
+    players::PlayerCode,
+    simulate::Simulation,
+    test_support::load_test_decks,
+};
+use std::{fs, path::PathBuf};
+use uuid::Uuid;
+
+fn unique_temp_dir() -> PathBuf {
+    std::env::temp_dir().join(format!("deckgym-export-test-{}", Uuid::new_v4()))
+}
+
+/// Every simulated game should produce a folder holding its pre-action ply
+/// snapshots plus an `outcome.json` whose result matches what the engine reported.
+#[test]
+fn test_data_exporter_writes_plies_and_outcome_per_game() {
+    let output_dir = unique_temp_dir();
+    let export_dir = output_dir.clone();
+    let (deck_a, deck_b) = load_test_decks();
+    let num_games = 3;
+
+    let mut simulation = Simulation::new_with_decks(
+        deck_a,
+        deck_b,
+        vec![PlayerCode::R, PlayerCode::R],
+        num_games,
+        Some(7),
+        false,
+        None,
+    )
+    .expect("simulation should build")
+    .register_with_closure(move || Box::new(DataExporter::new(export_dir.clone())));
+
+    let outcomes = simulation.run();
+    assert_eq!(outcomes.len(), num_games as usize);
+
+    let game_folders: Vec<PathBuf> = fs::read_dir(&output_dir)
+        .expect("output folder should exist")
+        .map(|entry| entry.unwrap().path())
+        .filter(|path| path.is_dir())
+        .collect();
+    assert_eq!(game_folders.len(), num_games as usize);
+
+    let mut exported_results = Vec::new();
+    for game_folder in &game_folders {
+        let game_id = game_folder
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
+
+        let ply_files: Vec<PathBuf> = fs::read_dir(game_folder)
+            .unwrap()
+            .map(|entry| entry.unwrap().path())
+            .filter(|path| {
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .is_some_and(|name| name.starts_with("ply_"))
+            })
+            .collect();
+        assert!(!ply_files.is_empty(), "game {game_id} exported no plies");
+
+        let first_ply: ExportedDataPoint =
+            serde_json::from_str(&fs::read_to_string(game_folder.join("ply_0000.json")).unwrap())
+                .expect("ply file should round-trip through serde");
+        assert_eq!(first_ply.game_id, game_id);
+        assert_eq!(first_ply.ply, 0);
+        assert!(
+            first_ply.state.winner.is_none(),
+            "pre-action snapshots never hold the winner; that is why outcome.json exists"
+        );
+
+        let outcome: ExportedGameOutcome =
+            serde_json::from_str(&fs::read_to_string(game_folder.join("outcome.json")).unwrap())
+                .expect("outcome file should round-trip through serde");
+        assert_eq!(outcome.game_id, game_id);
+        exported_results.push(outcome.result);
+    }
+
+    // Folder iteration order is arbitrary, so compare as multisets.
+    let mut expected: Vec<String> = outcomes.iter().map(|o| format!("{o:?}")).collect();
+    let mut actual: Vec<String> = exported_results.iter().map(|o| format!("{o:?}")).collect();
+    expected.sort();
+    actual.sort();
+    assert_eq!(actual, expected);
+
+    fs::remove_dir_all(&output_dir).unwrap();
+}


### PR DESCRIPTION
## Why

The `--data-output` export writes one JSON file per decision point so people can train models on game data. Every one of those files had `winner: null`. Each snapshot is taken *before* an action, and the game loop stops as soon as a game ends, so no snapshot can ever contain the result. Anyone trying to train a value network from this data had no label to train on.

Separately, the loader example the README points to (`examples/load_exported_data.py`) crashed on the first game. It read a `current_energy` field that the state no longer has.

## What changed

- Each game folder now gets an `outcome.json` next to its `ply_*.json` files, written from the game-end callback where the engine already knows the result:
  ```json
  {"game_id": "<uuid>", "result": {"Win": 0}}
  ```
  `result` is `{"Win": 0}`, `{"Win": 1}`, `"Tie"`, or `null` if the game did not finish. Write failures log a warning instead of panicking, matching the existing ply writer.
- The loader example reads the current `energy_zone` field, loads `outcome.json` per game, and prints each game's result plus a summary count.
- The README data export section documents the new file.
- New integration test `tests/engine/data_exporter_test.rs` runs a small seeded simulation with the exporter attached and checks that every game folder has ply files and an `outcome.json` matching what `Simulation::run` returned.

## Checked

- `cargo fmt -- --check`: clean
- `cargo clippy --features "tui test-utils" -- -D warnings`: clean
- `cargo test --features "tui test-utils" --all-targets`: 804 passed, 0 failed
- Manual run of `simulate ... --num 3 --data-output <dir>`: 3 of 3 game folders contain `outcome.json`, results agree with the simulator's stdout summary
- `python3 examples/load_exported_data.py <dir>`: runs to completion and prints outcomes

Note: `cargo clippy --all-targets` (not what CI runs) fails on `tests/pokemon/victini_victory_star_test.rs:175` with a doc-comment lint that is already on `main`. Not touched here.
