### PR TITLE
Implement 36 attack effects across 59 printings (coverage batch D)

### DIFF
--- a/src/actions/apply_abilities_action.rs
+++ b/src/actions/apply_abilities_action.rs
@@ -25,8 +25,7 @@ pub(crate) fn forecast_ability(state: &State, action: &Action, in_play_idx: usiz
         .expect("Pokemon should be there if using ability");
 
     let mechanic = pokemon
-        .card
-        .get_ability()
+        .ability()
         .and_then(|a| ability_mechanic_from_effect(&a.effect))
         .expect("Pokemon should have ability implemented");
 

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -12,6 +12,7 @@ use crate::{
             apply_activate, shuffle_in_play_pokemon_and_attachments_into_deck,
             wrap_with_common_logic,
         },
+        attack_helpers::energy_blender_choices,
     },
     effects::TurnEffect,
     hooks::{
@@ -187,6 +188,7 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::DiscardFossil { .. }
         | SimpleAction::DiscardOwnBenchedThenDamage { .. }
         | SimpleAction::DiscardOwnBenchedGroupThenDamage { .. }
+        | SimpleAction::MoveEnergyAndReoffer { .. }
         | SimpleAction::ReturnPokemonToHand { .. }
         | SimpleAction::ShuffleInPlayPokemonIntoDeck { .. }
         | SimpleAction::DiscardToolFromPokemon { .. }
@@ -485,6 +487,19 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
         SimpleAction::ShuffleInPlayPokemonIntoDeck { in_play_idx } => {
             apply_shuffle_in_play_pokemon_into_deck(action.actor, state, *in_play_idx)
         }
+        SimpleAction::MoveEnergyAndReoffer {
+            from_in_play_idx,
+            to_in_play_idx,
+            energy_type,
+            remaining_moves,
+        } => apply_move_energy_and_reoffer(
+            state,
+            action.actor,
+            *from_in_play_idx,
+            *to_in_play_idx,
+            *energy_type,
+            *remaining_moves,
+        ),
         SimpleAction::DiscardToolFromPokemon {
             player,
             in_play_idx,
@@ -724,6 +739,31 @@ fn forecast_shuffle_self_and_attachments_into_deck(
     Outcomes::single_fn(move |rng, state, _action| {
         shuffle_in_play_pokemon_and_attachments_into_deck(rng, state, acting_player, in_play_idx);
     })
+}
+
+/// Delcatty's Energy Blender: move a single Energy, then offer the same choice again so the player
+/// can keep going (or stop) until the move budget runs out.
+fn apply_move_energy_and_reoffer(
+    state: &mut State,
+    acting_player: usize,
+    from_in_play_idx: usize,
+    to_in_play_idx: usize,
+    energy_type: EnergyType,
+    remaining_moves: usize,
+) {
+    apply_move_energy(
+        state,
+        acting_player,
+        from_in_play_idx,
+        to_in_play_idx,
+        energy_type,
+        1,
+    );
+
+    let choices = energy_blender_choices(state, acting_player, remaining_moves);
+    if !choices.is_empty() {
+        state.move_generation_stack.push((acting_player, choices));
+    }
 }
 
 fn apply_return_pokemon_to_hand(acting_player: usize, state: &mut State, in_play_idx: usize) {

--- a/src/actions/apply_action.rs
+++ b/src/actions/apply_action.rs
@@ -8,7 +8,10 @@ use crate::{
     actions::{
         abilities::AbilityMechanic,
         apply_abilities_action::forecast_ability,
-        apply_action_helpers::{apply_activate, wrap_with_common_logic},
+        apply_action_helpers::{
+            apply_activate, shuffle_in_play_pokemon_and_attachments_into_deck,
+            wrap_with_common_logic,
+        },
     },
     effects::TurnEffect,
     hooks::{
@@ -183,6 +186,7 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         | SimpleAction::HealAllEeveeEvolutions
         | SimpleAction::DiscardFossil { .. }
         | SimpleAction::DiscardOwnBenchedThenDamage { .. }
+        | SimpleAction::DiscardOwnBenchedGroupThenDamage { .. }
         | SimpleAction::ReturnPokemonToHand { .. }
         | SimpleAction::ShuffleInPlayPokemonIntoDeck { .. }
         | SimpleAction::DiscardToolFromPokemon { .. }
@@ -231,6 +235,9 @@ pub fn forecast_action(state: &State, action: &Action) -> Outcomes {
         }
         SimpleAction::ShuffleOpponentSupporter { supporter_card } => {
             forecast_shuffle_opponent_supporter(action.actor, supporter_card)
+        }
+        SimpleAction::ShuffleSelfAndAttachmentsIntoDeck { in_play_idx } => {
+            forecast_shuffle_self_and_attachments_into_deck(action.actor, *in_play_idx)
         }
         SimpleAction::DiscardOpponentSupporter { supporter_card } => {
             forecast_discard_opponent_supporter(action.actor, supporter_card)
@@ -463,6 +470,15 @@ fn apply_deterministic_action(state: &mut State, action: &Action) {
             in_play_idx,
             damage,
         } => apply_discard_own_benched_then_damage(action.actor, state, *in_play_idx, *damage),
+        SimpleAction::DiscardOwnBenchedGroupThenDamage {
+            in_play_indices,
+            damage,
+        } => apply_discard_own_benched_group_then_damage(
+            action.actor,
+            state,
+            in_play_indices,
+            *damage,
+        ),
         SimpleAction::ReturnPokemonToHand { in_play_idx } => {
             apply_return_pokemon_to_hand(action.actor, state, *in_play_idx)
         }
@@ -675,6 +691,39 @@ fn apply_discard_own_benched_then_damage(
             is_from_active_attack: true,
         }],
     ));
+}
+
+/// Gyarados's Wild Swing: discard the chosen Benched Pokémon (possibly none of them), then deal
+/// the already-computed boosted damage to the opponent's Active Pokémon in one go.
+fn apply_discard_own_benched_group_then_damage(
+    acting_player: usize,
+    state: &mut State,
+    in_play_indices: &[usize],
+    damage: u32,
+) {
+    for in_play_idx in in_play_indices {
+        if state.in_play_pokemon[acting_player][*in_play_idx].is_some() {
+            state.discard_from_play(acting_player, *in_play_idx);
+        }
+    }
+    let opponent = (acting_player + 1) % 2;
+    state.move_generation_stack.push((
+        acting_player,
+        vec![SimpleAction::ApplyDamage {
+            attacking_ref: (acting_player, 0),
+            targets: vec![(damage, opponent, 0)],
+            is_from_active_attack: true,
+        }],
+    ));
+}
+
+fn forecast_shuffle_self_and_attachments_into_deck(
+    acting_player: usize,
+    in_play_idx: usize,
+) -> Outcomes {
+    Outcomes::single_fn(move |rng, state, _action| {
+        shuffle_in_play_pokemon_and_attachments_into_deck(rng, state, acting_player, in_play_idx);
+    })
 }
 
 fn apply_return_pokemon_to_hand(acting_player: usize, state: &mut State, in_play_idx: usize) {

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -156,7 +156,11 @@ fn start_turn_ability_outcomes(state: &State, player: usize) -> (Probabilities, 
 fn get_poison_damage(state: &State, player: usize, in_play_idx: usize) -> u32 {
     use crate::actions::{abilities::AbilityMechanic, get_ability_mechanic};
 
-    let base_damage = 10;
+    // Usually 10, unless the attack that inflicted the Poison replaced that amount
+    // (Toxicroak's Toxic does 20, Toxapex's Severe Poison does 40).
+    let base_damage = state.in_play_pokemon[player][in_play_idx]
+        .as_ref()
+        .map_or(10, |pokemon| pokemon.poison_base_damage());
 
     // Nihilego's More Poison ability only affects the active Pokemon
     if in_play_idx != 0 {
@@ -712,6 +716,10 @@ pub(crate) fn handle_knockouts(
                 .and_then(|pokemon| pokemon.get_energy_type());
             state.record_knocked_out_by_opponent_attack(ko_pokemon_type);
         }
+
+        // Every knockout counts against the player who lost the Pokemon, however it happened
+        // (Kingambit's Overlord's Blade counts self-inflicted and Checkup knockouts too).
+        state.record_own_knockout(ko_receiver);
 
         state.discard_from_play(ko_receiver, ko_pokemon_idx);
     }

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -770,6 +770,38 @@ fn get_knocked_out(state: &State) -> Vec<(usize, usize)> {
     knockouts
 }
 
+/// Shuffle `player`'s Pokémon at `in_play_idx`, and everything attached to it, back into their
+/// deck: the card itself, every card it evolved from, and any attached Tool all go into the deck
+/// (which is then shuffled), while attached Energy returns to the discarded-Energy pile.
+///
+/// This is the "and all attached cards" form used by attacks like Eldegoss's Float Up and
+/// Accelgor's Deck and Cover. It differs from `apply_shuffle_in_play_pokemon_into_deck` (Professor
+/// Turo), which returns only the Pokémon cards and leaves the Tool and Energy behind.
+pub(crate) fn shuffle_in_play_pokemon_and_attachments_into_deck(
+    rng: &mut StdRng,
+    state: &mut State,
+    player: usize,
+    in_play_idx: usize,
+) {
+    let Some(pokemon) = state.in_play_pokemon[player][in_play_idx].take() else {
+        return;
+    };
+
+    let mut cards_to_shuffle = pokemon.cards_behind.clone();
+    cards_to_shuffle.push(pokemon.card.clone());
+    if let Some(tool) = pokemon.attached_tool.clone() {
+        cards_to_shuffle.push(tool);
+    }
+    state.decks[player].cards.extend(cards_to_shuffle);
+    state.discard_energies[player].extend(pokemon.attached_energy.iter().cloned());
+    state.decks[player].shuffle(false, rng);
+    state.refresh_double_grass_bonus_for_player(player);
+
+    if in_play_idx == 0 {
+        state.trigger_promotion_or_declare_winner(player);
+    }
+}
+
 /// Swap a bench pokemon into the active spot, clearing status/effects and setting turn flags.
 /// This is the swap portion of retreat without energy payment.
 pub(crate) fn apply_activate(player: usize, state: &mut State, bench_idx: usize) {

--- a/src/actions/apply_action_helpers.rs
+++ b/src/actions/apply_action_helpers.rs
@@ -5,8 +5,7 @@ use rand::rngs::StdRng;
 
 use crate::{
     actions::{
-        abilities::AbilityMechanic, ability_mechanic_from_effect,
-        effect_ability_mechanic_map::get_ability_mechanic, shared_mutations, SimpleAction,
+        abilities::AbilityMechanic, ability_mechanic_from_effect, shared_mutations, SimpleAction,
     },
     card_ids::CardId,
     effects::TurnEffect,
@@ -126,7 +125,7 @@ fn start_turn_ability_outcomes(state: &State, player: usize) -> (Probabilities, 
     let Some(active) = state.maybe_get_active(player) else {
         return (vec![1.0], vec![noop_mutation()]);
     };
-    let Some(ability) = active.card.get_ability() else {
+    let Some(ability) = active.ability() else {
         return (vec![1.0], vec![noop_mutation()]);
     };
     let Some(mechanic) = ability_mechanic_from_effect(&ability.effect) else {
@@ -154,7 +153,7 @@ fn start_turn_ability_outcomes(state: &State, player: usize) -> (Probabilities, 
 /// Calculate poison damage based on base damage (10) plus +10 for each opponent's Nihilego with More Poison ability
 /// Only applies the bonus if the poisoned Pokemon is in the active spot (index 0)
 fn get_poison_damage(state: &State, player: usize, in_play_idx: usize) -> u32 {
-    use crate::actions::{abilities::AbilityMechanic, get_ability_mechanic};
+    use crate::actions::abilities::AbilityMechanic;
 
     // Usually 10, unless the attack that inflicted the Poison replaced that amount
     // (Toxicroak's Toxic does 20, Toxapex's Severe Poison does 40).
@@ -172,7 +171,7 @@ fn get_poison_damage(state: &State, player: usize, in_play_idx: usize) -> u32 {
         .enumerate_in_play_pokemon(opponent)
         .filter(|(_, pokemon)| {
             matches!(
-                get_ability_mechanic(&pokemon.card),
+                pokemon.ability_mechanic(),
                 Some(AbilityMechanic::IncreasePoisonDamage { amount: 10 })
             )
         })
@@ -328,14 +327,12 @@ fn apply_checkup_healing_abilities(state: &mut State) {
         .flat_map(|player| {
             state
                 .enumerate_in_play_pokemon(player)
-                .filter_map(
-                    move |(_, pokemon)| match get_ability_mechanic(&pokemon.card) {
-                        Some(AbilityMechanic::HealAllYourPokemonDuringCheckup { amount }) => {
-                            Some((player, *amount))
-                        }
-                        _ => None,
-                    },
-                )
+                .filter_map(move |(_, pokemon)| match pokemon.ability_mechanic() {
+                    Some(AbilityMechanic::HealAllYourPokemonDuringCheckup { amount }) => {
+                        Some((player, *amount))
+                    }
+                    _ => None,
+                })
         })
         .collect();
 
@@ -361,7 +358,7 @@ fn apply_snowy_terrain_checkup_damage(state: &mut State) {
         if active.is_knocked_out() {
             continue;
         }
-        match get_ability_mechanic(&active.card) {
+        match active.ability_mechanic() {
             Some(AbilityMechanic::CheckupDamageToOpponentActive { amount }) => {
                 active_only_damage.push((player, *amount));
             }
@@ -437,9 +434,7 @@ fn checkapply_prevent_first_attack(
     if let Some(target_pokemon) = state.in_play_pokemon[target_player][target_pokemon_idx].as_mut()
     {
         if !target_pokemon.prevent_first_attack_damage_used {
-            if let Some(AbilityMechanic::PreventFirstAttack) =
-                get_ability_mechanic(&target_pokemon.card)
-            {
+            if let Some(AbilityMechanic::PreventFirstAttack) = target_pokemon.ability_mechanic() {
                 debug!("PreventFirstAttackDamageAfterEnteringPlay: Preventing first attack damage");
                 target_pokemon.prevent_first_attack_damage_used = true;
                 return true;
@@ -466,7 +461,7 @@ pub(crate) fn guts_would_flip(
         return false;
     };
     if !matches!(
-        get_ability_mechanic(&pokemon.card),
+        pokemon.ability_mechanic(),
         Some(AbilityMechanic::CoinFlipToSurviveKnockOut)
     ) {
         return false;
@@ -617,7 +612,7 @@ fn apply_bouncy_body(state: &mut State, target_player: usize) {
     let Some(AbilityMechanic::AttachEnergyFromZoneToBenchedOnDamaged { energy_type }) = state
         .in_play_pokemon[target_player][0]
         .as_ref()
-        .and_then(|active| get_ability_mechanic(&active.card))
+        .and_then(|active| active.ability_mechanic())
     else {
         return;
     };

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -1131,6 +1131,9 @@ fn move_own_energy_any_way(damage: u32) -> AttackOutcomes {
     AttackOutcomes::single(AttackOutcome::damage_then_effect(
         vec![(damage, true, 0)],
         move |_, state, action| {
+            if !attacker_still_in_play(state, action.actor) {
+                return;
+            }
             let budget = total_attached_energy(state, action.actor);
             let choices = energy_blender_choices(state, action.actor, budget);
             if !choices.is_empty() {
@@ -1172,6 +1175,16 @@ fn inflict_poison_with_damage(damage: u32, poison_damage: u32) -> AttackOutcomes
     })
 }
 
+/// Whether the attacking Pokémon is still in the Active Spot and alive. Follow-up effects that act
+/// *from* the attacker (spot damage it deals, Energy it moves, a switch it makes) must not run
+/// after it has been knocked out — e.g. by Rocky Helmet recoil on the attack's own damage — both
+/// because the card says so and because `ApplyDamage` needs a live `attacking_ref`.
+fn attacker_still_in_play(state: &State, actor: usize) -> bool {
+    state.in_play_pokemon[actor][0]
+        .as_ref()
+        .is_some_and(|pokemon| !pokemon.is_knocked_out())
+}
+
 /// Tapu Koko - Volt Switch: like `switch_self_with_bench`, but only Benched Pokémon of
 /// `energy_type` may be switched in. The switch is mandatory when at least one is eligible.
 fn switch_self_with_bench_of_type(
@@ -1191,10 +1204,7 @@ fn switch_self_with_bench_of_type(
     AttackOutcomes::single(AttackOutcome::damage_then_effect(
         vec![(damage, true, 0)],
         move |_, state, action| {
-            let attacker_alive = state.in_play_pokemon[action.actor][0]
-                .as_ref()
-                .is_some_and(|p| !p.is_knocked_out());
-            if !choices.is_empty() && attacker_alive {
+            if !choices.is_empty() && attacker_still_in_play(state, action.actor) {
                 state
                     .move_generation_stack
                     .push((action.actor, choices.clone()));
@@ -1274,6 +1284,11 @@ fn self_damage_and_all_bench_damage(
 /// (the attacking Pokémon itself is a legal target).
 fn also_choice_own_pokemon_damage(active_damage: u32, damage: u32) -> AttackOutcomes {
     active_damage_effect_doutcome(active_damage, move |_, state, action| {
+        // The bonus damage is dealt *by* the attacker, so it fizzles if the attacker was itself
+        // knocked out first (e.g. by Rocky Helmet recoil on the main hit).
+        if !attacker_still_in_play(state, action.actor) {
+            return;
+        }
         let choices: Vec<SimpleAction> = state
             .enumerate_in_play_pokemon(action.actor)
             .map(|(in_play_idx, _)| SimpleAction::ApplyDamage {
@@ -1367,10 +1382,7 @@ fn may_shuffle_self_into_deck(damage: u32) -> AttackOutcomes {
         vec![(damage, true, 0)],
         move |_, state, action| {
             // Nothing to offer if the attacker was knocked out by counterdamage.
-            let attacker_alive = state.in_play_pokemon[action.actor][0]
-                .as_ref()
-                .is_some_and(|p| !p.is_knocked_out());
-            if !attacker_alive {
+            if !attacker_still_in_play(state, action.actor) {
                 return;
             }
             state.move_generation_stack.push((
@@ -1497,6 +1509,9 @@ fn optional_discard_benched_type_for_extra_damage(
         .collect();
 
     active_damage_effect_doutcome(0, move |_, state, action| {
+        if !attacker_still_in_play(state, action.actor) {
+            return;
+        }
         state
             .move_generation_stack
             .push((action.actor, choices.clone()));

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -15,7 +15,6 @@ use crate::{
             generate_distributions, total_attached_energy,
         },
         attacks::{BenchSide, CopyAttackSource, Mechanic},
-        effect_ability_mechanic_map::ability_mechanic_from_effect,
         effect_mechanic_map::EFFECT_MECHANIC_MAP,
         Action,
     },
@@ -166,9 +165,7 @@ fn apply_defender_guts_if_needed(
         .enumerate_in_play_pokemon(opponent)
         .filter(|(_, pokemon)| {
             pokemon
-                .card
-                .get_ability()
-                .and_then(|a| ability_mechanic_from_effect(&a.effect))
+                .ability_mechanic()
                 .map(|m| matches!(m, AbilityMechanic::CoinFlipToSurviveKnockOut))
                 .unwrap_or(false)
         })
@@ -3572,7 +3569,7 @@ fn extra_damage_if_opponent_active_has_ability(
 ) -> AttackOutcomes {
     let opponent = (state.current_player + 1) % 2;
     let opponent_active = state.get_active(opponent);
-    let has_ability = opponent_active.card.get_ability().is_some();
+    let has_ability = opponent_active.ability().is_some();
     active_damage_doutcome(if has_ability { base + extra } else { base })
 }
 
@@ -3584,7 +3581,7 @@ fn extra_damage_per_opponent_pokemon_with_ability(
     let opponent = (state.current_player + 1) % 2;
     let ability_count = state
         .enumerate_in_play_pokemon(opponent)
-        .filter(|(_, pokemon)| pokemon.card.get_ability().is_some())
+        .filter(|(_, pokemon)| pokemon.ability().is_some())
         .count() as u32;
     active_damage_doutcome(base + damage_per * ability_count)
 }

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -1111,7 +1111,51 @@ fn forecast_effect_attack_by_mechanic(
             *energy_type,
             *damage_per,
         ),
+        Mechanic::ExtraDamagePerOwnKnockoutThisGame { damage_per } => {
+            extra_damage_per_own_knockout_this_game(state, attack.fixed_damage, *damage_per)
+        }
+        Mechanic::ExtraDamagePerOpponentPointLastTurn { damage_per } => {
+            extra_damage_per_opponent_point_last_turn(state, attack.fixed_damage, *damage_per)
+        }
+        Mechanic::InflictPoisonWithDamage { poison_damage } => {
+            inflict_poison_with_damage(attack.fixed_damage, *poison_damage)
+        }
+        Mechanic::RequireBenchedNamesThenDiscardAllEnergy { .. } => {
+            damage_and_discard_all_energy(attack.fixed_damage)
+        }
     }
+}
+
+/// Kingambit - Overlord's Blade: `damage_per` more damage for each of the attacker's own Pokémon
+/// that has been Knocked Out this game.
+fn extra_damage_per_own_knockout_this_game(
+    state: &State,
+    base: u32,
+    damage_per: u32,
+) -> AttackOutcomes {
+    let knockouts = state.count_own_knockouts(state.current_player);
+    active_damage_doutcome(base + knockouts * damage_per)
+}
+
+/// Hisuian Basculegion - Soul Counter: `damage_per` more damage for each point the opponent scored
+/// during their own previous turn.
+fn extra_damage_per_opponent_point_last_turn(
+    state: &State,
+    base: u32,
+    damage_per: u32,
+) -> AttackOutcomes {
+    let opponent = (state.current_player + 1) % 2;
+    let points = state.points_gained_during_last_turn(opponent);
+    active_damage_doutcome(base + points * damage_per)
+}
+
+/// Toxicroak - Toxic / Toxapex - Severe Poison: Poison the opponent's Active Pokémon, with Checkup
+/// dealing `poison_damage` instead of the usual 10.
+fn inflict_poison_with_damage(damage: u32, poison_damage: u32) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        state.apply_poison_with_damage(opponent, 0, poison_damage);
+    })
 }
 
 /// Tapu Koko - Volt Switch: like `switch_self_with_bench`, but only Benched Pokémon of

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -1930,12 +1930,17 @@ fn also_choice_bench_damage(
             }
         })
         .collect();
+
+    // "This attack ALSO does X to 1 of ... Benched Pokémon": with no eligible Benched target the
+    // bonus simply fizzles, but the attack's own damage to the Defending Pokémon still happens.
+    if choices.is_empty() {
+        return active_damage_doutcome(active_damage);
+    }
+
     AttackOutcomes::single_effect(move |_, state, action| {
-        if !choices.is_empty() {
-            state
-                .move_generation_stack
-                .push((action.actor, choices.clone()));
-        }
+        state
+            .move_generation_stack
+            .push((action.actor, choices.clone()));
     })
 }
 

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -6,7 +6,9 @@ use rand::{rngs::StdRng, Rng};
 use crate::{
     actions::{
         abilities::AbilityMechanic,
-        apply_action_helpers::handle_knockouts,
+        apply_action_helpers::{
+            handle_knockouts, shuffle_in_play_pokemon_and_attachments_into_deck,
+        },
         apply_evolve,
         attack_helpers::{
             collect_in_play_indices_by_type, energy_any_way_choices, generate_distributions,
@@ -1031,7 +1033,416 @@ fn forecast_effect_attack_by_mechanic(
             damage_per,
         } => damage_per_own_pokemon_with_attack_name(state, attack_name, *damage_per),
         Mechanic::HealEqualToDamageDealt => heal_equal_to_damage_dealt_attack(attack.fixed_damage),
+        Mechanic::SwitchSelfWithBenchOfType { energy_type } => {
+            switch_self_with_bench_of_type(state, attack.fixed_damage, *energy_type)
+        }
+        Mechanic::AttachEnergyFromZoneToNamed { energy_type, names } => {
+            attach_energy_from_zone_to_named(attack.fixed_damage, *energy_type, names.clone())
+        }
+        Mechanic::AttachRandomBasicEnergyToBenched => {
+            attach_random_basic_energy_to_benched(attack.fixed_damage)
+        }
+        Mechanic::SelfDamageAndAllBenchDamage {
+            self_damage,
+            bench_damage,
+        } => self_damage_and_all_bench_damage(
+            state,
+            attack.fixed_damage,
+            *self_damage,
+            *bench_damage,
+        ),
+        Mechanic::AlsoChoiceOwnPokemonDamage { damage } => {
+            also_choice_own_pokemon_damage(attack.fixed_damage, *damage)
+        }
+        Mechanic::DamageAllOpponentPokemonEscalating {
+            attack_name,
+            damage,
+            increment,
+        } => damage_all_opponent_pokemon_escalating(state, attack_name, *damage, *increment),
+        Mechanic::ExtraDamagePerPokemonWithNamesOnBench {
+            pokemon_names,
+            damage_per,
+        } => extra_damage_per_pokemon_with_names_on_bench(
+            state,
+            attack.fixed_damage,
+            pokemon_names,
+            *damage_per,
+        ),
+        Mechanic::ExtraDamagePerOpponentSpecialCondition { damage_per } => {
+            extra_damage_per_opponent_special_condition(state, attack.fixed_damage, *damage_per)
+        }
+        Mechanic::DamageEqualToSelfRemainingHp => damage_equal_to_self_remaining_hp(state),
+        Mechanic::DamageUnaffectedByWeaknessAndOpponentActiveEffects => {
+            active_damage_doutcome(attack.fixed_damage)
+        }
+        Mechanic::MayShuffleSelfIntoDeck => may_shuffle_self_into_deck(attack.fixed_damage),
+        Mechanic::InflictStatusConditionsAndShuffleSelfIntoDeck { conditions } => {
+            inflict_status_conditions_and_shuffle_self_into_deck(
+                attack.fixed_damage,
+                conditions.clone(),
+            )
+        }
+        Mechanic::InflictStatusConditionsAndCardEffect {
+            conditions,
+            effect,
+            duration,
+        } => inflict_status_conditions_and_card_effect(
+            attack.fixed_damage,
+            conditions.clone(),
+            effect.clone(),
+            *duration,
+        ),
+        Mechanic::ShuffleRandomOpponentHandCardIntoDeck => {
+            shuffle_random_opponent_hand_card_into_deck(attack.fixed_damage, false)
+        }
+        Mechanic::ShuffleRandomOpponentHandCardIntoDeckAndSelfIntoDeck => {
+            shuffle_random_opponent_hand_card_into_deck(attack.fixed_damage, true)
+        }
+        Mechanic::RevealOpponentHand => active_damage_doutcome(attack.fixed_damage),
+        Mechanic::ChooseOpponentHandCardToShuffleIntoDeck => {
+            choose_opponent_hand_card_to_shuffle_into_deck(attack.fixed_damage)
+        }
+        Mechanic::OptionalDiscardBenchedTypeForExtraDamage {
+            energy_type,
+            damage_per,
+        } => optional_discard_benched_type_for_extra_damage(
+            state,
+            attack.fixed_damage,
+            *energy_type,
+            *damage_per,
+        ),
     }
+}
+
+/// Tapu Koko - Volt Switch: like `switch_self_with_bench`, but only Benched Pokémon of
+/// `energy_type` may be switched in. The switch is mandatory when at least one is eligible.
+fn switch_self_with_bench_of_type(
+    state: &State,
+    damage: u32,
+    energy_type: EnergyType,
+) -> AttackOutcomes {
+    let choices: Vec<_> = state
+        .enumerate_bench_pokemon(state.current_player)
+        .filter(|(_, pokemon)| pokemon.get_energy_type() == Some(energy_type))
+        .map(|(in_play_idx, _)| SimpleAction::Activate {
+            player: state.current_player,
+            in_play_idx,
+        })
+        .collect();
+
+    AttackOutcomes::single(AttackOutcome::damage_then_effect(
+        vec![(damage, true, 0)],
+        move |_, state, action| {
+            let attacker_alive = state.in_play_pokemon[action.actor][0]
+                .as_ref()
+                .is_some_and(|p| !p.is_knocked_out());
+            if !choices.is_empty() && attacker_alive {
+                state
+                    .move_generation_stack
+                    .push((action.actor, choices.clone()));
+            }
+        },
+    ))
+}
+
+/// Uxie - Mind Boost: take an Energy of `energy_type` from the Energy Zone and attach it to one of
+/// your in-play Pokémon named in `names`. With several eligible targets the attacker chooses.
+fn attach_energy_from_zone_to_named(
+    damage: u32,
+    energy_type: EnergyType,
+    names: Vec<String>,
+) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let choices: Vec<SimpleAction> = state
+            .enumerate_in_play_pokemon(action.actor)
+            .filter(|(_, pokemon)| names.iter().any(|name| pokemon.get_name() == *name))
+            .map(|(in_play_idx, _)| SimpleAction::Attach {
+                attachments: vec![(1, energy_type, in_play_idx)],
+                is_turn_energy: false,
+            })
+            .collect();
+        if choices.is_empty() {
+            return; // No Mesprit or Azelf in play: the Energy simply fizzles.
+        }
+        state.move_generation_stack.push((action.actor, choices));
+    })
+}
+
+/// Sableye - Jeweled Gift: take 1 random Energy from among the 8 basic types out of your Energy
+/// Zone and attach it to 1 of your Benched Pokémon. The type is rolled uniformly, then the
+/// attacker chooses which Benched Pokémon receives it.
+fn attach_random_basic_energy_to_benched(damage: u32) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |rng, state, action| {
+        let choices_of_type = EnergyType::SELECTABLE;
+        let energy_type = choices_of_type[rng.gen_range(0..choices_of_type.len())];
+        let choices: Vec<SimpleAction> = state
+            .enumerate_bench_pokemon(action.actor)
+            .map(|(in_play_idx, _)| SimpleAction::Attach {
+                attachments: vec![(1, energy_type, in_play_idx)],
+                is_turn_energy: false,
+            })
+            .collect();
+        if choices.is_empty() {
+            return; // No Benched Pokémon: the Energy fizzles.
+        }
+        state.move_generation_stack.push((action.actor, choices));
+    })
+}
+
+/// Forretress - Enormous Explosion: the attack's damage to the Defending Pokémon, plus
+/// `self_damage` to the attacker and `bench_damage` to every Benched Pokémon on both sides.
+fn self_damage_and_all_bench_damage(
+    state: &State,
+    active_damage: u32,
+    self_damage: u32,
+    bench_damage: u32,
+) -> AttackOutcomes {
+    let current_player = state.current_player;
+    let opponent = (current_player + 1) % 2;
+
+    let mut targets: Vec<DamageTarget> = vec![(active_damage, true, 0)];
+    for (idx, _) in state.enumerate_bench_pokemon(opponent) {
+        targets.push((bench_damage, true, idx));
+    }
+    for (idx, _) in state.enumerate_bench_pokemon(current_player) {
+        targets.push((bench_damage, false, idx));
+    }
+    targets.push((self_damage, false, 0));
+
+    damage_effect_doutcome(targets, |_, _, _| {})
+}
+
+/// Mimikyu - Shadow Hit: the attack's damage, plus `damage` to 1 of the attacker's OWN Pokémon
+/// (the attacking Pokémon itself is a legal target).
+fn also_choice_own_pokemon_damage(active_damage: u32, damage: u32) -> AttackOutcomes {
+    active_damage_effect_doutcome(active_damage, move |_, state, action| {
+        let choices: Vec<SimpleAction> = state
+            .enumerate_in_play_pokemon(action.actor)
+            .map(|(in_play_idx, _)| SimpleAction::ApplyDamage {
+                attacking_ref: (action.actor, 0),
+                targets: vec![(damage, action.actor, in_play_idx)],
+                is_from_active_attack: false,
+            })
+            .collect();
+        if choices.is_empty() {
+            return;
+        }
+        state.move_generation_stack.push((action.actor, choices));
+    })
+}
+
+/// Archeops - Wild Spin: `damage` to every one of the opponent's Pokémon, escalated by `increment`
+/// for each stacked `IncreasedDamageForAttack` this attack left on itself. The ordinary hook only
+/// boosts Active-to-Active damage, so the bonus is resolved here and applied to every target.
+fn damage_all_opponent_pokemon_escalating(
+    state: &State,
+    attack_name: &str,
+    damage: u32,
+    increment: u32,
+) -> AttackOutcomes {
+    let opponent = (state.current_player + 1) % 2;
+    let stacks = state
+        .get_active(state.current_player)
+        .get_active_effects()
+        .iter()
+        .filter(|effect| {
+            matches!(
+                effect,
+                CardEffect::IncreasedSpreadDamageForAttack { attack_name: name, .. }
+                    if name == attack_name
+            )
+        })
+        .count() as u32;
+    let total = damage + stacks * increment;
+
+    let targets: Vec<DamageTarget> = state
+        .enumerate_in_play_pokemon(opponent)
+        .map(|(idx, _)| (total, true, idx))
+        .collect();
+    let effect = CardEffect::IncreasedSpreadDamageForAttack {
+        attack_name: attack_name.to_string(),
+        amount: increment,
+    };
+    damage_effect_doutcome(targets, move |_, state, action| {
+        if let Some(attacker) = state.in_play_pokemon[action.actor][0].as_mut() {
+            attacker.add_effect(effect.clone(), 2);
+        }
+    })
+}
+
+/// Wishiwashi ex - School Storm: `damage_per` more damage for each Benched Pokémon whose name is
+/// any of `pokemon_names`.
+fn extra_damage_per_pokemon_with_names_on_bench(
+    state: &State,
+    base: u32,
+    pokemon_names: &[String],
+    damage_per: u32,
+) -> AttackOutcomes {
+    let count = state
+        .enumerate_bench_pokemon(state.current_player)
+        .filter(|(_, pokemon)| pokemon_names.iter().any(|name| pokemon.get_name() == *name))
+        .count() as u32;
+    active_damage_doutcome(base + count * damage_per)
+}
+
+/// Team Rocket's Magmar - Derisive Roasting: `damage_per` more damage for each Special Condition
+/// on the opponent's Active Pokémon.
+fn extra_damage_per_opponent_special_condition(
+    state: &State,
+    base: u32,
+    damage_per: u32,
+) -> AttackOutcomes {
+    let opponent_active = state.get_active((state.current_player + 1) % 2);
+    let count = opponent_active.count_status_conditions() as u32;
+    active_damage_doutcome(base + count * damage_per)
+}
+
+/// Teal Mask Ogerpon - Ogre's Whip: damage equal to the attacking Pokémon's remaining HP.
+fn damage_equal_to_self_remaining_hp(state: &State) -> AttackOutcomes {
+    active_damage_doutcome(state.get_active(state.current_player).get_remaining_hp())
+}
+
+/// Eldegoss - Float Up / Dunsparce - Bop 'n' Burrow: after damage, the attacker may shuffle itself
+/// and all attached cards into its owner's deck.
+fn may_shuffle_self_into_deck(damage: u32) -> AttackOutcomes {
+    AttackOutcomes::single(AttackOutcome::damage_then_effect(
+        vec![(damage, true, 0)],
+        move |_, state, action| {
+            // Nothing to offer if the attacker was knocked out by counterdamage.
+            let attacker_alive = state.in_play_pokemon[action.actor][0]
+                .as_ref()
+                .is_some_and(|p| !p.is_knocked_out());
+            if !attacker_alive {
+                return;
+            }
+            state.move_generation_stack.push((
+                action.actor,
+                vec![
+                    SimpleAction::ShuffleSelfAndAttachmentsIntoDeck { in_play_idx: 0 },
+                    SimpleAction::Noop,
+                ],
+            ));
+        },
+    ))
+}
+
+/// Accelgor - Deck and Cover: inflict `conditions` on the opponent's Active Pokémon, then shuffle
+/// the attacking Pokémon and everything attached to it into its owner's deck.
+fn inflict_status_conditions_and_shuffle_self_into_deck(
+    damage: u32,
+    conditions: Vec<StatusCondition>,
+) -> AttackOutcomes {
+    AttackOutcomes::single(AttackOutcome::damage_then_effect(
+        vec![(damage, true, 0)],
+        move |rng, state, action| {
+            let opponent = (action.actor + 1) % 2;
+            for condition in &conditions {
+                state.apply_status_condition(opponent, 0, *condition);
+            }
+            shuffle_in_play_pokemon_and_attachments_into_deck(rng, state, action.actor, 0);
+        },
+    ))
+}
+
+/// Roserade - Poison Ring: inflict `conditions` on the opponent's Active Pokémon and leave `effect`
+/// on it for `duration` turns.
+fn inflict_status_conditions_and_card_effect(
+    damage: u32,
+    conditions: Vec<StatusCondition>,
+    effect: CardEffect,
+    duration: u8,
+) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        for condition in &conditions {
+            state.apply_status_condition(opponent, 0, *condition);
+        }
+        if let Some(defender) = state.in_play_pokemon[opponent][0].as_mut() {
+            defender.add_effect(effect.clone(), duration);
+        }
+    })
+}
+
+/// Tsareena - Kick Down (and, with `shuffle_self`, Liepard - Snatch and Flee): a random card from
+/// the opponent's hand is shuffled into their deck.
+fn shuffle_random_opponent_hand_card_into_deck(damage: u32, shuffle_self: bool) -> AttackOutcomes {
+    AttackOutcomes::single(AttackOutcome::damage_then_effect(
+        vec![(damage, true, 0)],
+        move |rng, state, action| {
+            let opponent = (action.actor + 1) % 2;
+            if !state.hands[opponent].is_empty() {
+                let idx = rng.gen_range(0..state.hands[opponent].len());
+                let card = state.hands[opponent].remove(idx);
+                state.decks[opponent].cards.push(card);
+                state.decks[opponent].shuffle(false, rng);
+            }
+            if shuffle_self {
+                shuffle_in_play_pokemon_and_attachments_into_deck(rng, state, action.actor, 0);
+            }
+        },
+    ))
+}
+
+/// Purugly - Interrupt: the opponent reveals their hand and the attacker picks 1 card from it to
+/// shuffle into the opponent's deck. Identical cards are offered once.
+fn choose_opponent_hand_card_to_shuffle_into_deck(damage: u32) -> AttackOutcomes {
+    active_damage_effect_doutcome(damage, move |_, state, action| {
+        let opponent = (action.actor + 1) % 2;
+        let mut seen: Vec<Card> = Vec::new();
+        let mut choices: Vec<SimpleAction> = Vec::new();
+        for card in &state.hands[opponent] {
+            if seen.contains(card) {
+                continue;
+            }
+            seen.push(card.clone());
+            choices.push(SimpleAction::ShuffleOpponentSupporter {
+                supporter_card: card.clone(),
+            });
+        }
+        if choices.is_empty() {
+            return; // Empty hand: nothing to shuffle away.
+        }
+        state.move_generation_stack.push((action.actor, choices));
+    })
+}
+
+/// Gyarados - Wild Swing: the attacker may discard any number of their own Benched Pokémon of
+/// `energy_type`, dealing `damage_per` more damage for each one discarded this way. Every subset of
+/// the eligible Bench is offered (the empty subset is the "decline" branch).
+fn optional_discard_benched_type_for_extra_damage(
+    state: &State,
+    base: u32,
+    energy_type: EnergyType,
+    damage_per: u32,
+) -> AttackOutcomes {
+    let eligible: Vec<usize> = state
+        .enumerate_bench_pokemon(state.current_player)
+        .filter(|(_, pokemon)| pokemon.get_energy_type() == Some(energy_type))
+        .map(|(idx, _)| idx)
+        .collect();
+
+    if eligible.is_empty() {
+        return active_damage_doutcome(base);
+    }
+
+    let choices: Vec<SimpleAction> = (0..=eligible.len())
+        .flat_map(|count| {
+            generate_combinations(&eligible, count)
+                .into_iter()
+                .map(
+                    move |subset| SimpleAction::DiscardOwnBenchedGroupThenDamage {
+                        in_play_indices: subset,
+                        damage: base + (count as u32) * damage_per,
+                    },
+                )
+        })
+        .collect();
+
+    active_damage_effect_doutcome(0, move |_, state, action| {
+        state
+            .move_generation_stack
+            .push((action.actor, choices.clone()));
+    })
 }
 
 fn copy_attack(

--- a/src/actions/apply_attack_action.rs
+++ b/src/actions/apply_attack_action.rs
@@ -11,7 +11,8 @@ use crate::{
         },
         apply_evolve,
         attack_helpers::{
-            collect_in_play_indices_by_type, energy_any_way_choices, generate_distributions,
+            collect_in_play_indices_by_type, energy_any_way_choices, energy_blender_choices,
+            generate_distributions, total_attached_energy,
         },
         attacks::{BenchSide, CopyAttackSource, Mechanic},
         effect_ability_mechanic_map::ability_mechanic_from_effect,
@@ -1123,7 +1124,23 @@ fn forecast_effect_attack_by_mechanic(
         Mechanic::RequireBenchedNamesThenDiscardAllEnergy { .. } => {
             damage_and_discard_all_energy(attack.fixed_damage)
         }
+        Mechanic::MoveOwnEnergyAnyWay => move_own_energy_any_way(attack.fixed_damage),
     }
+}
+
+/// Delcatty - Energy Blender: after damage, let the attacker move any amount of Energy among their
+/// own Pokémon in play, one Energy at a time (see `SimpleAction::MoveEnergyAndReoffer`).
+fn move_own_energy_any_way(damage: u32) -> AttackOutcomes {
+    AttackOutcomes::single(AttackOutcome::damage_then_effect(
+        vec![(damage, true, 0)],
+        move |_, state, action| {
+            let budget = total_attached_energy(state, action.actor);
+            let choices = energy_blender_choices(state, action.actor, budget);
+            if !choices.is_empty() {
+                state.move_generation_stack.push((action.actor, choices));
+            }
+        },
+    ))
 }
 
 /// Kingambit - Overlord's Blade: `damage_per` more damage for each of the attacker's own Pokémon

--- a/src/actions/apply_trainer_action.rs
+++ b/src/actions/apply_trainer_action.rs
@@ -517,7 +517,7 @@ fn team_effect(rng: &mut StdRng, state: &mut State, action: &Action) {
     let mut eligible_energy: Vec<(usize, EnergyType)> = Vec::new();
 
     for (in_play_idx, pokemon) in state.enumerate_in_play_pokemon(opponent) {
-        if pokemon.card.get_ability().is_some() {
+        if pokemon.ability().is_some() {
             for energy in pokemon.attached_energy.iter().copied() {
                 eligible_energy.push((in_play_idx, energy));
             }

--- a/src/actions/attack_helpers.rs
+++ b/src/actions/attack_helpers.rs
@@ -17,6 +17,64 @@ pub(crate) fn collect_in_play_indices_by_type(
         .collect()
 }
 
+/// Delcatty's Energy Blender: the choices offered at one step of "move any amount of Energy from
+/// your Pokémon in play to your other Pokémon in any way you like" — every single-Energy move
+/// between two distinct Pokémon of `player`, plus `Noop` to stop.
+///
+/// Returns an empty list (i.e. nothing to offer) once no move is possible or the move budget is
+/// spent, so callers can skip pushing a pointless prompt.
+pub(crate) fn energy_blender_choices(
+    state: &State,
+    player: usize,
+    remaining_moves: usize,
+) -> Vec<SimpleAction> {
+    if remaining_moves == 0 {
+        return Vec::new();
+    }
+
+    let occupied: Vec<usize> = state
+        .enumerate_in_play_pokemon(player)
+        .map(|(idx, _)| idx)
+        .collect();
+
+    let mut choices = Vec::new();
+    for (from_in_play_idx, pokemon) in state.enumerate_in_play_pokemon(player) {
+        let mut types_seen: Vec<EnergyType> = Vec::new();
+        for energy_type in &pokemon.attached_energy {
+            if types_seen.contains(energy_type) {
+                continue;
+            }
+            types_seen.push(*energy_type);
+            for &to_in_play_idx in &occupied {
+                if to_in_play_idx == from_in_play_idx {
+                    continue;
+                }
+                choices.push(SimpleAction::MoveEnergyAndReoffer {
+                    from_in_play_idx,
+                    to_in_play_idx,
+                    energy_type: *energy_type,
+                    remaining_moves: remaining_moves - 1,
+                });
+            }
+        }
+    }
+
+    if choices.is_empty() {
+        return choices;
+    }
+    choices.push(SimpleAction::Noop);
+    choices
+}
+
+/// The total Energy attached across all of `player`'s Pokémon in play. Used as the move budget for
+/// `energy_blender_choices`: no Energy ever has to move more than once to reach a given board.
+pub(crate) fn total_attached_energy(state: &State, player: usize) -> usize {
+    state
+        .enumerate_in_play_pokemon(player)
+        .map(|(_, pokemon)| pokemon.attached_energy.len())
+        .sum()
+}
+
 pub(crate) fn energy_any_way_choices(
     target_indices: &[usize],
     energy_type: EnergyType,

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -812,4 +812,25 @@ pub enum Mechanic {
         energy_type: EnergyType,
         damage_per: u32,
     },
+    /// Kingambit's Overlord's Blade: `damage_per` more damage for each time one of the attacker's
+    /// own Pokémon has been Knocked Out during this game.
+    ExtraDamagePerOwnKnockoutThisGame {
+        damage_per: u32,
+    },
+    /// Hisuian Basculegion's Soul Counter: `damage_per` more damage for each point the opponent
+    /// scored during their own previous turn.
+    ExtraDamagePerOpponentPointLastTurn {
+        damage_per: u32,
+    },
+    /// Toxicroak's Toxic / Toxapex's Severe Poison: Poison the opponent's Active Pokémon, but its
+    /// Checkup damage is `poison_damage` instead of the usual 10.
+    InflictPoisonWithDamage {
+        poison_damage: u32,
+    },
+    /// Mesprit's Supreme Blast: usable only while every Pokémon named in `required_bench_names` is
+    /// on the attacker's Bench; on use, all Energy is discarded from the attacking Pokémon. The
+    /// usability half is enforced in `move_generation::attacks`, which consults this variant.
+    RequireBenchedNamesThenDiscardAllEnergy {
+        required_bench_names: Vec<String>,
+    },
 }

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -827,6 +827,10 @@ pub enum Mechanic {
     InflictPoisonWithDamage {
         poison_damage: u32,
     },
+    /// Delcatty's Energy Blender: after damage, the attacker may freely redistribute the Energy
+    /// attached to their own Pokémon in play. Resolved one Energy at a time through
+    /// `SimpleAction::MoveEnergyAndReoffer`; see that variant for why.
+    MoveOwnEnergyAnyWay,
     /// Mesprit's Supreme Blast: usable only while every Pokémon named in `required_bench_names` is
     /// on the attacker's Bench; on use, all Energy is discarded from the attacking Pokémon. The
     /// usability half is enforced in `move_generation::attacks`, which consults this variant.

--- a/src/actions/attacks/mechanic.rs
+++ b/src/actions/attacks/mechanic.rs
@@ -724,4 +724,92 @@ pub enum Mechanic {
     DamagePerOwnToolAttached {
         damage_per: u32,
     },
+
+    /// Tapu Koko's Volt Switch: like `SwitchSelfWithBench`, but the Bench choice is restricted to
+    /// your Pokémon of `energy_type`.
+    SwitchSelfWithBenchOfType {
+        energy_type: EnergyType,
+    },
+    /// Uxie's Mind Boost: take an Energy of `energy_type` from your Energy Zone and attach it to
+    /// one of your in-play Pokémon whose name is in `names` (e.g. Mesprit or Azelf).
+    AttachEnergyFromZoneToNamed {
+        energy_type: EnergyType,
+        names: Vec<String>,
+    },
+    /// Sableye's Jeweled Gift: take one uniformly random basic Energy (of the 8 selectable types)
+    /// from your Energy Zone and attach it to 1 of your Benched Pokémon.
+    AttachRandomBasicEnergyToBenched,
+    /// Forretress's Enormous Explosion: on top of the attack's damage to the Defending Pokémon,
+    /// deal `self_damage` to the attacking Pokémon and `bench_damage` to EVERY Benched Pokémon on
+    /// both sides.
+    SelfDamageAndAllBenchDamage {
+        self_damage: u32,
+        bench_damage: u32,
+    },
+    /// Mimikyu's Shadow Hit: this attack also does `damage` to 1 of YOUR OWN Pokémon — the
+    /// attacking Pokémon itself included (unlike `AlsoChoiceBenchDamage`, which is Bench-only).
+    AlsoChoiceOwnPokemonDamage {
+        damage: u32,
+    },
+    /// Archeops's Wild Spin: deal `damage` to each of the opponent's Pokémon, plus `increment` for
+    /// each `IncreasedDamageForAttack` effect this attack left on itself during a previous turn.
+    /// The spread damage cannot use the ordinary Active-to-Active `IncreasedDamageForAttack` hook,
+    /// so the bonus is read off the attacker here instead.
+    DamageAllOpponentPokemonEscalating {
+        attack_name: String,
+        damage: u32,
+        increment: u32,
+    },
+    /// Wishiwashi ex's School Storm: like `ExtraDamagePerPokemonWithNameOnBench`, but counts each
+    /// Benched Pokémon matching ANY of `pokemon_names` (e.g. "Wishiwashi" and "Wishiwashi ex").
+    ExtraDamagePerPokemonWithNamesOnBench {
+        pokemon_names: Vec<String>,
+        damage_per: u32,
+    },
+    /// Team Rocket's Magmar's Derisive Roasting: extra damage for each Special Condition currently
+    /// affecting the opponent's Active Pokémon.
+    ExtraDamagePerOpponentSpecialCondition {
+        damage_per: u32,
+    },
+    /// Teal Mask Ogerpon's Ogre's Whip: damage equal to the attacking Pokémon's remaining HP.
+    DamageEqualToSelfRemainingHp,
+    /// Swift: routes as ordinary Active damage. Both bypasses ("isn't affected by Weakness or by
+    /// any effects on your opponent's Active Pokémon") are applied from the attack's effect text in
+    /// `hooks::modify_damage`, exactly like `DamageUnaffectedByWeakness` and
+    /// `DamageUnaffectedByOpponentActiveEffects`.
+    DamageUnaffectedByWeaknessAndOpponentActiveEffects,
+    /// Eldegoss's Float Up / Dunsparce's Bop 'n' Burrow: after damage, the attacker MAY shuffle
+    /// itself and everything attached to it back into its owner's deck.
+    MayShuffleSelfIntoDeck,
+    /// Accelgor's Deck and Cover: inflict `conditions` on the opponent's Active Pokémon, then
+    /// shuffle the attacking Pokémon and everything attached to it into your deck (not optional).
+    InflictStatusConditionsAndShuffleSelfIntoDeck {
+        conditions: Vec<StatusCondition>,
+    },
+    /// Roserade's Poison Ring: inflict `conditions` on the opponent's Active Pokémon and leave
+    /// `effect` on it for `duration` turns (e.g. Poisoned plus "can't retreat next turn").
+    InflictStatusConditionsAndCardEffect {
+        conditions: Vec<StatusCondition>,
+        effect: CardEffect,
+        duration: u8,
+    },
+    /// Tsareena's Kick Down: a random card from the opponent's hand is shuffled into their deck.
+    /// The deterministic counterpart of `CoinFlipShuffleRandomOpponentHandCardIntoDeck`.
+    ShuffleRandomOpponentHandCardIntoDeck,
+    /// Liepard's Snatch and Flee: `ShuffleRandomOpponentHandCardIntoDeck`, and then the attacking
+    /// Pokémon is shuffled into its own owner's deck as well.
+    ShuffleRandomOpponentHandCardIntoDeckAndSelfIntoDeck,
+    /// Mew's Psy Report / Noctowl's Silent Wing: "Your opponent reveals their hand." `State` is
+    /// fully observable to both players in this engine, so revealing a hand changes nothing — the
+    /// attack reduces to its plain damage.
+    RevealOpponentHand,
+    /// Purugly's Interrupt: the opponent reveals their hand and the attacker chooses 1 card from it
+    /// to shuffle into the opponent's deck.
+    ChooseOpponentHandCardToShuffleIntoDeck,
+    /// Gyarados's Wild Swing: the attacker may discard any number of their own Benched Pokémon of
+    /// `energy_type`, dealing `damage_per` more damage for each Pokémon discarded this way.
+    OptionalDiscardBenchedTypeForExtraDamage {
+        energy_type: EnergyType,
+        damage_per: u32,
+    },
 }

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2860,5 +2860,10 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "This attack does 50 more damage for each point your opponent got during their last turn.",
         Mechanic::ExtraDamagePerOpponentPointLastTurn { damage_per: 50 },
     );
+    // Delcatty - Energy Blender
+    map.insert(
+        "You may move any amount of Energy from your Pokémon in play to your other Pokémon in any way you like.",
+        Mechanic::MoveOwnEnergyAnyWay,
+    );
     map
 });

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -2692,7 +2692,17 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per: 20,
         },
     );
-    // map.insert("The Defending Pokémon loses all Abilities. This effect lasts until the Defending Pokémon leaves the Active Spot.", todo_implementation);
+    // Budew - Prickly Powder. Leaving the Active Spot clears a Pokémon's effects, so a very long
+    // duration expresses "until the Defending Pokémon leaves the Active Spot".
+    map.insert(
+        "The Defending Pokémon loses all Abilities. This effect lasts until the Defending Pokémon leaves the Active Spot.",
+        Mechanic::DamageAndCardEffect {
+            opponent: true,
+            effect: CardEffect::AbilitiesDisabled,
+            duration: u8::MAX,
+            coin_flip: false,
+        },
+    );
     map.insert(
         "This attack does 30 damage for each of your Benched [D] Pokémon.",
         Mechanic::BenchCountDamage {

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1944,7 +1944,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             coin_flip: false,
         },
     );
-    // map.insert("You can use this attack only if you have Uxie and Azelf on your Bench. Discard all Energy from this Pokémon.", todo_implementation);
+    // Mesprit - Supreme Blast
+    map.insert(
+        "You can use this attack only if you have Uxie and Azelf on your Bench. Discard all Energy from this Pokémon.",
+        Mechanic::RequireBenchedNamesThenDiscardAllEnergy {
+            required_bench_names: vec!["Uxie".to_string(), "Azelf".to_string()],
+        },
+    );
     // Gyarados - Wild Swing
     map.insert(
         "You may discard any number of your Benched [W] Pokémon. This attack does 40 more damage for each Benched Pokémon you discarded in this way.",
@@ -2028,7 +2034,11 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "Discard a random Energy from among the Energy attached to all Pokémon (both yours and your opponent's).",
         Mechanic::DiscardRandomGlobalEnergy { count: 1 },
     );
-    // map.insert("Your opponent's Active Pokémon is now Poisoned. Do 20 damage to this Pokémon instead of the usual amount for this Special Condition.", todo_implementation);
+    // Toxicroak - Toxic
+    map.insert(
+        "Your opponent's Active Pokémon is now Poisoned. Do 20 damage to this Pokémon instead of the usual amount for this Special Condition.",
+        Mechanic::InflictPoisonWithDamage { poison_damage: 20 },
+    );
     map.insert(
         "If this Pokémon has at least 2 extra [W] Energy attached, this attack also does 50 damage to 1 of your opponent's Benched Pokémon.",
         Mechanic::ConditionalBenchDamage {
@@ -2834,6 +2844,21 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::InflictStatusConditionsAndShuffleSelfIntoDeck {
             conditions: vec![StatusCondition::Poisoned, StatusCondition::Paralyzed],
         },
+    );
+    // Toxapex - Severe Poison
+    map.insert(
+        "Your opponent's Active Pokémon is now Poisoned. Do 40 damage to this Pokémon instead of the usual amount for this Special Condition.",
+        Mechanic::InflictPoisonWithDamage { poison_damage: 40 },
+    );
+    // Kingambit - Overlord's Blade
+    map.insert(
+        "This attack does 40 more damage for each time your Pokémon have been Knocked Out during this game.",
+        Mechanic::ExtraDamagePerOwnKnockoutThisGame { damage_per: 40 },
+    );
+    // Hisuian Basculegion - Soul Counter
+    map.insert(
+        "This attack does 50 more damage for each point your opponent got during their last turn.",
+        Mechanic::ExtraDamagePerOpponentPointLastTurn { damage_per: 50 },
     );
     map
 });

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1717,7 +1717,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per_energy: 20,
         },
     );
-    // map.insert("This attack does 20 more damage for each [G] Energy attached to this Pokémon.", todo_implementation);
+    // Leafeon - Leaf Blast
+    map.insert(
+        "This attack does 20 more damage for each [G] Energy attached to this Pokémon.",
+        Mechanic::ExtraDamagePerSpecificEnergy {
+            energy_type: EnergyType::Grass,
+            damage_per_energy: 20,
+        },
+    );
     map.insert(
         "This attack does 20 more damage for each [P] Energy attached to all of your Pokémon.",
         Mechanic::ExtraDamagePerSpecificEnergyAllYours {
@@ -1825,7 +1832,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             bench_only: false,
         },
     );
-    // map.insert("This attack does 40 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost.", todo_implementation);
+    // Tangrowth - Grass Knot
+    map.insert(
+        "This attack does 40 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost.",
+        Mechanic::ExtraDamagePerRetreatCost {
+            damage_per_energy: 40,
+        },
+    );
     // map.insert("This attack does 40 more damage for each of your Benched Wishiwashi and Wishiwashi ex.", todo_implementation);
     map.insert(
         "This attack does 40 more damage for each of your opponent's Pokémon in play that has an Ability.",
@@ -1886,7 +1899,19 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "This attack's damage isn't affected by any effects on your opponent's Active Pokémon.",
         Mechanic::DamageUnaffectedByOpponentActiveEffects,
     );
-    // map.insert("Until this Pokémon leaves the Active Spot, this Pokémon's Rolling Frenzy attack does +30 damage. This effect stacks.", todo_implementation);
+    // Miltank - Rolling Frenzy
+    map.insert(
+        "Until this Pokémon leaves the Active Spot, this Pokémon's Rolling Frenzy attack does +30 damage. This effect stacks.",
+        Mechanic::DamageAndCardEffect {
+            opponent: false,
+            effect: CardEffect::IncreasedDamageForAttack {
+                attack_name: "Rolling Frenzy".to_string(),
+                amount: 30,
+            },
+            duration: u8::MAX,
+            coin_flip: false,
+        },
+    );
     // map.insert("You can use this attack only if you have Uxie and Azelf on your Bench. Discard all Energy from this Pokémon.", todo_implementation);
     // map.insert("You may discard any number of your Benched [W] Pokémon. This attack does 40 more damage for each Benched Pokémon you discarded in this way.", todo_implementation);
     // map.insert("You may switch this Pokémon with 1 of your Benched Pokémon.", todo_implementation);
@@ -1925,7 +1950,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             target_opponent: true,
         },
     );
-    // map.insert("Your opponent's Active Pokémon is now Poisoned and Burned.", todo_implementation);
+    // Salazzle - Heated Poison / Team Rocket's Houndoom - Toxfire Fang
+    map.insert(
+        "Your opponent's Active Pokémon is now Poisoned and Burned.",
+        Mechanic::InflictStatusConditions {
+            conditions: vec![StatusCondition::Poisoned, StatusCondition::Burned],
+            target_opponent: true,
+        },
+    );
     map.insert(
         "Your opponent's Active Pokémon is now Poisoned and Asleep.",
         Mechanic::InflictStatusConditions {
@@ -2182,7 +2214,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per_card: 20,
         },
     );
-    // map.insert("This attack does 70 damage to 1 of your opponent's Benched Pokémon.", todo_implementation);
+    // Indeedee - Zen Shard
+    map.insert(
+        "This attack does 70 damage to 1 of your opponent's Benched Pokémon.",
+        Mechanic::DirectDamage {
+            damage: 70,
+            bench_only: true,
+        },
+    );
     map.insert(
         "This attack is used twice in a row. The second attack does 40 damage.(If the first attack Knocks Out your opponent's Active Pokémon, the second attack is used after your opponent chooses a new Active Pokémon.)",
         Mechanic::MegaKangaskhanExDoublePunchingFamily,
@@ -2268,7 +2307,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             target_benched_type: None,
         },
     );
-    // map.insert("This attack also does 50 damage to 1 of your opponent's Benched Pokémon.", todo_implementation);
+    // Palafin - Jet Punch
+    map.insert(
+        "This attack also does 50 damage to 1 of your opponent's Benched Pokémon.",
+        Mechanic::AlsoChoiceBenchDamage {
+            opponent: true,
+            damage: 50,
+        },
+    );
     map.insert(
         "This attack does 20 more damage for each Pokémon in your discard pile.",
         Mechanic::ExtraDamagePerPokemonInDiscard {
@@ -2567,7 +2613,11 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             bench_side: BenchSide::YourBench,
         },
     );
-    // map.insert("This attack does 60 damage to 1 of your opponent's Pokémon that have damage on them.", todo_implementation);
+    // Mandibuzz - Blindside
+    map.insert(
+        "This attack does 60 damage to 1 of your opponent's Pokémon that have damage on them.",
+        Mechanic::DirectDamageIfDamaged { damage: 60 },
+    );
 
     // B3a Mechanics
     map.insert(
@@ -2645,6 +2695,43 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         Mechanic::ExtraDamagePerSpecificEnergy {
             energy_type: EnergyType::Metal,
             damage_per_energy: 10,
+        },
+    );
+    // ---------------------------------------------------------------------------------------
+    // Coverage batch: attacks-d
+    // ---------------------------------------------------------------------------------------
+    // Galarian Obstagoon - Bass Control
+    map.insert(
+        "This attack does 80 damage to 1 of your opponent's Pokémon.",
+        Mechanic::DirectDamage {
+            damage: 80,
+            bench_only: false,
+        },
+    );
+    // Mewtwo - Psychic
+    map.insert(
+        "This attack does 40 more damage for each Energy attached to your opponent's Active Pokémon.",
+        Mechanic::ExtraDamagePerEnergy {
+            include_fixed_damage: true,
+            opponent: true,
+            damage_per_energy: 40,
+        },
+    );
+    // Team Rocket's Arbok - Shadow Seeker
+    map.insert(
+        "This attack does 10 more damage for each Energy in your opponent's Active Pokémon's Retreat Cost.",
+        Mechanic::ExtraDamagePerRetreatCost {
+            damage_per_energy: 10,
+        },
+    );
+    // Team Rocket's Persian - Dangerous Rogue
+    map.insert(
+        "This attack does 40 more damage for each of your opponent's Benched Pokémon.",
+        Mechanic::BenchCountDamage {
+            include_fixed_damage: true,
+            damage_per: 40,
+            energy_type: None,
+            bench_side: BenchSide::OpponentBench,
         },
     );
     map

--- a/src/actions/effect_mechanic_map.rs
+++ b/src/actions/effect_mechanic_map.rs
@@ -1340,7 +1340,13 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "You may switch this Pokémon with 1 of your Benched Pokémon.",
         Mechanic::MaySwitchSelfWithBench,
     );
-    // map.insert("Switch this Pokémon with 1 of your Benched [L] Pokémon.", todo_implementation);
+    // Tapu Koko - Volt Switch
+    map.insert(
+        "Switch this Pokémon with 1 of your Benched [L] Pokémon.",
+        Mechanic::SwitchSelfWithBenchOfType {
+            energy_type: EnergyType::Lightning,
+        },
+    );
     map.insert(
         "Take 2 [M] Energy from your Energy Zone and attach it to 1 of your Benched Pokémon.",
         Mechanic::ChargeBench {
@@ -1412,7 +1418,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             energies: vec![EnergyType::Metal],
         },
     );
-    // map.insert("Take a [P] Energy from your Energy Zone and attach it to Mesprit or Azelf.", todo_implementation);
+    // Uxie - Mind Boost
+    map.insert(
+        "Take a [P] Energy from your Energy Zone and attach it to Mesprit or Azelf.",
+        Mechanic::AttachEnergyFromZoneToNamed {
+            energy_type: EnergyType::Psychic,
+            names: vec!["Mesprit".to_string(), "Azelf".to_string()],
+        },
+    );
     map.insert(
         "Take a [P] Energy from your Energy Zone and attach it to this Pokémon.",
         Mechanic::SelfChargeActive {
@@ -1539,7 +1552,11 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage: 20,
         },
     );
-    // map.insert("This attack also does 20 damage to 1 of your Pokémon.", todo_implementation);
+    // Mimikyu - Shadow Hit
+    map.insert(
+        "This attack also does 20 damage to 1 of your Pokémon.",
+        Mechanic::AlsoChoiceOwnPokemonDamage { damage: 20 },
+    );
     map.insert(
         "This attack also does 20 damage to 1 of your opponent's Benched Pokémon.",
         Mechanic::AlsoChoiceBenchDamage {
@@ -1673,7 +1690,15 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     // map.insert("This attack does 20 damage to each of your opponent's Pokémon.", todo_implementation);
-    // map.insert("This attack does 20 damage to each of your opponent's Pokémon. During your next turn, this Pokémon's Wild Spin attack does +20 damage to each of your opponent's Pokémon.", todo_implementation);
+    // Archeops - Wild Spin
+    map.insert(
+        "This attack does 20 damage to each of your opponent's Pokémon. During your next turn, this Pokémon's Wild Spin attack does +20 damage to each of your opponent's Pokémon.",
+        Mechanic::DamageAllOpponentPokemonEscalating {
+            attack_name: "Wild Spin".to_string(),
+            damage: 20,
+            increment: 20,
+        },
+    );
     map.insert(
         "This attack does 20 more damage for each type of Energy attached to this Pokémon.",
         Mechanic::ExtraDamagePerEnergyType {
@@ -1839,7 +1864,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per_energy: 40,
         },
     );
-    // map.insert("This attack does 40 more damage for each of your Benched Wishiwashi and Wishiwashi ex.", todo_implementation);
+    // Wishiwashi ex - School Storm
+    map.insert(
+        "This attack does 40 more damage for each of your Benched Wishiwashi and Wishiwashi ex.",
+        Mechanic::ExtraDamagePerPokemonWithNamesOnBench {
+            pokemon_names: vec!["Wishiwashi".to_string(), "Wishiwashi ex".to_string()],
+            damage_per: 40,
+        },
+    );
     map.insert(
         "This attack does 40 more damage for each of your opponent's Pokémon in play that has an Ability.",
         Mechanic::ExtraDamagePerOpponentPokemonWithAbility { damage_per: 40 },
@@ -1913,7 +1945,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         },
     );
     // map.insert("You can use this attack only if you have Uxie and Azelf on your Bench. Discard all Energy from this Pokémon.", todo_implementation);
-    // map.insert("You may discard any number of your Benched [W] Pokémon. This attack does 40 more damage for each Benched Pokémon you discarded in this way.", todo_implementation);
+    // Gyarados - Wild Swing
+    map.insert(
+        "You may discard any number of your Benched [W] Pokémon. This attack does 40 more damage for each Benched Pokémon you discarded in this way.",
+        Mechanic::OptionalDiscardBenchedTypeForExtraDamage {
+            energy_type: EnergyType::Water,
+            damage_per: 40,
+        },
+    );
     // map.insert("You may switch this Pokémon with 1 of your Benched Pokémon.", todo_implementation);
     map.insert(
         "Your opponent can't use any Supporter cards from their hand during their next turn.",
@@ -1922,13 +1961,26 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             duration: 1,
         },
     );
-    // map.insert("Your opponent reveals a random card from their hand and shuffles it into their deck.", todo_implementation);
-    // map.insert("Your opponent reveals their hand.", todo_implementation);
+    // Tsareena - Kick Down
+    map.insert(
+        "Your opponent reveals a random card from their hand and shuffles it into their deck.",
+        Mechanic::ShuffleRandomOpponentHandCardIntoDeck,
+    );
+    // Mew - Psy Report / Noctowl - Silent Wing. `State` is fully observable in this engine, so
+    // revealing a hand has no mechanical effect: the attack is just its damage.
+    map.insert(
+        "Your opponent reveals their hand.",
+        Mechanic::RevealOpponentHand,
+    );
     map.insert(
         "Your opponent reveals their hand. Choose a Supporter card you find there and discard it.",
         Mechanic::DarknessClaw,
     );
-    // map.insert("Your opponent reveals their hand. Choose a card you find there and shuffle it into your opponent's deck.", todo_implementation);
+    // Purugly - Interrupt
+    map.insert(
+        "Your opponent reveals their hand. Choose a card you find there and shuffle it into your opponent's deck.",
+        Mechanic::ChooseOpponentHandCardToShuffleIntoDeck,
+    );
     map.insert(
         "Your opponent's Active Pokémon is now Asleep.",
         Mechanic::InflictStatusConditions {
@@ -2226,7 +2278,11 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
         "This attack is used twice in a row. The second attack does 40 damage.(If the first attack Knocks Out your opponent's Active Pokémon, the second attack is used after your opponent chooses a new Active Pokémon.)",
         Mechanic::MegaKangaskhanExDoublePunchingFamily,
     );
-    // map.insert("This attack's damage isn't affected by Weakness or by any effects on your opponent's Active Pokémon.", todo_implementation);
+    // Ledian / Staryu / Starmie - Swift
+    map.insert(
+        "This attack's damage isn't affected by Weakness or by any effects on your opponent's Active Pokémon.",
+        Mechanic::DamageUnaffectedByWeaknessAndOpponentActiveEffects,
+    );
     map.insert(
         "Until this Pokémon leaves the Active Spot, this Pokémon's Heat-Up Crunch attack does +30 damage. This effect stacks.",
         Mechanic::DamageAndCardEffect {
@@ -2239,9 +2295,25 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             coin_flip: false,
         },
     );
-    // map.insert("You may shuffle this Pokémon and all attached cards into your deck.", todo_implementation);
-    // map.insert("Your opponent reveals a random card from their hand and shuffles it into their deck. Shuffle this Pokémon into your deck.", todo_implementation);
-    // map.insert("Your opponent's Active Pokémon is now Poisoned. During your opponent's next turn, that Pokémon can't retreat.", todo_implementation);
+    // Eldegoss - Float Up / Dunsparce - Bop 'n' Burrow
+    map.insert(
+        "You may shuffle this Pokémon and all attached cards into your deck.",
+        Mechanic::MayShuffleSelfIntoDeck,
+    );
+    // Liepard - Snatch and Flee
+    map.insert(
+        "Your opponent reveals a random card from their hand and shuffles it into their deck. Shuffle this Pokémon into your deck.",
+        Mechanic::ShuffleRandomOpponentHandCardIntoDeckAndSelfIntoDeck,
+    );
+    // Roserade - Poison Ring
+    map.insert(
+        "Your opponent's Active Pokémon is now Poisoned. During your opponent's next turn, that Pokémon can't retreat.",
+        Mechanic::InflictStatusConditionsAndCardEffect {
+            conditions: vec![StatusCondition::Poisoned],
+            effect: CardEffect::NoRetreat,
+            duration: 1,
+        },
+    );
 
     // New Mechanics from B2a
     map.insert(
@@ -2398,7 +2470,14 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             energies: vec![EnergyType::Water, EnergyType::Lightning],
         },
     );
-    // map.insert("This Pokémon also does 100 damage to itself and 50 damage to all Benched Pokémon (both yours and your opponent's).", todo_implementation);
+    // Forretress - Enormous Explosion
+    map.insert(
+        "This Pokémon also does 100 damage to itself and 50 damage to all Benched Pokémon (both yours and your opponent's).",
+        Mechanic::SelfDamageAndAllBenchDamage {
+            self_damage: 100,
+            bench_damage: 50,
+        },
+    );
     map.insert(
         "This attack does 20 more damage for each Benched Pokémon (both yours and your opponent's).",
         Mechanic::BenchCountDamage {
@@ -2732,6 +2811,28 @@ pub static EFFECT_MECHANIC_MAP: LazyLock<HashMap<&'static str, Mechanic>> = Lazy
             damage_per: 40,
             energy_type: None,
             bench_side: BenchSide::OpponentBench,
+        },
+    );
+    // Sableye - Jeweled Gift
+    map.insert(
+        "Take a random Energy from among [G], [R], [W], [L], [P], [F], [D], and [M] Energy from your Energy Zone and attach it to 1 of your Benched Pokémon.",
+        Mechanic::AttachRandomBasicEnergyToBenched,
+    );
+    // Team Rocket's Magmar - Derisive Roasting
+    map.insert(
+        "This attack does 50 more damage for each Special Condition affecting your opponent's Active Pokémon.",
+        Mechanic::ExtraDamagePerOpponentSpecialCondition { damage_per: 50 },
+    );
+    // Teal Mask Ogerpon - Ogre's Whip
+    map.insert(
+        "This attack does damage to your opponent's Active Pokémon equal to this Pokémon's remaining HP.",
+        Mechanic::DamageEqualToSelfRemainingHp,
+    );
+    // Accelgor - Deck and Cover
+    map.insert(
+        "Your opponent's Active Pokémon is now Poisoned and Paralyzed. Shuffle this Pokémon and all attached cards into your deck.",
+        Mechanic::InflictStatusConditionsAndShuffleSelfIntoDeck {
+            conditions: vec![StatusCondition::Poisoned, StatusCondition::Paralyzed],
         },
     );
     map

--- a/src/actions/mod.rs
+++ b/src/actions/mod.rs
@@ -25,6 +25,7 @@ pub(crate) use apply_action::resolve_pending_coin_reflip;
 pub(crate) use apply_action_helpers::handle_damage_only;
 pub(crate) use apply_action_helpers::handle_knockouts;
 pub use apply_trainer_action::may_effect;
+pub(crate) use attacks::Mechanic;
 pub use effect_ability_mechanic_map::ability_mechanic_from_effect;
 pub(crate) use effect_ability_mechanic_map::card_effect_from_ability_mechanic;
 pub(crate) use effect_ability_mechanic_map::get_ability_mechanic;

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -150,6 +150,20 @@ pub enum SimpleAction {
         in_play_idx: usize,
         damage: u32,
     },
+    /// Gyarados's Wild Swing: discard any number (possibly zero) of your own Benched Pokémon, then
+    /// deal the attack's resulting boosted damage to the opponent's Active Pokémon. Like
+    /// `DiscardOwnBenchedThenDamage` this is one action so the boosted damage is applied once.
+    DiscardOwnBenchedGroupThenDamage {
+        in_play_indices: Vec<usize>,
+        damage: u32,
+    },
+    /// Eldegoss's Float Up / Accelgor's Deck and Cover: shuffle one of your own Pokémon in play,
+    /// and everything attached to it (evolution cards, Tool), back into your deck. Attached Energy
+    /// goes to the discarded-Energy pile. Distinct from `ShuffleInPlayPokemonIntoDeck`, which
+    /// leaves the Tool and Energy behind.
+    ShuffleSelfAndAttachmentsIntoDeck {
+        in_play_idx: usize,
+    },
     /// Use an activated stadium effect (once per turn per player)
     UseStadium,
     /// Return a Pokemon in play to your hand (e.g., Ilima).
@@ -346,6 +360,18 @@ impl fmt::Display for SimpleAction {
                 damage,
             } => {
                 write!(f, "DiscardOwnBenchedThenDamage({in_play_idx}, {damage})")
+            }
+            SimpleAction::DiscardOwnBenchedGroupThenDamage {
+                in_play_indices,
+                damage,
+            } => {
+                write!(
+                    f,
+                    "DiscardOwnBenchedGroupThenDamage({in_play_indices:?}, {damage})"
+                )
+            }
+            SimpleAction::ShuffleSelfAndAttachmentsIntoDeck { in_play_idx } => {
+                write!(f, "ShuffleSelfAndAttachmentsIntoDeck({in_play_idx})")
             }
             SimpleAction::ReturnPokemonToHand { in_play_idx } => {
                 write!(f, "ReturnPokemonToHand({in_play_idx})")

--- a/src/actions/types.rs
+++ b/src/actions/types.rs
@@ -157,6 +157,22 @@ pub enum SimpleAction {
         in_play_indices: Vec<usize>,
         damage: u32,
     },
+    /// Delcatty's Energy Blender: move a single Energy between two of your own Pokémon, then offer
+    /// the same choice again (with `remaining_moves` one lower) plus the option to stop.
+    ///
+    /// "You may move any amount of Energy from your Pokémon in play to your other Pokémon in any
+    /// way you like" is played out one Energy at a time rather than enumerated as whole
+    /// redistributions: the number of redistributions is exponential in the Energy on the board
+    /// (thousands of actions in an ordinary mid-game position), while one-at-a-time keeps the
+    /// branching factor to a few dozen and reaches exactly the same set of final boards.
+    /// `remaining_moves` starts at the player's total attached Energy — enough for any
+    /// redistribution, since no Energy ever needs to move twice — and guarantees termination.
+    MoveEnergyAndReoffer {
+        from_in_play_idx: usize,
+        to_in_play_idx: usize,
+        energy_type: EnergyType,
+        remaining_moves: usize,
+    },
     /// Eldegoss's Float Up / Accelgor's Deck and Cover: shuffle one of your own Pokémon in play,
     /// and everything attached to it (evolution cards, Tool), back into your deck. Attached Energy
     /// goes to the discarded-Energy pile. Distinct from `ShuffleInPlayPokemonIntoDeck`, which
@@ -372,6 +388,17 @@ impl fmt::Display for SimpleAction {
             }
             SimpleAction::ShuffleSelfAndAttachmentsIntoDeck { in_play_idx } => {
                 write!(f, "ShuffleSelfAndAttachmentsIntoDeck({in_play_idx})")
+            }
+            SimpleAction::MoveEnergyAndReoffer {
+                from_in_play_idx,
+                to_in_play_idx,
+                energy_type,
+                remaining_moves,
+            } => {
+                write!(
+                    f,
+                    "MoveEnergyAndReoffer({from_in_play_idx} -> {to_in_play_idx}, {energy_type:?}, {remaining_moves} left)"
+                )
             }
             SimpleAction::ReturnPokemonToHand { in_play_idx } => {
                 write!(f, "ReturnPokemonToHand({in_play_idx})")

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -25,6 +25,16 @@ pub enum CardEffect {
         attack_name: String,
         amount: u32,
     },
+    /// Like `IncreasedDamageForAttack`, but for a *spread* attack, whose bonus has to reach every
+    /// target rather than only the Active-to-Active damage that `hooks::modify_damage` sees (e.g.
+    /// Archeops's Wild Spin: "+20 damage to each of your opponent's Pokémon"). The attack's own
+    /// mechanic reads this off the attacker and folds it into every target's damage, so
+    /// `modify_damage` deliberately ignores it — using `IncreasedDamageForAttack` here would
+    /// double-count the bonus on the Active.
+    IncreasedSpreadDamageForAttack {
+        attack_name: String,
+        amount: u32,
+    },
     PreventAllDamageAndEffects,
     /// Prevent all damage from attacks if the incoming damage is at most `threshold` (e.g. Cascoon's Harden).
     PreventDamageIfLessOrEqual {

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -43,6 +43,13 @@ pub enum CardEffect {
     /// Prevent all damage done by attacks from Basic Pokémon (e.g. Carracosta's Blocking Shell).
     PreventDamageFromBasic,
     NoWeakness,
+    /// Budew's Prickly Powder: "The Defending Pokémon loses all Abilities." While this effect is on
+    /// a Pokémon, `PlayedCard::ability` / `PlayedCard::ability_mechanic` report it as having none,
+    /// which is what every ability lookup in the engine goes through — so the Pokémon stops
+    /// offering activated abilities, stops contributing passive ones, and stops deriving
+    /// ability-based `CardEffect`s. Applied with a very long duration; the wording is "until the
+    /// Defending Pokémon leaves the Active Spot", and leaving the Active Spot clears effects.
+    AbilitiesDisabled,
     CoinFlipToBlockAttack,
     DelayedDamage {
         amount: u32,

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -287,7 +287,7 @@ pub(crate) fn on_bench_from_hand(actor: usize, state: &mut State, card: &Card, b
 pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
     // Check if active Pokémon has an end-of-turn ability
     let active = state.get_active(player_ending_turn);
-    if let Some(mechanic) = get_ability_mechanic(&active.card) {
+    if let Some(mechanic) = active.ability_mechanic() {
         if matches!(
             mechanic,
             AbilityMechanic::EndTurnDrawCardIfActive { amount: 1 }
@@ -399,7 +399,7 @@ pub(crate) fn on_end_turn(player_ending_turn: usize, state: &mut State) {
             .enumerate_in_play_pokemon(player_ending_turn)
             .filter_map(|(in_play_idx, pokemon)| {
                 if matches!(
-                    get_ability_mechanic(&pokemon.card),
+                    pokemon.ability_mechanic(),
                     Some(AbilityMechanic::EndFirstTurnAttachEnergyToSelf {
                         energy_type: EnergyType::Lightning
                     })
@@ -522,7 +522,7 @@ fn apply_bad_dreams_damage(state: &mut State) {
                     if pokemon.is_knocked_out() {
                         return None;
                     }
-                    get_ability_mechanic(&pokemon.card).and_then(|m| match m {
+                    pokemon.ability_mechanic().and_then(|m| match m {
                         AbilityMechanic::BadDreamsEndOfTurn { amount } => {
                             Some((player, idx, *amount))
                         }
@@ -571,7 +571,7 @@ pub(crate) fn can_play_support(state: &State) -> bool {
             .as_ref()
             .is_some_and(|opponent_active| {
                 matches!(
-                    get_ability_mechanic(&opponent_active.card),
+                    opponent_active.ability_mechanic(),
                     Some(AbilityMechanic::NoOpponentSupportInActive)
                 )
             });
@@ -704,7 +704,7 @@ fn get_ability_damage_reduction(
 
     // Magnezone's Resilience Link depends on the rest of the board, so it can't be derived as a
     // CardEffect from the card alone.
-    let arceus_reduction = match get_ability_mechanic(&receiving_pokemon.card) {
+    let arceus_reduction = match receiving_pokemon.ability_mechanic() {
         Some(AbilityMechanic::ReduceDamageFromAttacksIfArceusInPlay { amount })
             if has_arceus_in_play(state, target_player) =>
         {
@@ -716,7 +716,7 @@ fn get_ability_damage_reduction(
 
     // Mamoswine's Thick Fat depends on the attacker's type, so it can't be derived as a
     // CardEffect from the card alone.
-    let attacker_type_reduction = match get_ability_mechanic(&receiving_pokemon.card) {
+    let attacker_type_reduction = match receiving_pokemon.ability_mechanic() {
         Some(AbilityMechanic::ReduceDamageFromAttacksByAttackerType {
             amount,
             attacker_types,
@@ -751,7 +751,7 @@ fn get_ability_damage_increase(
         return 0;
     }
 
-    let Some(ability) = attacking_pokemon.card.get_ability() else {
+    let Some(ability) = attacking_pokemon.ability() else {
         return 0;
     };
 
@@ -1356,7 +1356,7 @@ fn calculate_type_boost_bonus(
 
     // Check each Pokemon in play for type-boosting abilities
     for (_, pokemon) in state.enumerate_in_play_pokemon(attacking_player) {
-        if let Some(mechanic) = get_ability_mechanic(&pokemon.card) {
+        if let Some(mechanic) = pokemon.ability_mechanic() {
             match mechanic {
                 AbilityMechanic::IncreaseDamageForTypeInPlay {
                     energy_type,
@@ -1395,7 +1395,7 @@ pub(crate) fn get_attack_cost(
     let opponent = (attacking_player + 1) % 2;
     if let Some(opponent_active) = &state.in_play_pokemon[opponent][0] {
         if matches!(
-            get_ability_mechanic(&opponent_active.card),
+            opponent_active.ability_mechanic(),
             Some(AbilityMechanic::IncreaseAttackCostForOpponentActive { amount: 1 })
         ) {
             modified_cost.push(EnergyType::Colorless);
@@ -1459,7 +1459,7 @@ fn vigor_link_cost(mut cost: Vec<EnergyType>, state: &State, player: usize) -> V
     let Some(active) = state.in_play_pokemon[player][0].as_ref() else {
         return cost;
     };
-    let reduction = match get_ability_mechanic(&active.card) {
+    let reduction = match active.ability_mechanic() {
         Some(AbilityMechanic::ReduceAttackCostIfArceusInPlay { amount })
             if has_arceus_in_play(state, player) =>
         {
@@ -1480,12 +1480,10 @@ fn future_system_cost(mut cost: Vec<EnergyType>, state: &State, player: usize) -
         .as_ref()
         .is_some_and(|active| is_future_pokemon(&active.get_name()));
     let has_future_system = attacker_is_future
-        && state.in_play_pokemon[player].iter().flatten().any(|p| {
-            matches!(
-                get_ability_mechanic(&p.card),
-                Some(AbilityMechanic::FutureSystem)
-            )
-        });
+        && state.in_play_pokemon[player]
+            .iter()
+            .flatten()
+            .any(|p| matches!(p.ability_mechanic(), Some(AbilityMechanic::FutureSystem)));
     if has_future_system {
         if let Some(pos) = cost.iter().position(|e| *e == EnergyType::Colorless) {
             debug!("Future System: Reducing attack cost by 1 Colorless");
@@ -1682,7 +1680,7 @@ fn apply_offload_pass(
 
     let offload_energy = state.in_play_pokemon[knocked_out_player][knocked_out_idx]
         .as_ref()
-        .and_then(|pokemon| match get_ability_mechanic(&pokemon.card) {
+        .and_then(|pokemon| match pokemon.ability_mechanic() {
             Some(AbilityMechanic::MoveAllTypedEnergyToBenchOnKnockout { energy_type }) => {
                 Some(*energy_type)
             }
@@ -1746,7 +1744,7 @@ pub(crate) fn on_attack_knockout(
         return;
     };
     if matches!(
-        get_ability_mechanic(&attacking_pokemon.card),
+        attacking_pokemon.ability_mechanic(),
         Some(AbilityMechanic::ProtectSelfNextTurnAfterAttackKnockout)
     ) {
         attacking_pokemon.add_effect(CardEffect::PreventAllDamageAndEffects, 1);

--- a/src/hooks/core.rs
+++ b/src/hooks/core.rs
@@ -966,21 +966,28 @@ enum WeaknessApplication {
     Double,
 }
 
-const DAMAGE_UNAFFECTED_BY_WEAKNESS_EFFECT: &str =
-    "This attack's damage isn't affected by Weakness.";
+/// The Weakness-bypass clause. Matched as a substring so that attacks combining it with another
+/// clause share the bypass — e.g. Swift's "This attack's damage isn't affected by Weakness **or by
+/// any effects on your opponent's Active Pokémon**." (Ledian, Staryu, Starmie).
+const DAMAGE_UNAFFECTED_BY_WEAKNESS_CLAUSE: &str =
+    "This attack's damage isn't affected by Weakness";
 
 /// Sawk's Brick Break (and any card sharing this clause): the attack's damage ignores every effect
 /// on the opponent's Active Pokémon — ability-derived reductions/preventions, stored CardEffects,
 /// and damage-reducing Tools alike. See `attack_ignores_opponent_active_effects`.
-pub(crate) const DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT: &str =
-    "This attack's damage isn't affected by any effects on your opponent's Active Pokémon.";
+///
+/// Kept as the bare clause so it also matches sentences that lead with something else — Sawk's
+/// "This attack's damage isn't affected by ...", Mega Medicham ex's Chakra Fist (after its Energy
+/// bonus), and Swift's "... isn't affected by Weakness **or** by any effects on ...".
+const DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_CLAUSE: &str =
+    "by any effects on your opponent's Active Pokémon";
 
 /// Whether an attack's effect text carries the "isn't affected by any effects on your opponent's
 /// Active Pokémon" clause. This is a substring match (not equality) so attacks that combine it with
 /// another clause — e.g. Mega Medicham ex's "Chakra Fist" (the [P]-Energy damage bonus plus this
-/// clause) — share Sawk's bypass behavior.
+/// clause) or Swift (the Weakness bypass plus this clause) — share Sawk's bypass behavior.
 pub(crate) fn attack_effect_ignores_opponent_active_effects(effect: Option<&str>) -> bool {
-    effect.is_some_and(|e| e.contains(DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_EFFECT))
+    effect.is_some_and(|e| e.contains(DAMAGE_UNAFFECTED_BY_OPPONENT_ACTIVE_EFFECTS_CLAUSE))
 }
 
 #[derive(Clone, Copy, Default)]
@@ -992,7 +999,9 @@ pub(crate) struct DamageModifierContext<'a> {
 fn attack_effect_ignores_weakness(context: DamageModifierContext<'_>) -> bool {
     // TODO: If more attack text needs to alter damage-modifier stages, replace this
     // effect-string check with a typed attack metadata/damage-modifier capability.
-    context.attack_effect == Some(DAMAGE_UNAFFECTED_BY_WEAKNESS_EFFECT)
+    context
+        .attack_effect
+        .is_some_and(|e| e.contains(DAMAGE_UNAFFECTED_BY_WEAKNESS_CLAUSE))
 }
 
 fn attack_ignores_opponent_active_effects(context: DamageModifierContext<'_>) -> bool {

--- a/src/hooks/retreat.rs
+++ b/src/hooks/retreat.rs
@@ -1,5 +1,5 @@
 use crate::{
-    actions::{abilities::AbilityMechanic, get_ability_mechanic},
+    actions::abilities::AbilityMechanic,
     card_ids::CardId,
     effects::{CardEffect, TurnEffect},
     models::{Card, EnergyType, PlayedCard},
@@ -23,7 +23,7 @@ pub(crate) fn can_retreat(state: &State) -> bool {
 pub(crate) fn get_retreat_cost(state: &State, card: &PlayedCard) -> Vec<EnergyType> {
     if let Card::Pokemon(pokemon_card) = &card.card {
         if matches!(
-            get_ability_mechanic(&card.card),
+            card.ability_mechanic(),
             Some(AbilityMechanic::NoRetreatIfHasEnergy)
         ) && !card.attached_energy.is_empty()
         {
@@ -69,7 +69,7 @@ pub(crate) fn get_retreat_cost(state: &State, card: &PlayedCard) -> Vec<EnergyTy
             let current_player = state.current_player;
             for (_idx, benched_pokemon) in state.enumerate_bench_pokemon(current_player) {
                 if matches!(
-                    get_ability_mechanic(&benched_pokemon.card),
+                    benched_pokemon.ability_mechanic(),
                     Some(
                         AbilityMechanic::ReduceRetreatCostOfYourActiveBasicFromBench { amount: 1 }
                     )
@@ -84,7 +84,7 @@ pub(crate) fn get_retreat_cost(state: &State, card: &PlayedCard) -> Vec<EnergyTy
                 if let Some(AbilityMechanic::ReduceRetreatCostOfYourActiveTypedFromBench {
                     energy_type,
                     amount,
-                }) = get_ability_mechanic(&benched_pokemon.card)
+                }) = benched_pokemon.ability_mechanic()
                 {
                     if energy_type == &active_energy_type {
                         to_subtract += *amount as u8;
@@ -108,7 +108,7 @@ pub(crate) fn get_retreat_cost(state: &State, card: &PlayedCard) -> Vec<EnergyTy
         let opponent = (state.current_player + 1) % 2;
         for (_idx, pokemon) in state.enumerate_in_play_pokemon(opponent) {
             if matches!(
-                get_ability_mechanic(&pokemon.card),
+                pokemon.ability_mechanic(),
                 Some(AbilityMechanic::IncreaseRetreatCostForOpponentActive { amount: 1 })
             ) {
                 normal_cost.push(EnergyType::Colorless);

--- a/src/move_generation/attacks.rs
+++ b/src/move_generation/attacks.rs
@@ -1,8 +1,5 @@
 use crate::{
-    actions::{
-        abilities::AbilityMechanic, has_ability_mechanic, Mechanic, SimpleAction,
-        EFFECT_MECHANIC_MAP,
-    },
+    actions::{abilities::AbilityMechanic, Mechanic, SimpleAction, EFFECT_MECHANIC_MAP},
     effects::CardEffect,
     hooks::{contains_energy, get_attack_cost},
     models::{Attack, PlayedCard},
@@ -92,7 +89,7 @@ fn attack_precondition_met(state: &State, player: usize, attack: &Attack) -> boo
 fn time_recall_attacks(state: &State, player: usize, active_pokemon: &PlayedCard) -> Vec<Attack> {
     let time_recall_active = state
         .enumerate_in_play_pokemon(player)
-        .any(|(_, pokemon)| has_ability_mechanic(&pokemon.card, &AbilityMechanic::TimeRecall));
+        .any(|(_, pokemon)| pokemon.has_ability(&AbilityMechanic::TimeRecall));
     if !time_recall_active {
         return Vec::new();
     }

--- a/src/move_generation/attacks.rs
+++ b/src/move_generation/attacks.rs
@@ -1,5 +1,8 @@
 use crate::{
-    actions::{abilities::AbilityMechanic, has_ability_mechanic, SimpleAction},
+    actions::{
+        abilities::AbilityMechanic, has_ability_mechanic, Mechanic, SimpleAction,
+        EFFECT_MECHANIC_MAP,
+    },
     effects::CardEffect,
     hooks::{contains_energy, get_attack_cost},
     models::{Attack, PlayedCard},
@@ -48,6 +51,9 @@ pub(crate) fn generate_attack_actions(state: &State) -> Vec<SimpleAction> {
             if restricted_attack_names.contains(&attack.title) {
                 continue;
             }
+            if !attack_precondition_met(state, current_player, &attack) {
+                continue;
+            }
             let modified_cost = get_attack_cost(&attack.energy_required, state, current_player);
             if contains_energy(active_pokemon, &modified_cost, state, current_player) {
                 offered.push(attack.clone());
@@ -56,6 +62,27 @@ pub(crate) fn generate_attack_actions(state: &State) -> Vec<SimpleAction> {
         }
     }
     actions
+}
+
+/// Whether an attack whose effect text carries a "You can use this attack only if ..." clause has
+/// that condition met. Attacks without such a clause are always usable (subject to the ordinary
+/// Energy cost and effect restrictions checked by the caller).
+fn attack_precondition_met(state: &State, player: usize, attack: &Attack) -> bool {
+    let Some(effect) = attack.effect.as_deref() else {
+        return true;
+    };
+    match EFFECT_MECHANIC_MAP.get(effect) {
+        // Mesprit's Supreme Blast: "You can use this attack only if you have Uxie and Azelf on
+        // your Bench."
+        Some(Mechanic::RequireBenchedNamesThenDiscardAllEnergy {
+            required_bench_names,
+        }) => required_bench_names.iter().all(|name| {
+            state
+                .enumerate_bench_pokemon(player)
+                .any(|(_, pokemon)| pokemon.get_name() == *name)
+        }),
+        _ => true,
+    }
 }
 
 /// Celebi's Time Recall: while a Pokémon with the ability is in play, each of your evolved

--- a/src/move_generation/mod.rs
+++ b/src/move_generation/mod.rs
@@ -2,7 +2,7 @@ mod attacks;
 mod move_generation_abilities;
 mod move_generation_trainer;
 
-use crate::actions::{abilities::AbilityMechanic, get_ability_mechanic, Action, SimpleAction};
+use crate::actions::{abilities::AbilityMechanic, Action, SimpleAction};
 use crate::hooks::{can_evolve_into, can_retreat, contains_energy, get_retreat_cost};
 use crate::models::Card;
 use crate::stadiums::{
@@ -193,7 +193,7 @@ fn generate_hand_actions(state: &State) -> Vec<SimpleAction> {
                         .as_ref()
                         .is_some_and(|active| {
                             matches!(
-                                get_ability_mechanic(&active.card),
+                                active.ability_mechanic(),
                                 Some(AbilityMechanic::CanEvolveOnFirstTurnIfActive)
                             )
                         });
@@ -210,7 +210,7 @@ fn generate_hand_actions(state: &State) -> Vec<SimpleAction> {
                             // Check if this pokemon has Boosted Evolution and is in active spot
                             let can_bypass_timing = i == 0
                                 && matches!(
-                                    get_ability_mechanic(&pokemon.card),
+                                    pokemon.ability_mechanic(),
                                     Some(AbilityMechanic::CanEvolveOnFirstTurnIfActive)
                                 );
 
@@ -270,7 +270,7 @@ fn has_opponent_aerodactyl_ex_primeval_law(state: &State, player: usize) -> bool
         .enumerate_in_play_pokemon(opponent)
         .any(|(_, pokemon)| {
             matches!(
-                get_ability_mechanic(&pokemon.card),
+                pokemon.ability_mechanic(),
                 Some(AbilityMechanic::PreventOpponentActiveEvolution)
             )
         })

--- a/src/move_generation/move_generation_abilities.rs
+++ b/src/move_generation/move_generation_abilities.rs
@@ -24,13 +24,12 @@ pub(crate) fn generate_ability_actions(state: &State) -> Vec<SimpleAction> {
 }
 
 fn can_use_ability(state: &State, (in_play_index, card): (usize, &PlayedCard)) -> bool {
-    if card.card.get_ability().is_none() {
+    if card.ability().is_none() {
         return false;
     }
 
     let mechanic = card
-        .card
-        .get_ability()
+        .ability()
         .and_then(|a| ability_mechanic_from_effect(&a.effect))
         .unwrap_or_else(|| {
             panic!(

--- a/src/move_generation/move_generation_trainer.rs
+++ b/src/move_generation/move_generation_trainer.rs
@@ -1,5 +1,5 @@
 use crate::{
-    actions::{abilities::AbilityMechanic, get_ability_mechanic, SimpleAction},
+    actions::{abilities::AbilityMechanic, SimpleAction},
     card_ids::CardId,
     card_logic::{
         active_has_psychic_attack, can_rare_candy_evolve, diantha_targets, ilima_targets,
@@ -325,7 +325,7 @@ fn can_play_stadium(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Sim
             .as_ref()
             .is_some_and(|opponent_active| {
                 matches!(
-                    get_ability_mechanic(&opponent_active.card),
+                    opponent_active.ability_mechanic(),
                     Some(AbilityMechanic::NoOpponentStadiumInActive)
                 )
             });
@@ -890,9 +890,7 @@ fn can_play_team(state: &State, trainer_card: &TrainerCard) -> Option<Vec<Simple
     let opponent = (state.current_player + 1) % 2;
     let has_target = state
         .enumerate_in_play_pokemon(opponent)
-        .any(|(_, pokemon)| {
-            pokemon.card.get_ability().is_some() && !pokemon.attached_energy.is_empty()
-        });
+        .any(|(_, pokemon)| pokemon.ability().is_some() && !pokemon.attached_energy.is_empty());
 
     if has_target {
         can_play_trainer(state, trainer_card)

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -73,6 +73,7 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::DiscardOwnBenchedThenDamage { .. } => 5, // Trading a Benched Pokemon for damage
         SimpleAction::DiscardOwnBenchedGroupThenDamage { .. } => 5, // Same trade, several Pokemon at once
         SimpleAction::ShuffleSelfAndAttachmentsIntoDeck { .. } => 5,
+        SimpleAction::MoveEnergyAndReoffer { .. } => 5,
 
         SimpleAction::ReturnPokemonToHand { .. } => 5,
         SimpleAction::ShuffleInPlayPokemonIntoDeck { .. } => 5,

--- a/src/players/weighted_random_player.rs
+++ b/src/players/weighted_random_player.rs
@@ -71,6 +71,8 @@ fn get_weight(action: &SimpleAction) -> u32 {
         SimpleAction::HealAllEeveeEvolutions => 5,
         SimpleAction::DiscardFossil { .. } => 1, // Low weight to discard fossils
         SimpleAction::DiscardOwnBenchedThenDamage { .. } => 5, // Trading a Benched Pokemon for damage
+        SimpleAction::DiscardOwnBenchedGroupThenDamage { .. } => 5, // Same trade, several Pokemon at once
+        SimpleAction::ShuffleSelfAndAttachmentsIntoDeck { .. } => 5,
 
         SimpleAction::ReturnPokemonToHand { .. } => 5,
         SimpleAction::ShuffleInPlayPokemonIntoDeck { .. } => 5,

--- a/src/state/energy.rs
+++ b/src/state/energy.rs
@@ -1,7 +1,7 @@
 use crate::{
     actions::{
-        abilities::AbilityMechanic, ability_mechanic_from_effect, apply_evolve,
-        get_ability_mechanic, handle_damage_only, handle_knockouts,
+        abilities::AbilityMechanic, ability_mechanic_from_effect, apply_evolve, handle_damage_only,
+        handle_knockouts,
     },
     effects::TurnEffect,
     hooks::{can_evolve_into, DamageModifierContext},
@@ -100,7 +100,7 @@ impl State {
             let pokemon = self.in_play_pokemon[actor][in_play_idx]
                 .as_ref()
                 .expect("Pokemon should be there if attaching energy to it");
-            get_ability_mechanic(&pokemon.card).cloned()
+            pokemon.ability_mechanic().cloned()
         };
 
         if from_zone {

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -112,6 +112,18 @@ pub struct State {
     // Alcremie's "Sweets Overload": "This attack does 40 damage for each time your Pokémon used
     // Sweets Relay during this game."). Using BTreeMap to keep State hashable.
     pub(crate) attack_name_used_count: [BTreeMap<String, u32>; 2],
+    // Number of each player's OWN Pokemon that have been Knocked Out over the whole game, however
+    // it happened (e.g. for Kingambit's "Overlord's Blade": "This attack does 40 more damage for
+    // each time your Pokemon have been Knocked Out during this game.").
+    #[serde(default)]
+    pub(crate) own_knocked_out_count: [u32; 2],
+    // Each player's point total as it stood when their current turn began, and how many points
+    // they gained over their previous turn. Together these answer "points your opponent got during
+    // their last turn" (e.g. Hisuian Basculegion's "Soul Counter").
+    #[serde(default)]
+    pub(crate) points_at_own_turn_start: [u8; 2],
+    #[serde(default)]
+    pub(crate) points_gained_during_own_last_turn: [u8; 2],
     // Maps turn to a vector of effects (cards) for that turn. Using BTreeMap to keep State hashable.
     turn_effects: BTreeMap<u8, Vec<TurnEffect>>,
 }
@@ -146,6 +158,9 @@ impl State {
             attack_name_used_this_turn: [None, None],
             attack_name_used_last_turn: [None, None],
             attack_name_used_count: [BTreeMap::new(), BTreeMap::new()],
+            own_knocked_out_count: [0, 0],
+            points_at_own_turn_start: [0, 0],
+            points_gained_during_own_last_turn: [0, 0],
             turn_effects: BTreeMap::new(),
         }
     }
@@ -560,7 +575,13 @@ impl State {
         self.end_turn_pending = false;
         self.attack_name_used_last_turn[self.current_player] =
             self.attack_name_used_this_turn[self.current_player].take();
+        // Close out the ending player's point ledger before handing over, and open the incoming
+        // player's, so "points your opponent got during their last turn" is readable all turn.
+        self.points_gained_during_own_last_turn[self.current_player] = self.points
+            [self.current_player]
+            .saturating_sub(self.points_at_own_turn_start[self.current_player]);
         self.current_player = (self.current_player + 1) % 2;
+        self.points_at_own_turn_start[self.current_player] = self.points[self.current_player];
         self.turn_count += 1;
         if self.turn_count > 30 {
             self.winner = Some(GameOutcome::Tie);
@@ -732,6 +753,39 @@ impl State {
         self.knocked_out_by_opponent_attack_this_turn = true;
         if let Some(energy_type) = energy_type {
             self.knocked_out_types_this_turn.insert(energy_type);
+        }
+    }
+
+    /// Records that one of `player`'s own Pokemon was Knocked Out (for Kingambit's Overlord's
+    /// Blade, which counts every such knockout over the whole game).
+    pub(crate) fn record_own_knockout(&mut self, player: usize) {
+        self.own_knocked_out_count[player] = self.own_knocked_out_count[player].saturating_add(1);
+    }
+
+    /// How many of `player`'s own Pokemon have been Knocked Out so far this game.
+    pub(crate) fn count_own_knockouts(&self, player: usize) -> u32 {
+        self.own_knocked_out_count[player]
+    }
+
+    /// How many points `player` gained during their own previous turn.
+    pub(crate) fn points_gained_during_last_turn(&self, player: usize) -> u32 {
+        self.points_gained_during_own_last_turn[player] as u32
+    }
+
+    /// Poisons `player`'s Pokemon at `in_play_idx` such that Checkup deals `amount` damage instead
+    /// of the usual 10 (e.g. Toxicroak's Toxic, Toxapex's Severe Poison). If the Pokemon turns out
+    /// to be immune to Special Conditions the override is not recorded either.
+    pub(crate) fn apply_poison_with_damage(
+        &mut self,
+        player: usize,
+        in_play_idx: usize,
+        amount: u32,
+    ) {
+        self.apply_status_condition(player, in_play_idx, StatusCondition::Poisoned);
+        if let Some(pokemon) = self.in_play_pokemon[player][in_play_idx].as_mut() {
+            if pokemon.is_poisoned() {
+                pokemon.set_poison_damage_override(amount);
+            }
         }
     }
 

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -10,7 +10,7 @@ use std::hash::Hash;
 
 use crate::{
     actions::abilities::AbilityMechanic,
-    actions::{has_ability_mechanic, SimpleAction},
+    actions::SimpleAction,
     deck::Deck,
     effects::TurnEffect,
     models::{Attack, Card, EnergyType, StatusCondition},
@@ -399,9 +399,7 @@ impl State {
             return None;
         }
         self.enumerate_in_play_pokemon(player)
-            .find(|(_, pokemon)| {
-                has_ability_mechanic(&pokemon.card, &AbilityMechanic::VictoryStarReflip)
-            })
+            .find(|(_, pokemon)| pokemon.has_ability(&AbilityMechanic::VictoryStarReflip))
             .map(|(idx, _)| idx)
     }
 
@@ -526,7 +524,7 @@ impl State {
             return;
         };
 
-        if has_ability_mechanic(&pokemon.card, &AbilityMechanic::ImmuneToStatusConditions) {
+        if pokemon.has_ability(&AbilityMechanic::ImmuneToStatusConditions) {
             debug!("Fabled Luster: Pokémon is immune to status conditions");
             return;
         }
@@ -543,9 +541,7 @@ impl State {
         // SoothingWind (Ogerpon ex) / Flower Shield (Comfey): if any of this player's Pokémon
         // has the ability, Pokémon meeting the energy requirement are immune to Special Conditions.
         for p in self.in_play_pokemon[player].iter().flatten() {
-            if let Some(AbilityMechanic::SoothingWind { energy_type }) =
-                crate::actions::get_ability_mechanic(&p.card)
-            {
+            if let Some(AbilityMechanic::SoothingWind { energy_type }) = p.ability_mechanic() {
                 let is_protected = match energy_type {
                     None => !pokemon.attached_energy.is_empty(),
                     Some(t) => pokemon.attached_energy.contains(t),

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -35,6 +35,12 @@ pub struct PlayedCard {
     pub moved_to_active_this_turn: bool,
     pub ability_used: bool,
     poisoned: bool,
+    /// Checkup damage this Pokemon takes from its current Poison, when an attack replaced the usual
+    /// amount ("Do 20 damage to this Pokemon instead of the usual amount for this Special
+    /// Condition." — Toxicroak's Toxic, Toxapex's Severe Poison). Cleared whenever the Poison is
+    /// cleared or re-applied normally, so a later ordinary Poison is back to 10.
+    #[serde(default)]
+    poison_damage_override: Option<u32>,
     paralyzed: bool,
     asleep: bool,
     burned: bool,
@@ -70,6 +76,7 @@ impl PlayedCard {
             attached_tool: None,
             ability_used: false,
             poisoned: false,
+            poison_damage_override: None,
             paralyzed: false,
             asleep: false,
             burned: false,
@@ -275,6 +282,18 @@ impl PlayedCard {
         self.poisoned
     }
 
+    /// Replaces the Checkup damage of this Pokemon's current Poison. Set right after the Poison
+    /// lands; `set_status_raw(Poisoned)` and every cure path reset it.
+    pub(crate) fn set_poison_damage_override(&mut self, amount: u32) {
+        self.poison_damage_override = Some(amount);
+    }
+
+    /// The Checkup damage this Pokemon's Poison deals before any board-wide bonus, i.e. the usual
+    /// 10 unless an attack overrode it.
+    pub(crate) fn poison_base_damage(&self) -> u32 {
+        self.poison_damage_override.unwrap_or(10)
+    }
+
     pub fn is_paralyzed(&self) -> bool {
         self.paralyzed
     }
@@ -351,6 +370,7 @@ impl PlayedCard {
 
     pub(crate) fn clear_status_and_effects(&mut self) {
         self.poisoned = false;
+        self.poison_damage_override = None;
         self.paralyzed = false;
         self.asleep = false;
         self.burned = false;
@@ -360,6 +380,7 @@ impl PlayedCard {
 
     pub(crate) fn cure_status_conditions(&mut self) {
         self.poisoned = false;
+        self.poison_damage_override = None;
         self.paralyzed = false;
         self.asleep = false;
         self.burned = false;
@@ -368,7 +389,10 @@ impl PlayedCard {
 
     pub(crate) fn clear_status_condition(&mut self, status: StatusCondition) {
         match status {
-            StatusCondition::Poisoned => self.poisoned = false,
+            StatusCondition::Poisoned => {
+                self.poisoned = false;
+                self.poison_damage_override = None;
+            }
             StatusCondition::Paralyzed => self.paralyzed = false,
             StatusCondition::Asleep => self.asleep = false,
             StatusCondition::Burned => self.burned = false,
@@ -381,7 +405,11 @@ impl PlayedCard {
         match status {
             StatusCondition::Asleep => self.asleep = true,
             StatusCondition::Paralyzed => self.paralyzed = true,
-            StatusCondition::Poisoned => self.poisoned = true,
+            StatusCondition::Poisoned => {
+                self.poisoned = true;
+                // An ordinary Poison replaces any earlier custom-damage Poison.
+                self.poison_damage_override = None;
+            }
             StatusCondition::Burned => self.burned = true,
             StatusCondition::Confused => self.confused = true,
         }

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -295,6 +295,21 @@ impl PlayedCard {
         self.poisoned || self.paralyzed || self.asleep || self.burned || self.confused
     }
 
+    /// How many Special Conditions currently affect this Pokémon (e.g. for Team Rocket's Magmar's
+    /// Derisive Roasting, which scales with that count).
+    pub fn count_status_conditions(&self) -> usize {
+        [
+            self.poisoned,
+            self.paralyzed,
+            self.asleep,
+            self.burned,
+            self.confused,
+        ]
+        .iter()
+        .filter(|flag| **flag)
+        .count()
+    }
+
     pub(crate) fn has_tool_attached(&self) -> bool {
         self.attached_tool.is_some()
     }

--- a/src/state/played_card.rs
+++ b/src/state/played_card.rs
@@ -5,7 +5,6 @@ use super::State;
 use crate::{
     actions::{
         abilities::AbilityMechanic, card_effect_from_ability_mechanic, get_ability_mechanic,
-        has_ability_mechanic,
     },
     card_ids::CardId,
     database::get_card_by_enum,
@@ -260,7 +259,7 @@ impl PlayedCard {
         if let Some(AbilityMechanic::IncreaseHpPerAttachedEnergy {
             energy_type,
             amount,
-        }) = get_ability_mechanic(&self.card)
+        }) = self.ability_mechanic()
         {
             let mut matching_count = self
                 .attached_energy
@@ -356,12 +355,45 @@ impl PlayedCard {
     /// are present exactly while the ability-holder is in play (no turn duration).
     pub(crate) fn get_effective_card_effects(&self) -> Vec<CardEffect> {
         let mut effects = self.get_active_effects();
-        if let Some(mechanic) = get_ability_mechanic(&self.card) {
+        if let Some(mechanic) = self.ability_mechanic() {
             if let Some(derived) = card_effect_from_ability_mechanic(mechanic) {
                 effects.push(derived);
             }
         }
         effects
+    }
+
+    /// Whether this Pokémon has been stripped of its Abilities (Budew's Prickly Powder).
+    fn abilities_disabled(&self) -> bool {
+        self.effects
+            .iter()
+            .any(|(effect, _)| matches!(effect, CardEffect::AbilitiesDisabled))
+    }
+
+    /// This Pokémon's Ability as it applies *in play*, i.e. `None` while its Abilities are
+    /// disabled. Every ability lookup that has a `PlayedCard` in hand should go through this
+    /// rather than reaching into `self.card` directly, so "loses all Abilities" is honoured
+    /// uniformly.
+    pub(crate) fn ability(&self) -> Option<crate::models::Ability> {
+        if self.abilities_disabled() {
+            return None;
+        }
+        self.card.get_ability()
+    }
+
+    /// The `AbilityMechanic` this Pokémon contributes in play, or `None` while its Abilities are
+    /// disabled. The in-play counterpart of `get_ability_mechanic(&card)`.
+    pub(crate) fn ability_mechanic(&self) -> Option<&'static AbilityMechanic> {
+        if self.abilities_disabled() {
+            return None;
+        }
+        get_ability_mechanic(&self.card)
+    }
+
+    /// Whether this Pokémon contributes `mechanic` in play. The in-play counterpart of
+    /// `has_ability_mechanic(&card, mechanic)`.
+    pub(crate) fn has_ability(&self, mechanic: &AbilityMechanic) -> bool {
+        self.ability_mechanic() == Some(mechanic)
     }
 
     pub(crate) fn get_effects(&self) -> &Vec<(CardEffect, u8)> {
@@ -484,9 +516,9 @@ impl fmt::Debug for PlayedCard {
 }
 
 pub fn has_serperior_jungle_totem(state: &State, player: usize) -> bool {
-    state.enumerate_in_play_pokemon(player).any(|(_, pokemon)| {
-        has_ability_mechanic(&pokemon.card, &AbilityMechanic::DoubleGrassEnergy)
-    })
+    state
+        .enumerate_in_play_pokemon(player)
+        .any(|(_, pokemon)| pokemon.has_ability(&AbilityMechanic::DoubleGrassEnergy))
 }
 
 #[cfg(test)]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -74,6 +74,8 @@ mod darkrai_ex_test;
 mod dedenne_surskit_test;
 #[path = "pokemon/delibird_test.rs"]
 mod delibird_test;
+#[path = "pokemon/direct_damage_attacks_d_test.rs"]
+mod direct_damage_attacks_d_test;
 #[path = "pokemon/dragonair_dragons_blessing_test.rs"]
 mod dragonair_dragons_blessing_test;
 #[path = "pokemon/drampa_test.rs"]
@@ -220,6 +222,8 @@ mod meowstic_test;
 mod meowth_carefree_steps_test;
 #[path = "pokemon/milotic_ex_aqua_charge_test.rs"]
 mod milotic_ex_aqua_charge_test;
+#[path = "pokemon/miltank_rolling_frenzy_test.rs"]
+mod miltank_rolling_frenzy_test;
 #[path = "pokemon/miraidon_ex_test.rs"]
 mod miraidon_ex_test;
 #[path = "pokemon/morpeko_test.rs"]
@@ -276,6 +280,8 @@ mod salamence_test;
 mod sandslash_fury_swipes_test;
 #[path = "pokemon/sawk_test.rs"]
 mod sawk_test;
+#[path = "pokemon/scaling_damage_attacks_d_test.rs"]
+mod scaling_damage_attacks_d_test;
 #[path = "pokemon/shinx_hide_test.rs"]
 mod shinx_hide_test;
 #[path = "pokemon/silcoon_cascoon_cocoon_collector_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -60,6 +60,8 @@ mod coalossal_coal_drop_test;
 mod coalossal_mountain_crush_test;
 #[path = "pokemon/comfey_flower_shield_test.rs"]
 mod comfey_flower_shield_test;
+#[path = "pokemon/conditional_damage_attacks_d_test.rs"]
+mod conditional_damage_attacks_d_test;
 #[path = "pokemon/corviknight_line_test.rs"]
 mod corviknight_line_test;
 #[path = "pokemon/cradily_stick_and_absorb_test.rs"]
@@ -282,6 +284,8 @@ mod sandslash_fury_swipes_test;
 mod sawk_test;
 #[path = "pokemon/scaling_damage_attacks_d_test.rs"]
 mod scaling_damage_attacks_d_test;
+#[path = "pokemon/self_relocation_attacks_d_test.rs"]
+mod self_relocation_attacks_d_test;
 #[path = "pokemon/shinx_hide_test.rs"]
 mod shinx_hide_test;
 #[path = "pokemon/silcoon_cascoon_cocoon_collector_test.rs"]
@@ -296,8 +300,12 @@ mod snorlax_massive_body_test;
 mod snover_ice_shard_test;
 #[path = "pokemon/spewpa_signs_of_evolution_test.rs"]
 mod spewpa_signs_of_evolution_test;
+#[path = "pokemon/spread_and_energy_attacks_d_test.rs"]
+mod spread_and_energy_attacks_d_test;
 #[path = "pokemon/sunflora_quick_grow_beam_test.rs"]
 mod sunflora_quick_grow_beam_test;
+#[path = "pokemon/swift_attacks_d_test.rs"]
+mod swift_attacks_d_test;
 #[path = "pokemon/swift_shot_test.rs"]
 mod swift_shot_test;
 #[path = "pokemon/sylveon_soothing_ribbon_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -36,6 +36,8 @@ mod bonsly_teary_attack_test;
 mod brambleghast_accept_pain_test;
 #[path = "pokemon/breloom_test.rs"]
 mod breloom_test;
+#[path = "pokemon/budew_prickly_powder_test.rs"]
+mod budew_prickly_powder_test;
 #[path = "pokemon/camerupt_eruption_test.rs"]
 mod camerupt_eruption_test;
 #[path = "pokemon/carbink_glittering_gift_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -108,6 +108,8 @@ mod flutter_mane_ex_test;
 mod flygon_ex_test;
 #[path = "pokemon/gallade_test.rs"]
 mod gallade_test;
+#[path = "pokemon/game_state_attacks_d_test.rs"]
+mod game_state_attacks_d_test;
 #[path = "pokemon/gardevoir_psy_turbo_test.rs"]
 mod gardevoir_psy_turbo_test;
 #[path = "pokemon/gigalith_ex_megaton_cannon_test.rs"]

--- a/tests/pokemon.rs
+++ b/tests/pokemon.rs
@@ -74,6 +74,8 @@ mod croagunk_toxicroak_test;
 mod darkrai_ex_test;
 #[path = "pokemon/dedenne_surskit_test.rs"]
 mod dedenne_surskit_test;
+#[path = "pokemon/delcatty_energy_blender_test.rs"]
+mod delcatty_energy_blender_test;
 #[path = "pokemon/delibird_test.rs"]
 mod delibird_test;
 #[path = "pokemon/direct_damage_attacks_d_test.rs"]

--- a/tests/pokemon/budew_prickly_powder_test.rs
+++ b/tests/pokemon/budew_prickly_powder_test.rs
@@ -1,0 +1,181 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Cloyster's Shell Armor ("This Pokémon takes -10 damage from attacks.") normally softens an
+/// incoming hit; this is the control for the Prickly Powder test below.
+#[test]
+fn test_cloysters_shell_armor_reduces_damage_without_prickly_powder() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1067Cloyster)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (0, 0),
+            targets: vec![(50, 1, 0)],
+            is_from_active_attack: true,
+        },
+        is_stack: false,
+    });
+
+    // 120 HP - (50 - 10) = 80
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 80);
+}
+
+/// Budew - Prickly Powder: "The Defending Pokémon loses all Abilities." Shell Armor stops working.
+#[test]
+fn test_budew_prickly_powder_strips_the_defenders_passive_ability() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B3013Budew),
+            PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1067Cloyster)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3013Budew, 0),
+        is_stack: false,
+    });
+    // Prickly Powder's own 10 damage is still soaked by Shell Armor (the effect only lands after
+    // that hit resolves); what matters is the effect it leaves behind.
+    let hp_before = game.get_state_clone().get_active(1).get_remaining_hp();
+    assert_eq!(hp_before, 120);
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (0, 0),
+            targets: vec![(50, 1, 0)],
+            is_from_active_attack: true,
+        },
+        is_stack: false,
+    });
+
+    // The full 50 lands: Shell Armor is gone.
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        hp_before - 50
+    );
+}
+
+/// The effect lasts only while the Defending Pokémon stays Active: switching it out restores its
+/// Ability.
+#[test]
+fn test_budew_prickly_powder_wears_off_when_the_defender_leaves_the_active_spot() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3013Budew)],
+        vec![
+            PlayedCard::from_id(CardId::A1067Cloyster),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3013Budew, 0),
+        is_stack: false,
+    });
+
+    // The opponent swaps Cloyster to the Bench and back, which clears effects on it.
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    game.set_state(state);
+    for _ in 0..2 {
+        game.apply_action(&Action {
+            actor: 1,
+            action: SimpleAction::Activate {
+                player: 1,
+                in_play_idx: 1,
+            },
+            is_stack: false,
+        });
+        let mut state = game.get_state_clone();
+        state.current_player = 1;
+        game.set_state(state);
+    }
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_name(), "Cloyster");
+    let hp_before = state.get_active(1).get_remaining_hp();
+
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (0, 0),
+            targets: vec![(50, 1, 0)],
+            is_from_active_attack: true,
+        },
+        is_stack: false,
+    });
+
+    // Shell Armor is back: only 40 gets through.
+    assert_eq!(
+        game.get_state_clone().get_active(1).get_remaining_hp(),
+        hp_before - 40
+    );
+}
+
+/// A Pokémon that has lost its Abilities also stops offering activated ones.
+#[test]
+fn test_budew_prickly_powder_removes_activated_abilities_from_the_defender() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3013Budew)],
+        vec![
+            PlayedCard::from_id(CardId::A1007Butterfree),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_damage(30),
+        ],
+    );
+
+    // Control: Butterfree's Powder Heal is offered on the opponent's turn.
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    game.set_state(state);
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        choices
+            .iter()
+            .any(|choice| matches!(choice.action, SimpleAction::UseAbility { in_play_idx: 0 })),
+        "Butterfree should normally offer its ability"
+    );
+
+    // Now strip it with Prickly Powder.
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3013Budew, 0),
+        is_stack: false,
+    });
+
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    game.set_state(state);
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !choices
+            .iter()
+            .any(|choice| matches!(choice.action, SimpleAction::UseAbility { in_play_idx: 0 })),
+        "Prickly Powder should take Butterfree's ability away"
+    );
+}

--- a/tests/pokemon/conditional_damage_attacks_d_test.rs
+++ b/tests/pokemon/conditional_damage_attacks_d_test.rs
@@ -1,0 +1,132 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Wishiwashi ex - School Storm: 30 damage, +40 for each Benched Wishiwashi *or* Wishiwashi ex.
+#[test]
+fn test_wishiwashi_ex_school_storm_counts_both_wishiwashi_names() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A3051WishiwashiEx).with_energy(vec![
+                EnergyType::Water,
+                EnergyType::Water,
+                EnergyType::Water,
+            ]),
+            PlayedCard::from_id(CardId::A3051WishiwashiEx),
+            PlayedCard::from_id(CardId::A1211Snorlax),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3051WishiwashiEx, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // 30 + 1 * 40 = 70 (the Active Wishiwashi ex does not count itself; Snorlax does not count)
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 80);
+}
+
+/// Team Rocket's Magmar - Derisive Roasting: 10 damage, +50 per Special Condition on the defender.
+#[test]
+fn test_team_rockets_magmar_derisive_roasting_scales_with_special_conditions() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4a006TeamRocketsMagmar)
+            .with_energy(vec![EnergyType::Fire])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    // No conditions: plain 10 damage.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a006TeamRocketsMagmar, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 140);
+
+    // Two conditions: 10 + 2 * 50 = 110.
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.apply_status_condition(1, 0, deckgym::models::StatusCondition::Poisoned);
+    state.apply_status_condition(1, 0, deckgym::models::StatusCondition::Burned);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a006TeamRocketsMagmar, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 30);
+}
+
+/// Teal Mask Ogerpon - Ogre's Whip: damage equal to its own remaining HP.
+#[test]
+fn test_teal_mask_ogerpon_ogres_whip_damage_equals_its_remaining_hp() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4019TealMaskOgerpon)
+            .with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Grass,
+                EnergyType::Colorless,
+            ])
+            .with_remaining_hp(60)],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4019TealMaskOgerpon, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 90);
+}
+
+/// Roserade - Poison Ring: 50 damage, Poisoned, and the defender cannot retreat next turn.
+#[test]
+fn test_roserade_poison_ring_poisons_and_blocks_retreat() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B2005Roserade)
+            .with_energy(vec![EnergyType::Grass, EnergyType::Grass])],
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+            ]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2005Roserade, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 100);
+    assert!(state.get_active(1).is_poisoned());
+
+    // The defender's own turn: retreating must not be offered despite paying-capable Energy.
+    game.play_until_stable();
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    if actor == 1 {
+        assert!(
+            !choices
+                .iter()
+                .any(|choice| matches!(choice.action, deckgym::actions::SimpleAction::Retreat(_))),
+            "Poison Ring should block the defender's retreat"
+        );
+    }
+}

--- a/tests/pokemon/delcatty_energy_blender_test.rs
+++ b/tests/pokemon/delcatty_energy_blender_test.rs
@@ -1,0 +1,145 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Delcatty - Energy Blender: "You may move any amount of Energy from your Pokémon in play to your
+/// other Pokémon in any way you like." The redistribution is played out one Energy at a time.
+#[test]
+fn test_delcatty_energy_blender_moves_energy_one_at_a_time() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4135Delcatty).with_energy(vec![
+                EnergyType::Colorless,
+                EnergyType::Colorless,
+                EnergyType::Water,
+            ]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4135Delcatty, 0),
+        is_stack: false,
+    });
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 100);
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    // Two distinct Energy types on Delcatty, one destination, plus the option to stop.
+    assert_eq!(choices.len(), 3);
+    assert!(choices
+        .iter()
+        .any(|choice| matches!(choice.action, SimpleAction::Noop)));
+
+    let move_water = choices
+        .iter()
+        .find(|choice| {
+            matches!(
+                choice.action,
+                SimpleAction::MoveEnergyAndReoffer {
+                    from_in_play_idx: 0,
+                    to_in_play_idx: 1,
+                    energy_type: EnergyType::Water,
+                    ..
+                }
+            )
+        })
+        .expect("moving the Water Energy to the Bench should be offered")
+        .clone();
+    game.apply_action(&move_water);
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .expect("bench")
+            .attached_energy,
+        vec![EnergyType::Water]
+    );
+    assert_eq!(state.get_active(0).attached_energy.len(), 2);
+
+    // The prompt comes back so more Energy can be moved; stopping ends the effect.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let stop = choices
+        .iter()
+        .find(|choice| matches!(choice.action, SimpleAction::Noop))
+        .expect("stopping should be offered")
+        .clone();
+    game.apply_action(&stop);
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !choices
+            .iter()
+            .any(|choice| matches!(choice.action, SimpleAction::MoveEnergyAndReoffer { .. })),
+        "the effect is over once the player stops"
+    );
+}
+
+/// With nothing to move, Energy Blender is just its damage — no prompt is raised.
+#[test]
+fn test_delcatty_energy_blender_without_a_second_pokemon_just_deals_damage() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4135Delcatty)
+            .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4135Delcatty, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 100);
+    let (_, choices) = state.generate_possible_actions();
+    assert!(
+        !choices
+            .iter()
+            .any(|choice| matches!(choice.action, SimpleAction::MoveEnergyAndReoffer { .. })),
+        "with no other Pokémon in play there is nothing to offer"
+    );
+}
+
+/// The move budget is the player's total attached Energy, so the prompt always terminates.
+#[test]
+fn test_delcatty_energy_blender_terminates() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4135Delcatty)
+                .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur).with_energy(vec![EnergyType::Grass]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4135Delcatty, 0),
+        is_stack: false,
+    });
+
+    // Always take the first non-Noop move; the budget must still run out.
+    let mut steps = 0;
+    loop {
+        let (_, choices) = game.get_state_clone().generate_possible_actions();
+        let Some(next) = choices
+            .iter()
+            .find(|choice| matches!(choice.action, SimpleAction::MoveEnergyAndReoffer { .. }))
+            .cloned()
+        else {
+            break;
+        };
+        game.apply_action(&next);
+        steps += 1;
+        assert!(steps <= 3, "the move budget is the 3 Energy in play");
+    }
+    assert_eq!(steps, 3);
+}

--- a/tests/pokemon/direct_damage_attacks_d_test.rs
+++ b/tests/pokemon/direct_damage_attacks_d_test.rs
@@ -1,0 +1,178 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Palafin - Jet Punch: 50 to the Defending Pokémon, and also 50 to a chosen Benched Pokémon.
+#[test]
+fn test_palafin_jet_punch_hits_active_and_a_chosen_bench_pokemon() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B2a028Palafin).with_energy(vec![
+            EnergyType::Water,
+            EnergyType::Water,
+            EnergyType::Water,
+        ])],
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax),
+            PlayedCard::from_id(CardId::A1211Snorlax),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2a028Palafin, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(choices
+        .iter()
+        .all(|choice| matches!(choice.action, SimpleAction::ApplyDamage { .. })));
+    game.apply_action(&choices[0].clone());
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 100);
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("bench Snorlax")
+            .get_remaining_hp(),
+        100
+    );
+}
+
+/// Palafin with no opposing Bench still deals its 50 damage to the Defending Pokémon.
+#[test]
+fn test_palafin_jet_punch_still_damages_active_without_a_bench() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B2a028Palafin).with_energy(vec![
+            EnergyType::Water,
+            EnergyType::Water,
+            EnergyType::Water,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2a028Palafin, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 100);
+}
+
+/// Indeedee - Zen Shard: 70 damage to a chosen Benched Pokémon only (never the Active).
+#[test]
+fn test_indeedee_zen_shard_only_targets_the_bench() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B2076Indeedee).with_energy(vec![
+            EnergyType::Psychic,
+            EnergyType::Psychic,
+            EnergyType::Psychic,
+        ])],
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax),
+            PlayedCard::from_id(CardId::A1211Snorlax),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2076Indeedee, 0),
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(
+        choices.len(),
+        1,
+        "only the single Benched Pokémon is a target"
+    );
+    game.apply_action(&choices[0].clone());
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 150);
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("bench Snorlax")
+            .get_remaining_hp(),
+        80
+    );
+}
+
+/// Mandibuzz - Blindside: 60 damage to a chosen opposing Pokémon that already has damage on it.
+#[test]
+fn test_mandibuzz_blindside_only_targets_damaged_pokemon() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3110Mandibuzz).with_energy(vec![EnergyType::Darkness])],
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax),
+            PlayedCard::from_id(CardId::A1211Snorlax).with_remaining_hp(100),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3110Mandibuzz, 0),
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(
+        choices.len(),
+        1,
+        "only the damaged Benched Pokémon qualifies"
+    );
+    game.apply_action(&choices[0].clone());
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 150);
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("bench Snorlax")
+            .get_remaining_hp(),
+        40
+    );
+}
+
+/// Galarian Obstagoon - Bass Control: 80 damage to any 1 opposing Pokémon (Active included).
+#[test]
+fn test_galarian_obstagoon_bass_control_can_target_the_active() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4097GalarianObstagoon).with_energy(vec![
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+            ]),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax),
+            PlayedCard::from_id(CardId::A1211Snorlax),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4097GalarianObstagoon, 0),
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(
+        choices.len(),
+        2,
+        "the Active and the Bench are both targets"
+    );
+    game.apply_action(&choices[0].clone());
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 70);
+}

--- a/tests/pokemon/game_state_attacks_d_test.rs
+++ b/tests/pokemon/game_state_attacks_d_test.rs
@@ -1,0 +1,273 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Kingambit - Overlord's Blade: 60 damage, +40 for each of your own Pokémon Knocked Out this game.
+#[test]
+fn test_kingambit_overlords_blade_scales_with_your_own_knockouts() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3a043Kingambit)
+            .with_energy(vec![EnergyType::Darkness, EnergyType::Darkness])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    // No losses yet: the printed 60.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3a043Kingambit, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 90);
+
+    // Give player 0 a Benched Pokémon and knock it out, then attack again.
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    state.in_play_pokemon[0][1] =
+        Some(PlayedCard::from_id(CardId::A1001Bulbasaur).with_remaining_hp(10));
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (1, 0),
+            targets: vec![(50, 0, 1)],
+            is_from_active_attack: false,
+        },
+        is_stack: false,
+    });
+
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    assert!(
+        game.get_state_clone().in_play_pokemon[0][1].is_none(),
+        "the Benched Bulbasaur should have been knocked out"
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3a043Kingambit, 0),
+        is_stack: false,
+    });
+
+    // 60 + 1 * 40 = 100
+    assert_eq!(game.get_state_clone().in_play_pokemon[1][0], None);
+}
+
+/// Hisuian Basculegion - Soul Counter: 50 damage, +50 for each point the opponent got last turn.
+#[test]
+fn test_hisuian_basculegion_soul_counter_without_opponent_points() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4a018HisuianBasculegion)
+            .with_energy(vec![EnergyType::Water, EnergyType::Water])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a018HisuianBasculegion, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 100);
+}
+
+/// The opponent scoring a point during their turn boosts the next Soul Counter by 50.
+#[test]
+fn test_hisuian_basculegion_soul_counter_scales_with_points_scored_last_turn() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4a018HisuianBasculegion)
+                .with_energy(vec![EnergyType::Water, EnergyType::Water])
+                .with_remaining_hp(10),
+            PlayedCard::from_id(CardId::B4a018HisuianBasculegion)
+                .with_energy(vec![EnergyType::Water, EnergyType::Water]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    // Hand the turn to the opponent, who knocks out the Active Basculegion for a point.
+    let mut state = game.get_state_clone();
+    state.current_player = 1;
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::ApplyDamage {
+            attacking_ref: (1, 0),
+            targets: vec![(50, 0, 0)],
+            is_from_active_attack: true,
+        },
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.points[1], 1, "the opponent should have scored");
+
+    // The opponent ends their turn, which closes their point ledger for that turn.
+    game.apply_action(&Action {
+        actor: 1,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+    game.play_until_stable();
+    assert_eq!(game.get_state_clone().current_player, 0);
+
+    // Back on our turn, Soul Counter is 50 + 1 * 50 = 100.
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a018HisuianBasculegion, 0),
+        is_stack: false,
+    });
+
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 50);
+}
+
+/// Toxicroak - Toxic: the Poison it inflicts deals 20 at Checkup instead of the usual 10.
+#[test]
+fn test_toxicroak_toxic_poison_deals_twenty_at_checkup() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A2a052Toxicroak).with_energy(vec![EnergyType::Darkness])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A2a052Toxicroak, 0),
+        is_stack: false,
+    });
+    let state = game.get_state_clone();
+    assert!(state.get_active(1).is_poisoned());
+    // Toxic itself does no damage.
+    assert_eq!(state.get_active(1).get_remaining_hp(), 150);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 130);
+}
+
+/// Toxapex - Severe Poison: 40 at Checkup instead of 10.
+#[test]
+fn test_toxapex_severe_poison_deals_forty_at_checkup() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3b047ToxapEx)
+            .with_energy(vec![EnergyType::Darkness, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b047ToxapEx, 0),
+        is_stack: false,
+    });
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 110);
+}
+
+/// An ordinary Poison applied later resets the Checkup damage back to 10.
+#[test]
+fn test_ordinary_poison_after_severe_poison_is_back_to_ten() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B3b047ToxapEx)
+            .with_energy(vec![EnergyType::Darkness, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B3b047ToxapEx, 0),
+        is_stack: false,
+    });
+
+    // Re-apply Poison the ordinary way before Checkup runs.
+    let mut state = game.get_state_clone();
+    state.apply_status_condition(1, 0, deckgym::models::StatusCondition::Poisoned);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: SimpleAction::EndTurn,
+        is_stack: false,
+    });
+
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 140);
+}
+
+/// Mesprit - Supreme Blast: unusable unless Uxie AND Azelf are on the Bench.
+#[test]
+fn test_mesprit_supreme_blast_requires_uxie_and_azelf_on_the_bench() {
+    let game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A2076Mesprit).with_energy(vec![
+                EnergyType::Psychic,
+                EnergyType::Psychic,
+                EnergyType::Psychic,
+            ]),
+            PlayedCard::from_id(CardId::A2075Uxie),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        !choices.iter().any(|choice| matches!(
+            &choice.action,
+            SimpleAction::Attack(attack) if attack.title == "Supreme Blast"
+        )),
+        "Supreme Blast must not be offered with only Uxie on the Bench"
+    );
+}
+
+/// With both on the Bench, Supreme Blast is usable and discards all of Mesprit's Energy.
+#[test]
+fn test_mesprit_supreme_blast_discards_all_energy_when_usable() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A2076Mesprit).with_energy(vec![
+                EnergyType::Psychic,
+                EnergyType::Psychic,
+                EnergyType::Psychic,
+            ]),
+            PlayedCard::from_id(CardId::A2075Uxie),
+            PlayedCard::from_id(CardId::A2077Azelf),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    assert!(
+        choices.iter().any(|choice| matches!(
+            &choice.action,
+            SimpleAction::Attack(attack) if attack.title == "Supreme Blast"
+        )),
+        "Supreme Blast should be offered once Uxie and Azelf are both benched"
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A2076Mesprit, 0),
+        is_stack: false,
+    });
+
+    let state = game.get_state_clone();
+    assert!(
+        state.in_play_pokemon[1][0].is_none(),
+        "160 knocks out Snorlax"
+    );
+    assert!(state.get_active(0).attached_energy.is_empty());
+}

--- a/tests/pokemon/miltank_rolling_frenzy_test.rs
+++ b/tests/pokemon/miltank_rolling_frenzy_test.rs
@@ -1,0 +1,91 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Miltank - Rolling Frenzy: "Until this Pokémon leaves the Active Spot, this Pokémon's Rolling
+/// Frenzy attack does +30 damage. This effect stacks."
+#[test]
+fn test_miltank_rolling_frenzy_stacks_while_it_stays_active() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A4a062Miltank).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    for expected_remaining in [140, 100, 30] {
+        let mut state = game.get_state_clone();
+        state.current_player = 0;
+        game.set_state(state);
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::A4a062Miltank, 0),
+            is_stack: false,
+        });
+        game.play_until_stable();
+
+        assert_eq!(
+            game.get_state_clone().get_active(1).get_remaining_hp(),
+            expected_remaining
+        );
+    }
+}
+
+/// The bonus is tied to the Active Spot: switching Miltank out clears the stacked effect.
+#[test]
+fn test_miltank_rolling_frenzy_bonus_is_lost_when_it_leaves_the_active_spot() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A4a062Miltank).with_energy(vec![EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A4a062Miltank, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 140);
+
+    // Swap Miltank to the Bench and back, which clears effects on it.
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 0,
+        action: deckgym::actions::SimpleAction::Activate {
+            player: 0,
+            in_play_idx: 1,
+        },
+        is_stack: false,
+    });
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 0,
+        action: deckgym::actions::SimpleAction::Activate {
+            player: 0,
+            in_play_idx: 1,
+        },
+        is_stack: false,
+    });
+
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A4a062Miltank, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // Back to the unboosted 10 damage.
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 130);
+}

--- a/tests/pokemon/scaling_damage_attacks_d_test.rs
+++ b/tests/pokemon/scaling_damage_attacks_d_test.rs
@@ -1,0 +1,128 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Mewtwo (B4) - Psychic: 10 damage, +40 for each Energy on the Defending Pokémon.
+#[test]
+fn test_mewtwo_psychic_scales_with_defender_energy() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4070Mewtwo).with_energy(vec![
+            EnergyType::Psychic,
+            EnergyType::Psychic,
+            EnergyType::Psychic,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)
+            .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4070Mewtwo, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // 10 + 2 * 40 = 90
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 60);
+}
+
+/// Tangrowth - Grass Knot: 10 damage, +40 for each Energy in the defender's Retreat Cost.
+#[test]
+fn test_tangrowth_grass_knot_scales_with_defender_retreat_cost() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A4005Tangrowth).with_energy(vec![
+                EnergyType::Grass,
+                EnergyType::Grass,
+                EnergyType::Grass,
+            ]),
+        ],
+        // Snorlax has a 4-Energy Retreat Cost.
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A4005Tangrowth, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // 10 + 4 * 40 = 170, capped by Snorlax's 150 HP -> knocked out.
+    assert!(game.get_state_clone().in_play_pokemon[1][0].is_none());
+}
+
+/// Team Rocket's Arbok - Shadow Seeker: 70 damage, +10 per Energy in the defender's Retreat Cost.
+#[test]
+fn test_team_rockets_arbok_shadow_seeker_scales_with_retreat_cost() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4a039TeamRocketsArbok).with_energy(vec![
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+                EnergyType::Darkness,
+            ]),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a039TeamRocketsArbok, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // 70 + 4 * 10 = 110
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 40);
+}
+
+/// Team Rocket's Persian - Dangerous Rogue: 10 damage, +40 per opposing Benched Pokémon.
+#[test]
+fn test_team_rockets_persian_dangerous_rogue_scales_with_opponent_bench() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4a061TeamRocketsPersian)
+            .with_energy(vec![EnergyType::Colorless, EnergyType::Colorless])],
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4a061TeamRocketsPersian, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // 10 + 2 * 40 = 90
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 60);
+}
+
+/// Leafeon - Leaf Blast: 10 damage, +20 for each [G] Energy attached to it.
+#[test]
+fn test_leafeon_leaf_blast_scales_with_own_grass_energy() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A3b002Leafeon).with_energy(vec![
+            EnergyType::Grass,
+            EnergyType::Grass,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3b002Leafeon, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // 10 + 2 * 20 = 50 (the Colorless Energy does not count)
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 100);
+}

--- a/tests/pokemon/self_relocation_attacks_d_test.rs
+++ b/tests/pokemon/self_relocation_attacks_d_test.rs
@@ -1,0 +1,262 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Tapu Koko - Volt Switch: after damage, switch with a Benched [L] Pokémon (and only a [L] one).
+#[test]
+fn test_tapu_koko_volt_switch_only_offers_lightning_bench() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A3068TapuKoko).with_energy(vec![
+                EnergyType::Lightning,
+                EnergyType::Lightning,
+                EnergyType::Lightning,
+            ]),
+            // Bulbasaur is [G] and must not be offered.
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A3068TapuKoko),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3068TapuKoko, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(
+        choices.len(),
+        1,
+        "only the Benched [L] Pokémon may be switched in"
+    );
+    assert!(matches!(
+        choices[0].action,
+        SimpleAction::Activate {
+            player: 0,
+            in_play_idx: 2
+        }
+    ));
+
+    game.apply_action(&choices[0].clone());
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 80);
+    assert!(state.get_active(0).attached_energy.is_empty());
+}
+
+/// Eldegoss - Float Up: the player MAY shuffle Eldegoss and everything attached back into the deck.
+#[test]
+fn test_eldegoss_float_up_can_shuffle_itself_and_attachments_into_the_deck() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B2016Eldegoss)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Grass]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    let deck_size_before = game.get_state_clone().decks[0].cards.len();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2016Eldegoss, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let shuffle_action = choices
+        .iter()
+        .find(|choice| {
+            matches!(
+                choice.action,
+                SimpleAction::ShuffleSelfAndAttachmentsIntoDeck { in_play_idx: 0 }
+            )
+        })
+        .expect("Float Up should offer shuffling itself into the deck")
+        .clone();
+    assert!(
+        choices
+            .iter()
+            .any(|choice| matches!(choice.action, SimpleAction::Noop)),
+        "the effect is optional, so declining must be offered"
+    );
+
+    game.apply_action(&shuffle_action);
+
+    // Vacating the Active Spot prompts a promotion from the Bench.
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    let promote = choices
+        .iter()
+        .find(|choice| {
+            matches!(
+                choice.action,
+                SimpleAction::Activate {
+                    player: 0,
+                    in_play_idx: 1
+                }
+            )
+        })
+        .expect("Bulbasaur should be promotable")
+        .clone();
+    game.apply_action(&promote);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 110);
+    // Eldegoss went back to the deck and Bulbasaur was promoted; its Energy was discarded.
+    assert_eq!(state.decks[0].cards.len(), deck_size_before + 1);
+    assert_eq!(state.get_active(0).get_name(), "Bulbasaur");
+    assert_eq!(state.discard_energies[0].len(), 2);
+}
+
+/// Float Up is optional: declining leaves Eldegoss in the Active Spot with its Energy.
+#[test]
+fn test_eldegoss_float_up_can_be_declined() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B2016Eldegoss).with_energy(vec![EnergyType::Grass]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2016Eldegoss, 0),
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    let decline = choices
+        .iter()
+        .find(|choice| matches!(choice.action, SimpleAction::Noop))
+        .expect("declining should be offered")
+        .clone();
+    game.apply_action(&decline);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(0).get_name(), "Eldegoss");
+    assert_eq!(state.get_active(0).attached_energy.len(), 1);
+}
+
+/// Accelgor - Deck and Cover: Poison + Paralysis, then Accelgor goes back into the deck.
+#[test]
+fn test_accelgor_deck_and_cover_poisons_paralyzes_then_shuffles_itself_away() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B4014Accelgor)
+                .with_energy(vec![EnergyType::Grass, EnergyType::Grass]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    let deck_size_before = game.get_state_clone().decks[0].cards.len();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4014Accelgor, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.decks[0].cards.len(), deck_size_before + 1);
+    assert_eq!(state.get_active(0).get_name(), "Bulbasaur");
+    assert_eq!(state.discard_energies[0].len(), 2);
+}
+
+/// Liepard - Snatch and Flee: a random opposing hand card goes back to their deck, and Liepard
+/// shuffles itself away too.
+#[test]
+fn test_liepard_snatch_and_flee_returns_a_hand_card_and_itself() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B1a048Liepard).with_energy(vec![EnergyType::Darkness]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let state = game.get_state_clone();
+    let opponent_hand_before = state.hands[1].len();
+    let opponent_deck_before = state.decks[1].cards.len();
+    assert!(opponent_hand_before > 0, "opponent should hold cards");
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1a048Liepard, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.hands[1].len(), opponent_hand_before - 1);
+    assert_eq!(state.decks[1].cards.len(), opponent_deck_before + 1);
+    assert_eq!(state.get_active(0).get_name(), "Bulbasaur");
+}
+
+/// Tsareena - Kick Down: a random opposing hand card is shuffled into their deck. Tsareena stays.
+#[test]
+fn test_tsareena_kick_down_shuffles_a_random_hand_card_back() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A3b005Tsareena).with_energy(vec![EnergyType::Grass])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let state = game.get_state_clone();
+    let opponent_hand_before = state.hands[1].len();
+    let opponent_deck_before = state.decks[1].cards.len();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3b005Tsareena, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.hands[1].len(), opponent_hand_before - 1);
+    assert_eq!(state.decks[1].cards.len(), opponent_deck_before + 1);
+    assert_eq!(state.get_active(0).get_name(), "Tsareena");
+    assert_eq!(state.get_active(1).get_remaining_hp(), 100);
+}
+
+/// Purugly - Interrupt: the attacker picks which revealed card goes back into the opponent's deck.
+#[test]
+fn test_purugly_interrupt_lets_the_attacker_choose_the_card_to_shuffle_away() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A2140Purugly).with_energy(vec![
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+            EnergyType::Colorless,
+        ])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let state = game.get_state_clone();
+    let opponent_hand_before = state.hands[1].len();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A2140Purugly, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert!(!choices.is_empty());
+    assert!(choices
+        .iter()
+        .all(|choice| matches!(choice.action, SimpleAction::ShuffleOpponentSupporter { .. })));
+
+    game.apply_action(&choices[0].clone());
+    let state = game.get_state_clone();
+    assert_eq!(state.hands[1].len(), opponent_hand_before - 1);
+    assert_eq!(state.get_active(1).get_remaining_hp(), 90);
+}

--- a/tests/pokemon/spread_and_energy_attacks_d_test.rs
+++ b/tests/pokemon/spread_and_energy_attacks_d_test.rs
@@ -1,0 +1,302 @@
+use deckgym::{
+    actions::{Action, SimpleAction},
+    card_ids::CardId,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Forretress - Enormous Explosion: 100 to the Defending Pokémon, 100 to itself, and 50 to every
+/// Benched Pokémon on both sides.
+#[test]
+fn test_forretress_enormous_explosion_hits_both_benches_and_itself() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::B2b046Forretress).with_energy(vec![
+                EnergyType::Metal,
+                EnergyType::Metal,
+                EnergyType::Metal,
+            ]),
+            PlayedCard::from_id(CardId::A1211Snorlax),
+        ],
+        vec![
+            PlayedCard::from_id(CardId::A1211Snorlax),
+            PlayedCard::from_id(CardId::A1211Snorlax),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2b046Forretress, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 50);
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("opponent bench")
+            .get_remaining_hp(),
+        100
+    );
+    // Forretress has 100 HP and takes 100 to itself, so it knocks itself out and the Benched
+    // Snorlax — already down 50 from the same explosion — is promoted into the Active Spot.
+    assert_eq!(state.get_active(0).get_name(), "Snorlax");
+    assert_eq!(state.get_active(0).get_remaining_hp(), 100);
+}
+
+/// Mimikyu - Shadow Hit: 60 to the Defending Pokémon, plus 20 to one of YOUR OWN Pokémon — the
+/// attacker itself is a legal target.
+#[test]
+fn test_mimikyu_shadow_hit_can_damage_any_of_your_own_pokemon() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A3083Mimikyu)
+                .with_energy(vec![EnergyType::Psychic, EnergyType::Colorless]),
+            PlayedCard::from_id(CardId::A1211Snorlax),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A3083Mimikyu, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(choices.len(), 2, "Mimikyu itself and its Bench are targets");
+
+    // Pick the Benched Snorlax (index 1), leaving Mimikyu untouched.
+    let bench_choice = choices
+        .iter()
+        .find(|choice| match &choice.action {
+            SimpleAction::ApplyDamage { targets, .. } => targets[0].2 == 1,
+            _ => false,
+        })
+        .expect("the Bench should be a target")
+        .clone();
+    game.apply_action(&bench_choice);
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 90);
+    assert_eq!(state.get_active(0).get_remaining_hp(), 70);
+    assert_eq!(
+        state.in_play_pokemon[0][1]
+            .as_ref()
+            .expect("own bench")
+            .get_remaining_hp(),
+        130
+    );
+}
+
+/// Archeops - Wild Spin: 20 to each of the opponent's Pokémon, and +20 to each on the next turn.
+#[test]
+fn test_archeops_wild_spin_spreads_damage_and_escalates_next_turn() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B1134Archeops).with_energy(vec![EnergyType::Fighting])],
+        vec![
+            // Venusaur ex is Weak to [R], not [F], so no weakness math interferes.
+            PlayedCard::from_id(CardId::A1004VenusaurEx),
+            PlayedCard::from_id(CardId::A1004VenusaurEx),
+        ],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1134Archeops, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 170);
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("opponent bench")
+            .get_remaining_hp(),
+        170
+    );
+
+    // Next use of Wild Spin does 40 to each.
+    let mut state = game.get_state_clone();
+    state.current_player = 0;
+    game.set_state(state);
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B1134Archeops, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 130);
+    assert_eq!(
+        state.in_play_pokemon[1][1]
+            .as_ref()
+            .expect("opponent bench")
+            .get_remaining_hp(),
+        130
+    );
+}
+
+/// Uxie - Mind Boost: attach a [P] Energy from the Energy Zone to Mesprit or Azelf only.
+#[test]
+fn test_uxie_mind_boost_only_offers_mesprit_or_azelf() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A2075Uxie).with_energy(vec![EnergyType::Psychic]),
+            PlayedCard::from_id(CardId::A1001Bulbasaur),
+            PlayedCard::from_id(CardId::A2076Mesprit),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A2075Uxie, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    assert_eq!(choices.len(), 1, "only Mesprit is an eligible target");
+    game.apply_action(&choices[0].clone());
+
+    let state = game.get_state_clone();
+    assert_eq!(
+        state.in_play_pokemon[0][2]
+            .as_ref()
+            .expect("Mesprit")
+            .attached_energy,
+        vec![EnergyType::Psychic]
+    );
+    assert_eq!(state.get_active(1).get_remaining_hp(), 130);
+}
+
+/// Sableye - Jeweled Gift: a random basic Energy is attached to a chosen Benched Pokémon.
+#[test]
+fn test_sableye_jeweled_gift_attaches_one_random_energy_to_a_benched_pokemon() {
+    for seed in 0..10 {
+        let mut game = deckgym::test_support::get_initialized_game_with_board(
+            seed,
+            0,
+            3,
+            vec![
+                PlayedCard::from_id(CardId::B3a040Sableye).with_energy(vec![EnergyType::Colorless]),
+                PlayedCard::from_id(CardId::A1001Bulbasaur),
+            ],
+            vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+        );
+
+        game.apply_action(&Action {
+            actor: 0,
+            action: attack_action(CardId::B3a040Sableye, 0),
+            is_stack: false,
+        });
+
+        let (_, choices) = game.get_state_clone().generate_possible_actions();
+        assert_eq!(choices.len(), 1, "seed {seed}: only one Benched Pokémon");
+        game.apply_action(&choices[0].clone());
+
+        let state = game.get_state_clone();
+        let bench = state.in_play_pokemon[0][1].as_ref().expect("bench");
+        assert_eq!(
+            bench.attached_energy.len(),
+            1,
+            "seed {seed}: exactly one Energy attached"
+        );
+        assert_ne!(
+            bench.attached_energy[0],
+            EnergyType::Colorless,
+            "seed {seed}: Jeweled Gift only produces the 8 basic types"
+        );
+    }
+}
+
+/// Gyarados - Wild Swing: 20 damage, +40 for each Benched [W] Pokémon discarded.
+#[test]
+fn test_gyarados_wild_swing_boosts_damage_per_discarded_water_bench() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A4045Gyarados)
+                .with_energy(vec![EnergyType::Water, EnergyType::Water]),
+            PlayedCard::from_id(CardId::A1211Snorlax), // [C], not eligible
+            PlayedCard::from_id(CardId::B4032Staryu),  // [W], eligible
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A4045Gyarados, 0),
+        is_stack: false,
+    });
+
+    let (actor, choices) = game.get_state_clone().generate_possible_actions();
+    assert_eq!(actor, 0);
+    // One eligible [W] Bench member => discard none, or discard it.
+    assert_eq!(choices.len(), 2);
+
+    let discard_one = choices
+        .iter()
+        .find(|choice| match &choice.action {
+            SimpleAction::DiscardOwnBenchedGroupThenDamage {
+                in_play_indices, ..
+            } => in_play_indices.len() == 1,
+            _ => false,
+        })
+        .expect("discarding the Benched Staryu should be offered")
+        .clone();
+    game.apply_action(&discard_one);
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    // 20 + 40 = 60
+    assert_eq!(state.get_active(1).get_remaining_hp(), 90);
+    assert!(
+        state.in_play_pokemon[0][2].is_none(),
+        "Staryu was discarded"
+    );
+    assert!(state.in_play_pokemon[0][1].is_some(), "Snorlax stays");
+}
+
+/// Wild Swing with nothing discarded deals only its base damage.
+#[test]
+fn test_gyarados_wild_swing_can_decline_the_discard() {
+    let mut game = get_test_game_with_board(
+        vec![
+            PlayedCard::from_id(CardId::A4045Gyarados)
+                .with_energy(vec![EnergyType::Water, EnergyType::Water]),
+            PlayedCard::from_id(CardId::B4032Staryu),
+        ],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A4045Gyarados, 0),
+        is_stack: false,
+    });
+
+    let (_, choices) = game.get_state_clone().generate_possible_actions();
+    let discard_none = choices
+        .iter()
+        .find(|choice| match &choice.action {
+            SimpleAction::DiscardOwnBenchedGroupThenDamage {
+                in_play_indices, ..
+            } => in_play_indices.is_empty(),
+            _ => false,
+        })
+        .expect("discarding nothing should be offered")
+        .clone();
+    game.apply_action(&discard_none);
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 130);
+    assert!(state.in_play_pokemon[0][1].is_some(), "Staryu stays");
+}

--- a/tests/pokemon/swift_attacks_d_test.rs
+++ b/tests/pokemon/swift_attacks_d_test.rs
@@ -1,0 +1,97 @@
+use deckgym::{
+    actions::Action,
+    card_ids::CardId,
+    effects::CardEffect,
+    models::{EnergyType, PlayedCard},
+    test_support::{attack_action, get_test_game_with_board},
+};
+
+/// Starmie - Swift: "This attack's damage isn't affected by Weakness or by any effects on your
+/// opponent's Active Pokémon." Turtonator is [R] and Weak to [W], but takes the printed 60 rather
+/// than a weakness-boosted 80.
+#[test]
+fn test_starmie_swift_damage_is_not_boosted_by_weakness() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4033Starmie)
+            .with_energy(vec![EnergyType::Water, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A3037Turtonator)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4033Starmie, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // 120 HP - 60 = 60 (a weakness-boosted 80 would leave 40).
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 60);
+}
+
+/// Ledian - Swift: same clause, against an Onix that is Weak to [G].
+#[test]
+fn test_ledian_swift_damage_is_not_boosted_by_weakness() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B2002Ledian).with_energy(vec![EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1150Onix)],
+    );
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B2002Ledian, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // 110 HP - 40 = 70 (a weakness-boosted 60 would leave 50).
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 70);
+}
+
+/// Swift also ignores damage-reducing effects sitting on the opponent's Active Pokémon.
+#[test]
+fn test_starmie_swift_ignores_effects_on_the_defender() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::B4033Starmie)
+            .with_energy(vec![EnergyType::Water, EnergyType::Colorless])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+
+    let mut state = game.get_state_clone();
+    state.in_play_pokemon[1][0]
+        .as_mut()
+        .expect("defender")
+        .add_effect(CardEffect::ReducedDamage { amount: 30 }, 1);
+    game.set_state(state);
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::B4033Starmie, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    // The full 60 lands despite the -30 reduction on the defender.
+    assert_eq!(game.get_state_clone().get_active(1).get_remaining_hp(), 90);
+}
+
+/// Mew - Psy Report / Noctowl - Silent Wing: revealing the opponent's hand is informational only,
+/// so the attack resolves as its plain damage and leaves the hand intact.
+#[test]
+fn test_psy_report_deals_its_damage_and_leaves_the_hand_alone() {
+    let mut game = get_test_game_with_board(
+        vec![PlayedCard::from_id(CardId::A1283Mew).with_energy(vec![EnergyType::Psychic])],
+        vec![PlayedCard::from_id(CardId::A1211Snorlax)],
+    );
+    let hand_before = game.get_state_clone().hands[1].clone();
+
+    game.apply_action(&Action {
+        actor: 0,
+        action: attack_action(CardId::A1283Mew, 0),
+        is_stack: false,
+    });
+    game.play_until_stable();
+
+    let state = game.get_state_clone();
+    assert_eq!(state.get_active(1).get_remaining_hp(), 130);
+    assert_eq!(state.hands[1], hand_before);
+}


### PR DESCRIPTION

## Summary

Fills in 36 unmapped attack effect texts (24 of them left as `todo_implementation`
upstream), completing 59 card printings: scaling damage (per Energy, Retreat Cost, Special
Condition, own knockout, point conceded last turn), direct and spread damage,
self-relocation, hand disruption, Poison with a custom Checkup value, and Energy
redistribution. It also adds the board-aware Ability accessors the rest of the stack uses.

## Stack note

Part 1 of 10; applies directly to `main` (`fda4839`).

## Cards

| ids | name | attack | Mechanic |
|---|---|---|---|
| A2 075 | Uxie | Mind Boost | `AttachEnergyFromZoneToNamed` |
| A2 076, A2 166 | Mesprit | Supreme Blast | `RequireBenchedNamesThenDiscardAllEnergy` |
| A2 140 | Purugly | Interrupt | `ChooseOpponentHandCardToShuffleIntoDeck` |
| A2a 052 | Toxicroak | Toxic | `InflictPoisonWithDamage { 20 }` |
| A1 283, A1a 031 | Mew | Psy Report | `RevealOpponentHand` |
| A2a 065 | Noctowl | Silent Wing | `RevealOpponentHand` |
| A3 036 | Salazzle | Heated Poison | `InflictStatusConditions` (Poisoned + Burned) |
| B4a 009 | Team Rocket's Houndoom | Toxfire Fang | `InflictStatusConditions` (Poisoned + Burned) |
| A3 051, A3 184, A3 202, A4b 124 | Wishiwashi ex | School Storm | `ExtraDamagePerPokemonWithNamesOnBench` |
| A3 068, A3 166 | Tapu Koko | Volt Switch | `SwitchSelfWithBenchOfType` |
| A3 083, P-A 066 | Mimikyu | Shadow Hit | `AlsoChoiceOwnPokemonDamage` |
| A3b 002, A3b 070 | Leafeon | Leaf Blast | `ExtraDamagePerSpecificEnergy` |
| A3b 005 | Tsareena | Kick Down | `ShuffleRandomOpponentHandCardIntoDeck` |
| B3a 040, P-B 070 | Sableye | Jeweled Gift | `AttachRandomBasicEnergyToBenched` |
| B3a 043 | Kingambit | Overlord's Blade | `ExtraDamagePerOwnKnockoutThisGame` |
| A4 005 | Tangrowth | Grass Knot | `ExtraDamagePerRetreatCost { 40 }` |
| A4 045, A4 215 | Gyarados | Wild Swing | `OptionalDiscardBenchedTypeForExtraDamage` |
| A4a 062, P-A 107 | Miltank | Rolling Frenzy | `DamageAndCardEffect` (`IncreasedDamageForAttack`, `u8::MAX`) |
| B1 134, B1 242 | Archeops | Wild Spin | `DamageAllOpponentPokemonEscalating` |
| B1a 048 | Liepard | Snatch and Flee | `ShuffleRandomOpponentHandCardIntoDeckAndSelfIntoDeck` |
| B2 002 | Ledian | Swift | `DamageUnaffectedByWeaknessAndOpponentActiveEffects` |
| B4 032, B4 033 | Staryu / Starmie | Swift | `DamageUnaffectedByWeaknessAndOpponentActiveEffects` |
| B2 005, B2 157 | Roserade | Poison Ring | `InflictStatusConditionsAndCardEffect` |
| B2 016 | Eldegoss | Float Up | `MayShuffleSelfIntoDeck` |
| B3 130 | Dunsparce | Bop 'n' Burrow | `MayShuffleSelfIntoDeck` |
| B2 076, B2 169 | Indeedee | Zen Shard | `DirectDamage { 70, bench_only }` |
| B2a 028 | Palafin | Jet Punch | `AlsoChoiceBenchDamage { 50 }` |
| B2b 046, B2b 104 | Forretress | Enormous Explosion | `SelfDamageAndAllBenchDamage` |
| B3 013, B3 159 | Budew | Prickly Powder | `DamageAndCardEffect` (`AbilitiesDisabled`) |
| B3 110 | Mandibuzz | Blindside | `DirectDamageIfDamaged` |
| B3b 047 | Toxapex | Severe Poison | `InflictPoisonWithDamage { 40 }` |
| B4 014, B4 159 | Accelgor | Deck and Cover | `InflictStatusConditionsAndShuffleSelfIntoDeck` |
| B4 019 | Teal Mask Ogerpon | Ogre's Whip | `DamageEqualToSelfRemainingHp` |
| B4 070, B4 212 | Mewtwo | Psychic | `ExtraDamagePerEnergy { 40, opponent }` |
| B4 097 | Galarian Obstagoon | Bass Control | `DirectDamage { 80 }` |
| B4 135 | Delcatty | Energy Blender | `MoveOwnEnergyAnyWay` |
| B4a 006 | Team Rocket's Magmar | Derisive Roasting | `ExtraDamagePerOpponentSpecialCondition` |
| B4a 018 | Hisuian Basculegion | Soul Counter | `ExtraDamagePerOpponentPointLastTurn` |
| B4a 039 | Team Rocket's Arbok | Shadow Seeker | `ExtraDamagePerRetreatCost { 10 }` |
| B4a 061 | Team Rocket's Persian | Dangerous Rogue | `BenchCountDamage` (opponent bench) |

## Engine changes

- **Board-aware Ability accessors.** `PlayedCard::ability()`, `ability_mechanic()` and
  `has_ability()` are the in-play counterparts of the `Card`-level lookups, returning `None`
  while a Pokémon's Abilities are disabled. Every lookup in `hooks::core`, `state/mod.rs`
  and `played_card.rs` holding a `PlayedCard` is converted to them.
- **`CardEffect::AbilitiesDisabled`** and **`IncreasedSpreadDamageForAttack`** — the latter
  ignored by `modify_damage`, so a spread attack's escalating bonus is not double-counted on
  the Active.
- 23 new `Mechanic` variants and three new `SimpleAction`s.
- New `State` fields (`own_knocked_out_count`, `points_at_own_turn_start`,
  `points_gained_during_own_last_turn`, all `#[serde(default)]`) plus
  `apply_poison_with_damage`; new `PlayedCard` field `poison_damage_override` with
  `poison_base_damage()` and `count_status_conditions()`.
- `attack_precondition_met` in `move_generation::attacks` gates "You can use this attack
  only if …"; the Weakness/effects-bypass constants become substring matches so Swift's
  combined sentence hits both.
- Two fixes: `also_choice_bench_damage` now deals the attack's Active damage when the
  opposing Bench is empty, and `attacker_still_in_play()` guards the five follow-ups that
  act *from* the attacker, so recoil that KOs it no longer panics `modify_damage`.

## Rulings and judgement calls

- **Prickly Powder** ("until the Defending Pokémon leaves the Active Spot") is
  `AbilitiesDisabled` with `duration: u8::MAX` — leaving the Active Spot already clears
  effects. Miltank's Rolling Frenzy uses the same convention.
- **"Your opponent reveals their hand" is a no-op**: `State` is fully observable.
- **Energy Blender** moves one Energy at a time instead of enumerating whole
  redistributions (exponential in board Energy). The budget starts at the player's total
  attached Energy — nothing needs to move twice — guaranteeing termination and reaching the
  same final boards.
- **Custom Poison is an override**, so a later ordinary Poison is back to 10.
- `ShuffleSelfAndAttachmentsIntoDeck` discards attached Energy, unlike
  `ShuffleInPlayPokemonIntoDeck`.

## Testing

49 new tests in 10 new `tests/pokemon/` files (804 → 853). `card_test` ran one card per
effect template — 36 cards × 10,000 games — and surfaced the attacker-KO panic fixed here.
`cargo clippy --features tui -- -D warnings` clean; the pre-existing
`doc_lazy_continuation` in `tests/pokemon/victini_victory_star_test.rs` is untouched.

## Notes for review

1. `PlayedCard::ability_mechanic()` and the ~20 converted call sites.
2. `also_choice_bench_damage`'s empty-bench fix.
3. `attacker_still_in_play()` and its five call sites.
4. `SimpleAction::MoveEnergyAndReoffer` with `attack_helpers::energy_blender_choices`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
